### PR TITLE
Fix message padding

### DIFF
--- a/packages/components/src/Message/Message.tsx
+++ b/packages/components/src/Message/Message.tsx
@@ -24,7 +24,7 @@ const Container = glamorous.div(({ theme, color }: { theme: Theme; color?: strin
     backgroundColor,
     color: textColor,
     overflow: "hidden",
-    padding: `${theme.spacing * 1 / 2}px ${theme.spacing * 3.5}px ${theme.spacing / 2} ${theme.spacing}`,
+    padding: `${theme.spacing * 1 / 2}px ${theme.spacing * 3.5}px ${theme.spacing / 2}px ${theme.spacing}px`,
     paddingRight: theme.spacing * 2.5, // Icon space
     borderRadius: 4,
     minHeight: theme.spacing * 2.5,

--- a/packages/components/src/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Message.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Message Component Should render 1`] = `
 <div
-  class="css-hnlc16"
+  class="css-190o3bm"
 >
   <div
     class="css-yb71r7"


### PR DESCRIPTION
Left out some `px` strings from the styling in the message component's padding, leading to paddings being ignored in the packaged version.