### PR TITLE
Add code snippet syntax highlighting

### DIFF
--- a/packages/showcase/components/StaticContent.js
+++ b/packages/showcase/components/StaticContent.js
@@ -9,7 +9,11 @@ import highlight from "highlight.js"
 const Container = glamorous.div(({ theme }) => ({
   label: "showcasestaticcontent",
   "& h2": {
-    ...theme.typography.heading1
+    ...theme.typography.heading1,
+    marginBottom: 5,
+    ":not(:first-child)": {
+      marginTop: 20
+    }
   },
   "& h3": {
     ...theme.typography.heading2,
@@ -68,7 +72,11 @@ export default class StaticContent extends React.Component {
     this.codes = []
     const n = this.codeNodes.length
     for (let i = 0; i < n; i++) {
-      this.codes.push(this.codeNodes[i].innerText)
+      const code = this.codeNodes[i].innerText
+      this.codes.push(code)
+      if (code[0] === " ") {
+        this.codeNodes[i].innerText = code.slice(1)
+      }
       highlight.highlightBlock(this.codeNodes[i])
     }
   }

--- a/packages/showcase/pages/_document.js
+++ b/packages/showcase/pages/_document.js
@@ -6,6 +6,80 @@ import { renderStatic } from "glamor/server"
 
 const staticPath = `/static`
 
+const highlightJsCss = `
+/* Base16 Atelier Sulphurpool Light - Theme */
+/* by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool) */
+/* Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16) */
+
+/* Atelier-Sulphurpool Comment */
+.hljs-comment,
+.hljs-quote {
+  color: #6b7394;
+}
+
+/* Atelier-Sulphurpool Red */
+.hljs-variable,
+.hljs-template-variable,
+.hljs-attribute,
+.hljs-tag,
+.hljs-name,
+.hljs-regexp,
+.hljs-link,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #c94922;
+}
+
+/* Atelier-Sulphurpool Orange */
+.hljs-number,
+.hljs-meta,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params {
+  color: #c76b29;
+}
+
+/* Atelier-Sulphurpool Green */
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet {
+  color: #ac9739;
+}
+
+/* Atelier-Sulphurpool Blue */
+.hljs-title,
+.hljs-section {
+  color: #3d8fd1;
+}
+
+/* Atelier-Sulphurpool Purple */
+.hljs-keyword,
+.hljs-selector-tag {
+  /* OPERATIONAL-UI OVERRIDE */
+  /* color: #6679cc; */
+  color: #1499CE;
+}
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  background: #f5f7ff;
+  color: #5e6687;
+  padding: 0.5em;
+}
+
+.hljs-emphasis {
+    font-style: italic;
+}
+
+.hljs-strong {
+    font-weight: bold;
+}
+`
+
 export default class MyDocument extends Document {
   static async getInitialProps({ renderPage }) {
     const page = renderPage()
@@ -25,7 +99,7 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <style dangerouslySetInnerHTML={{ __html: baseStylesheet(operational) }} />
+          <style dangerouslySetInnerHTML={{ __html: baseStylesheet(operational) + highlightJsCss }} />
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
           <title>Operational UI</title>
           <meta name="description" value="Building blocks for effective operational interfaces" />


### PR DESCRIPTION
Went with Atelier Sulphurpool Light (https://highlightjs.org/static/demo/), changing the purple with our light blue.

This also fixes the first-line-misalignment in the code snippets.