### PR TITLE
Simplify build scripts. Tests on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "test": "lerna run test",
     "lint": "lerna run lint",
     "prettier": "lerna run prettier",
-    "precommit": "lerna run precommit && git add .",
+    "precommit": "npm run ci:local && git add .",
     "package": "lerna run package",
     "publish": "lerna publish",
     "ensure:clean:repo": "./scripts/ensure-clean-repo.sh",
-    "ci:local": "npm run lint && npm run prettier && npm run package",
+    "ci:local": "lerna run package && lerna run test && lerna run lint && lerna run prettier",
     "ci": "npm run ci:local && npm run ensure:clean:repo"
   },
   "devDependencies": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -12,12 +12,9 @@
     "package": "rm -rf lib && tsc -d",
     "package:watch": "tsc -d -w",
     "test": "jest",
-    "test:watch": "jest --watch",
-    "lint": "tslint './src/**/*.{ts,tsx}' --fix",
-    "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run prettier",
     "test:u": "jest -u",
-    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
+    "lint": "tslint './src/**/*.{ts,tsx}' --fix",
+    "prettier": "prettier './src/**/*.{ts,tsx}' --write"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,11 +15,9 @@
     "package": "rm -rf lib && tsc -d",
     "package:watch": "tsc -d -w",
     "test": "jest",
-    "lint": "tslint './src/**/*.{ts,tsx}' --fix",
-    "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run prettier",
     "test:u": "jest -u",
-    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
+    "lint": "tslint './src/**/*.{ts,tsx}' --fix",
+    "prettier": "prettier './src/**/*.{ts,tsx}' --write"
   },
   "peerDependencies": {
     "glamor": "^2.20.40",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,10 +15,8 @@
     "package:watch": "tsc -d -w",
     "lint": "tslint './src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run prettier",
     "test": "jest",
-    "test:u": "jest -u",
-    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
+    "test:u": "jest -u"
   },
   "devDependencies": {
     "@types/core-js": "0.9.43",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,12 +14,9 @@
     "package": "rm -rf lib && tsc -d",
     "package:watch": "rm -rf lib && tsc -d -w",
     "test": "jest",
-    "test:watch": "jest --watch",
-    "lint": "tslint './src/**/*.{ts,tsx}' --fix",
-    "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run prettier",
     "test:u": "jest -u",
-    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
+    "lint": "tslint './src/**/*.{ts,tsx}' --fix",
+    "prettier": "prettier './src/**/*.{ts,tsx}' --write"
   },
   "dependencies": {
     "@operational/theme": "^0.1.0-14",

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -13,13 +13,11 @@
   "scripts": {
     "dev": "node scripts/dev-server/index.js",
     "test": "jest",
+    "test:u": "jest -u",
     "package": "rm -rf lib && tsc -d",
     "package:watch": "rm -rf lib && tsc -w",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "lint": "tslint './src/**/*.{ts,tsx}' --fix",
-    "precommit": "npm run prettier",
-    "test:u": "jest -u",
-    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
+    "lint": "tslint './src/**/*.{ts,tsx}' --fix"
   },
   "dependencies": {
     "@operational/theme": "^0.1.0-14",

--- a/scripts/add-build-scripts.js
+++ b/scripts/add-build-scripts.js
@@ -6,37 +6,23 @@ const scripts = {
   lint: "tslint './src/**/*.{ts,tsx}' --fix",
   test: "jest",
   "test:u": "jest -u",
-  package: "rm -rf lib && tsc -d",
-  precommit: "npm run prettier",
-  ci: "npm run test && npm run lint && npm run prettier && npm run package"
+  package: "rm -rf lib && tsc -d"
 }
 
 const jest = {
-  setupFiles: [
-    "./test-polyfills.js"
-  ],
-  moduleFileExtensions: [
-    "ts",
-    "tsx",
-    "js",
-    "jsx"
-  ],
+  setupFiles: ["./test-polyfills.js"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   transform: {
     "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
   },
   testRegex: "/__tests__/.*\\.(ts|tsx|js|jsx)$",
-  setupTestFrameworkScriptFile: "<rootDir>/node_modules/jest-enzyme/lib/index.js",
+  setupTestFrameworkScriptFile:
+    "<rootDir>/node_modules/jest-enzyme/lib/index.js",
   moduleNameMapper: {
     "\\.(css|jpg|png)$": "<rootDir>/empty-module.js"
   },
-  snapshotSerializers: [
-    "<rootDir>/node_modules/jest-serializer-enzyme"
-  ],
-  unmockedModulePathPatterns: [
-    "react",
-    "enzyme",
-    "jest-enzyme"
-  ],
+  snapshotSerializers: ["<rootDir>/node_modules/jest-serializer-enzyme"],
+  unmockedModulePathPatterns: ["react", "enzyme", "jest-enzyme"],
   mapCoverage: true
 }
 
@@ -124,21 +110,37 @@ const packages = ["blocks", "components", "theme", "utils", "visualizations"]
 const writeFiles = () => {
   packages.forEach(pkg => {
     Object.keys(files).forEach(file => {
-      fs.writeFileSync(path.resolve(__dirname, "../packages", pkg, file), files[file])
+      fs.writeFileSync(
+        path.resolve(__dirname, "../packages", pkg, file),
+        files[file]
+      )
     })
   })
 }
 
 const changePackageJson = () => {
   packages.forEach(pkg => {
-    const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../packages", pkg, "package.json"), "utf-8"))
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.resolve(__dirname, "../packages", pkg, "package.json"),
+        "utf-8"
+      )
+    )
     packageJson.scripts = Object.assign({}, packageJson.scripts, scripts)
-    packageJson.devDependencies = Object.assign({}, packageJson.devDependencies, devDependencies)
+    packageJson.devDependencies = Object.assign(
+      {},
+      packageJson.devDependencies,
+      devDependencies
+    )
     packageJson.jest = jest
     if (pkg === "showcase") {
-      packageJson.scripts.package = "echo 'Showcase is not published, hence no package script.'"
+      packageJson.scripts.package =
+        "echo 'Showcase is not published, hence no package script.'"
     }
-    fs.writeFileSync(path.resolve(__dirname, "../packages", pkg, "package.json"), JSON.stringify(packageJson, null, 2))
+    fs.writeFileSync(
+      path.resolve(__dirname, "../packages", pkg, "package.json"),
+      JSON.stringify(packageJson, null, 2)
+    )
   })
 }
 


### PR DESCRIPTION
Fixes #331, like so:
* packages define their own `lint`, `prettier`, `test` and `package`. In order to restore some readability, they don't define their own `precommit`. Due to the lack of usage, removing `test:watch`.
* at the root level, there is a `ci:local` script that runs the above scripts for each package. This script is run on precommit, with all its changes added to the commit.
* on Travis (tests now working), the script is run again, and `npm run ensure:clean:repo` makes sure nothing changes. If a snapshot changes or a semicolon is added back by a script compared to the version of the code that was pushed, everything fails.