### PR TITLE
Improve check unchanged script

### DIFF
--- a/scripts/check-unchanged.sh
+++ b/scripts/check-unchanged.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ -n "$(git status --porcelain | egrep -v '.*(\.|-)lock(\.json)?$')" ]; then
+if [ -n "$(git status --porcelain | egrep -v '((\.lock)|(-lock\.json)|(\.log)|(\.map))$')" ]; then
   echo "changes";
   exit 1;
 else


### PR DESCRIPTION
Improves `./scripts/check-unchanged.sh`, which verifies on Travis that files aren't changed after lint+prettier+package are run:
* ignore `.map` files (sometimes diffs creep in for some strange reason, but we shouldn't care about this)
* improve regex readability/extensibility