### PR TITLE
Fix typo in Checkboxes section of website

### DIFF
--- a/packages/website/src/Sections/Components/Checkboxes.tsx
+++ b/packages/website/src/Sections/Components/Checkboxes.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Checkbox } from "@operational/components"
 
-export const title = "Checkboxs"
+export const title = "Checkboxes"
 
 export const docsUrl = "https://github.com/contiamo/operational-ui/blob/master/docs/components/checkbox.md"
 


### PR DESCRIPTION
Pretty straightforward, `Checkboxs` -> `Checkboxes`.