### PR TITLE
Add visual test cases page to process flow

### DIFF
--- a/packages/showcase/components/Header.js
+++ b/packages/showcase/components/Header.js
@@ -8,8 +8,11 @@ export default props => {
   const pathnameChunks = props.pathname.split("/").filter(s => s !== "")
   const chunk1 = pathnameChunks[0]
   const chunk2 = pathnameChunks[1]
+  // Maintain a built-up version of the current breadcrumbs path so the links can point to
+  // e.g. /components, then /components/buttons, then /components/buttons/sublink
   let currentPath = ""
   const breadcrumbs = pathnameChunks.map((chunk, index) => {
+    // Add to this path in when creating the data for each breadcrumb link.
     currentPath += `/${chunk}`
     return {
       url: currentPath,

--- a/packages/showcase/components/Header.js
+++ b/packages/showcase/components/Header.js
@@ -6,21 +6,16 @@ import Link from "next/link"
 
 export default props => {
   const pathnameChunks = props.pathname.split("/").filter(s => s !== "")
-  const breadcrumbs = []
   const chunk1 = pathnameChunks[0]
   const chunk2 = pathnameChunks[1]
-  if (chunk1) {
-    breadcrumbs.push({
-      url: `/${chunk1}`,
-      label: props.pathmap[`/${chunk1}`].query.title
-    })
-  }
-  if (chunk2) {
-    breadcrumbs.push({
-      url: `/${chunk1}/${chunk2}`,
-      label: props.pathmap[`/${chunk1}/${chunk2}`].query.title
-    })
-  }
+  let currentPath = ""
+  const breadcrumbs = pathnameChunks.map((chunk, index) => {
+    currentPath += `/${chunk}`
+    return {
+      url: currentPath,
+      label: props.pathmap[currentPath].query.title
+    }
+  })
   return (
     <Header
       css={{

--- a/packages/showcase/components/Playground.js
+++ b/packages/showcase/components/Playground.js
@@ -10,6 +10,7 @@ const customGrey: string = "#dadada"
 
 const Container = glamorous.div(({ theme, isExpanded }) => ({
   border: `2px solid ${customGrey}`,
+  margin: `${theme.spacing}px 0`,
 
   ...isExpanded
     ? {

--- a/packages/showcase/components/Sidenavigation.js
+++ b/packages/showcase/components/Sidenavigation.js
@@ -45,7 +45,7 @@ export default ({ pathname, pathmap }) => {
       {mainPaths.map((url, index) => {
         const label = pathmap[url].query.title
         const items = Object.keys(pathmap)
-          .filter(s => !!s.match(new RegExp("^" + url)) && s !== url)
+          .filter(s => !!s.match(new RegExp("^" + url)) && s !== url && s.split("/").length < 4)
           .map(url => ({
             url,
             label: pathmap[url].query.title

--- a/packages/showcase/components/TestCases/ProcessFlow/case01.js
+++ b/packages/showcase/components/TestCases/ProcessFlow/case01.js
@@ -32,18 +32,17 @@ const data1 = {
   ]
 }
 
-const data2: any = {
+const data2 = {
   journeys: [
-    { path: ["1", "2", "3", "4"], size: 1500 },
-    { path: ["1", "2", "3", "5", "4"], size: 1200 },
-    { path: ["1", "7", "5", "8"], size: 700 },
+    { path: ["1", "10", "2", "3", "4"], size: 1500 },
+    { path: ["1", "10", "2", "3", "5", "4"], size: 1200 },
+    { path: ["9", "7", "5", "8"], size: 700 },
     { path: ["9", "2", "3", "8"], size: 600 },
-    { path: ["1", "2", "5", "6", "11"], size: 230 },
+    { path: ["1", "10", "2", "5", "6", "11"], size: 230 },
     { path: ["1", "2", "3", "6", "11"], size: 130 },
     { path: ["1", "2", "3", "4", "11"], size: 290 },
-    { path: ["1", "2", "3", "12", "11"], size: 120 },
-    { path: ["1", "2", "3", "4", "13"], size: 620 },
-    { path: ["4"], size: 23 }
+    { path: ["1", "10", "2", "3", "12", "11"], size: 120 },
+    { path: ["1", "10", "2", "3", "4", "13"], size: 620 }
   ],
   nodes: [
     { id: "1", group: "start" },
@@ -55,47 +54,63 @@ const data2: any = {
     { id: "7" },
     { id: "8", group: "end" },
     { id: "9", group: "start" },
+    { id: "10" },
     { id: "11", group: "end" },
     { id: "12" },
     { id: "13", group: "end" }
   ]
 }
 
-const marathon = ({ test, afterAll, container }: IMarathon): void => {
+const data3 = {
+  journeys: [
+    { path: ["1", "10", "2", "3", "4"], size: 1500 },
+    { path: ["1", "10", "2", "3", "5", "4"], size: 1200 },
+    { path: ["9", "7", "5", "8"], size: 700 },
+    { path: ["9", "2", "3", "8"], size: 600 }
+  ],
+  nodes: [
+    { id: "1", group: "start" },
+    { id: "2" },
+    { id: "3" },
+    { id: "4" },
+    { id: "5" },
+    { id: "7" },
+    { id: "8", group: "end" },
+    { id: "9", group: "start" },
+    { id: "10" }
+  ]
+}
+
+export const marathon = ({ test, afterAll, container }) => {
   const viz = new ProcessFlow(container)
 
-  test("Focuses a link", () => {
+  test("Renders a process flow with no data", () => {
+    viz.draw()
+  })
+
+  test("Renders a process flow with an empty dataset", () => {
+    viz.data({})
+    viz.draw()
+  })
+
+  test("Adds data", () => {
     viz.data(data1)
-    viz.config({
-      focusElement: {
-        type: "link",
-        matchers: { sourceId: "3", targetId: "5" }
-      }
-    })
-    viz.accessors("node", {
-      label: (node: any) => `Node ${node.id}`
-    })
+    viz.config({ duration: 2e3 })
     viz.draw()
   })
 
-  test("Removes focus", () => {
-    viz.config({ focusElement: {} })
-    viz.draw()
-  })
-
-  test("Focuses a node", () => {
+  test("Updates the data", () => {
     viz.data(data2)
-    viz.config({
-      focusElement: {
-        type: "node",
-        matchers: { id: "3" }
-      }
-    })
-    viz.accessors("node", {
-      label: (node: any) => `Node ${node.id}`,
-      content: [{ key: "Description", value: "This is a node." }, { key: "Comment", value: "This comment is boring." }]
-    })
     viz.draw()
+  })
+
+  test("Updates the data", () => {
+    viz.data(data3)
+    viz.draw()
+  })
+
+  test("Closes the viz", () => {
+    viz.close()
   })
 
   afterAll(() => {
@@ -103,11 +118,4 @@ const marathon = ({ test, afterAll, container }: IMarathon): void => {
   })
 }
 
-export default props => (
-  <Layout pathname={props.url.pathname}>
-    <Card>
-      <CardHeader>Process Flow Visualization Tests - Element Focussing</CardHeader>
-      <Marathon test={marathon} timeout={2e3} />
-    </Card>
-  </Layout>
-)
+export const title = "Data Updates"

--- a/packages/showcase/components/TestCases/ProcessFlow/case02.js
+++ b/packages/showcase/components/TestCases/ProcessFlow/case02.js
@@ -32,17 +32,18 @@ const data1 = {
   ]
 }
 
-const data2 = {
+const data2: any = {
   journeys: [
-    { path: ["1", "10", "2", "3", "4"], size: 1500 },
-    { path: ["1", "10", "2", "3", "5", "4"], size: 1200 },
-    { path: ["9", "7", "5", "8"], size: 700 },
+    { path: ["1", "2", "3", "4"], size: 1500 },
+    { path: ["1", "2", "3", "5", "4"], size: 1200 },
+    { path: ["1", "7", "5", "8"], size: 700 },
     { path: ["9", "2", "3", "8"], size: 600 },
-    { path: ["1", "10", "2", "5", "6", "11"], size: 230 },
+    { path: ["1", "2", "5", "6", "11"], size: 230 },
     { path: ["1", "2", "3", "6", "11"], size: 130 },
     { path: ["1", "2", "3", "4", "11"], size: 290 },
-    { path: ["1", "10", "2", "3", "12", "11"], size: 120 },
-    { path: ["1", "10", "2", "3", "4", "13"], size: 620 }
+    { path: ["1", "2", "3", "12", "11"], size: 120 },
+    { path: ["1", "2", "3", "4", "13"], size: 620 },
+    { path: ["4"], size: 23 }
   ],
   nodes: [
     { id: "1", group: "start" },
@@ -54,63 +55,47 @@ const data2 = {
     { id: "7" },
     { id: "8", group: "end" },
     { id: "9", group: "start" },
-    { id: "10" },
     { id: "11", group: "end" },
     { id: "12" },
     { id: "13", group: "end" }
   ]
 }
 
-const data3 = {
-  journeys: [
-    { path: ["1", "10", "2", "3", "4"], size: 1500 },
-    { path: ["1", "10", "2", "3", "5", "4"], size: 1200 },
-    { path: ["9", "7", "5", "8"], size: 700 },
-    { path: ["9", "2", "3", "8"], size: 600 }
-  ],
-  nodes: [
-    { id: "1", group: "start" },
-    { id: "2" },
-    { id: "3" },
-    { id: "4" },
-    { id: "5" },
-    { id: "7" },
-    { id: "8", group: "end" },
-    { id: "9", group: "start" },
-    { id: "10" }
-  ]
-}
-
-const marathon = ({ test, afterAll, container }) => {
+export const marathon = ({ test, afterAll, container }: IMarathon): void => {
   const viz = new ProcessFlow(container)
 
-  test("Renders a process flow with no data", () => {
-    viz.draw()
-  })
-
-  test("Renders a process flow with an empty dataset", () => {
-    viz.data({})
-    viz.draw()
-  })
-
-  test("Adds data", () => {
+  test("Focuses a link", () => {
     viz.data(data1)
-    viz.config({ duration: 2e3 })
+    viz.config({
+      focusElement: {
+        type: "link",
+        matchers: { sourceId: "3", targetId: "5" }
+      }
+    })
+    viz.accessors("node", {
+      label: (node: any) => `Node ${node.id}`
+    })
     viz.draw()
   })
 
-  test("Updates the data", () => {
+  test("Removes focus", () => {
+    viz.config({ focusElement: {} })
+    viz.draw()
+  })
+
+  test("Focuses a node", () => {
     viz.data(data2)
+    viz.config({
+      focusElement: {
+        type: "node",
+        matchers: { id: "3" }
+      }
+    })
+    viz.accessors("node", {
+      label: (node: any) => `Node ${node.id}`,
+      content: [{ key: "Description", value: "This is a node." }, { key: "Comment", value: "This comment is boring." }]
+    })
     viz.draw()
-  })
-
-  test("Updates the data", () => {
-    viz.data(data3)
-    viz.draw()
-  })
-
-  test("Closes the viz", () => {
-    viz.close()
   })
 
   afterAll(() => {
@@ -118,11 +103,4 @@ const marathon = ({ test, afterAll, container }) => {
   })
 }
 
-export default props => (
-  <Layout pathname={props.url.pathname}>
-    <Card>
-      <CardHeader>Process Flow Visualization Tests - Data Updates</CardHeader>
-      <Marathon test={marathon} timeout={2e3} />
-    </Card>
-  </Layout>
-)
+export const title = "Element Focussing"

--- a/packages/showcase/components/TestCases/ProcessFlow/case03.js
+++ b/packages/showcase/components/TestCases/ProcessFlow/case03.js
@@ -81,7 +81,7 @@ const linkAccessors: any = {
   size: 2
 }
 
-const marathon = ({ test, afterAll, container }: IMarathon): void => {
+export const marathon = ({ test, afterAll, container }: IMarathon): void => {
   const viz = new ProcessFlow(container)
 
   test("Renders viz with data accessors", () => {
@@ -105,11 +105,4 @@ const marathon = ({ test, afterAll, container }: IMarathon): void => {
   })
 }
 
-export default props => (
-  <Layout pathname={props.url.pathname}>
-    <Card>
-      <CardHeader>Process Flow Visualization Tests - Accessor Testing</CardHeader>
-      <Marathon test={marathon} timeout={2e3} />
-    </Card>
-  </Layout>
-)
+export const title = "Accessor Testing"

--- a/packages/showcase/components/TestCases/ProcessFlow/case04.js
+++ b/packages/showcase/components/TestCases/ProcessFlow/case04.js
@@ -158,7 +158,7 @@ const accessors = {
   }
 }
 
-const marathon = ({ test, afterAll, container }: IMarathon): void => {
+export const marathon = ({ test, afterAll, container }: IMarathon): void => {
   const viz = new ProcessFlow(container)
 
   test("Renders viz with looped data", () => {
@@ -175,11 +175,4 @@ const marathon = ({ test, afterAll, container }: IMarathon): void => {
   })
 }
 
-export default props => (
-  <Layout pathname={props.url.pathname}>
-    <Card>
-      <CardHeader>Process Flow Visualization Tests - Looped Data</CardHeader>
-      <Marathon test={marathon} timeout={2e3} />
-    </Card>
-  </Layout>
-)
+export const title = "Looped data"

--- a/packages/showcase/components/TestCases/ProcessFlow/case05.js
+++ b/packages/showcase/components/TestCases/ProcessFlow/case05.js
@@ -8,7 +8,7 @@ const data = {
   nodes: [{ id: "1" }, { id: "2" }, { id: "3" }, { id: "4" }, { id: "5" }, { id: "6" }]
 }
 
-const marathon = ({ test, afterAll, container }: IMarathon): void => {
+export const marathon = ({ test, afterAll, container }: IMarathon): void => {
   const viz = new ProcessFlow(container)
 
   test("Renders a process flow viz", () => {
@@ -45,11 +45,4 @@ const marathon = ({ test, afterAll, container }: IMarathon): void => {
   })
 }
 
-export default props => (
-  <Layout pathname={props.url.pathname}>
-    <Card>
-      <CardHeader>Process Flow Visualization Tests - Resizing</CardHeader>
-      <Marathon test={marathon} timeout={2e3} />
-    </Card>
-  </Layout>
-)
+export const title = "Resizing"

--- a/packages/showcase/components/TestCases/ProcessFlow/case06.js
+++ b/packages/showcase/components/TestCases/ProcessFlow/case06.js
@@ -184,7 +184,7 @@ const data = {
   ]
 }
 
-const marathon = ({ test, afterAll, container }: IMarathon): void => {
+export const marathon = ({ test, afterAll, container }: IMarathon): void => {
   const viz: ProcessFlow = new ProcessFlow(container)
 
   test("Renders a process flow", () => {
@@ -203,11 +203,4 @@ const marathon = ({ test, afterAll, container }: IMarathon): void => {
   })
 }
 
-export default props => (
-  <Layout pathname={props.url.pathname}>
-    <Card>
-      <CardHeader>Process Flow Visualization Tests - Undefined Config Options</CardHeader>
-      <Marathon test={marathon} timeout={2e3} />
-    </Card>
-  </Layout>
-)
+export const title = "Undefined Config Options"

--- a/packages/showcase/components/TestCases/ProcessFlow/index.js
+++ b/packages/showcase/components/TestCases/ProcessFlow/index.js
@@ -1,0 +1,8 @@
+import * as case01 from "./case01"
+import * as case02 from "./case02"
+import * as case03 from "./case03"
+import * as case04 from "./case04"
+import * as case05 from "./case05"
+import * as case06 from "./case06"
+
+export default [case01, case02, case03, case04, case05, case06]

--- a/packages/showcase/next.config.js
+++ b/packages/showcase/next.config.js
@@ -30,6 +30,7 @@ module.exports = {
     "/blocks/filters": { page: "/blocks/filters", query: { title: "Filters" } },
     "/visualizations": { page: "/visualizations", query: { title: "Visualizations" } },
     "/visualizations/process-flow": { page: "/visualizations/process-flow", query: { title: "Process Flow" } },
+    "/visualizations/process-flow/testcases": { page: "/visualizations/process-flow/testcases", query: { title: "Test Cases" } },
     "/documentation": { page: "/documentation", query: { title: "Documentation" } },
     "/documentation/design-guidelines": { page: "/documentation/design-guidelines", query: { title: "Design Guidelines" } },
     "/documentation/api": { page: "/documentation/api", query: { title: "API Design" } },

--- a/packages/showcase/pages/visualizations/process-flow/index.js
+++ b/packages/showcase/pages/visualizations/process-flow/index.js
@@ -1,4 +1,5 @@
 import * as React from "react"
+import Link from "next/link"
 import { Card, CardHeader, Heading2Type } from "@operational/components"
 import { ProcessFlow, VisualizationWrapper } from "@operational/visualizations"
 
@@ -372,7 +373,15 @@ export default props => (
       </p>
 
       <Heading2Type>Usage</Heading2Type>
+      <p>Here is a simple usage scenario for the process flow</p>
       <Playground snippet={simpleSnippet} scope={{ ProcessFlow }} components={{ VisualizationWrapper }} />
+
+      <p>
+        For more complicated use-cases, check out our collection of{" "}
+        <Link href="/visualizations/process-flow/testcases">
+          <a>visual test cases</a>
+        </Link>.
+      </p>
 
       <Heading2Type>Data</Heading2Type>
       <p>

--- a/packages/showcase/pages/visualizations/process-flow/testcases.js
+++ b/packages/showcase/pages/visualizations/process-flow/testcases.js
@@ -1,0 +1,61 @@
+import * as React from "react"
+import glamorous from "glamorous"
+import { Card, CardHeader, Heading2Type } from "@operational/components"
+import { ProcessFlow, VisualizationWrapper } from "@operational/visualizations"
+
+import Layout from "../../../components/Layout"
+import Table from "../../../components/PropsTable"
+import Playground from "../../../components/Playground"
+import Marathon from "../../../components/Marathon"
+
+import testcases from "../../../components/TestCases/ProcessFlow/index"
+
+const TestToggle = glamorous.span(({ theme, active }) => ({
+  display: "inline-block",
+  marginRight: 16,
+  padding: "2px 4px",
+  cursor: "pointer",
+  borderRadius: active ? 2 : 0,
+  color: active ? theme.colors.white : theme.colors.linkText,
+  backgroundColor: active ? theme.colors.linkText : theme.colors.white,
+  borderBottom: "1px solid currentColor"
+}))
+
+export default class TestCases extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      case: 0
+    }
+  }
+
+  render() {
+    return (
+      <Layout pathname={this.props.url.pathname}>
+        <Card>
+          {testcases.map((testcase, index) => (
+            <TestToggle
+              active={index === this.state.case}
+              key={index}
+              onClick={() => {
+                this.setState(p => ({
+                  case: null
+                }))
+                setTimeout(() => {
+                  this.setState(p => ({
+                    case: index
+                  }))
+                }, 50)
+              }}
+            >
+              {testcase.title}
+            </TestToggle>
+          ))}
+          {this.state.case || this.state.case === 0 ? (
+            <Marathon test={testcases[this.state.case].marathon} timeout={2000} />
+          ) : null}
+        </Card>
+      </Layout>
+    )
+  }
+}


### PR DESCRIPTION
Visual test cases are re-added under /visualizations/process-flow/testcases, and linked to from the docs page (right under the first code playground). I put an emphasis on speed to get this working as quick as possible, will make it nicer looking later.