### PR TITLE
Sidenav headers open by default

### DIFF
--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -120,7 +120,7 @@ const CloseButton = glamorous.div(({ theme }: { theme: Theme }): {} => ({
 
 class SidenavHeader extends React.Component<Props, State> {
   state = {
-    isOpen: false,
+    isOpen: true,
   }
 
   render() {


### PR DESCRIPTION
Sidenav headers should be open by default - they can be closed either by clicking on the header text or the collapse button on the right.

<img width="239" alt="screen shot 2018-06-01 at 1 03 19 pm" src="https://user-images.githubusercontent.com/6738398/40837901-353e3b60-659c-11e8-9c5e-6cb526a33f64.png">