### PR TITLE
Fix showcase header height shrink bug

### DIFF
--- a/packages/showcase/components/Layout.js
+++ b/packages/showcase/components/Layout.js
@@ -24,6 +24,9 @@ const Content = glamorous.div({
   height: "100vh",
   "& > *": {
     width: "100%"
+  },
+  "& > *:first-child": {
+    flexShrink: 0
   }
 })
 


### PR DESCRIPTION
Fixes this misalignment:

<img width="1440" alt="screen shot 2018-02-05 at 11 15 15 am" src="https://user-images.githubusercontent.com/6738398/35799427-f2584048-0a65-11e8-8a00-82fb77ce82cc.png">
