### PR TITLE
Update scatterplot example with axis titles and rotated axis labels.

### DIFF
--- a/packages/visual-tests/src/TestCases/Chart/symbol-3.ts
+++ b/packages/visual-tests/src/TestCases/Chart/symbol-3.ts
@@ -95,9 +95,12 @@ const createData = () => {
     axes: {
       x1: {
         type: "quant",
+        title: "Profit",
+        rotateLabels: true,
       },
       y1: {
         type: "quant",
+        title: "Sales",
       },
     },
   }

--- a/packages/visualizations/src/Chart/axes/categorical_axis.ts
+++ b/packages/visualizations/src/Chart/axes/categorical_axis.ts
@@ -232,10 +232,10 @@ class CategoricalAxis implements AxisClass<string> {
     labels
       .enter()
       .append("svg:text")
-      .call(setTextAttributes, startAttributes)
-      .merge(labels)
       .attr("class", styles.label)
+      .merge(labels)
       .style("font-size", `${this.options.fontSize}px`)
+      .call(setTextAttributes, startAttributes)
       .call(setTextAttributes, attributes, config.duration)
 
     labels
@@ -272,11 +272,9 @@ class CategoricalAxis implements AxisClass<string> {
   }
 
   private getStartAttributes(attributes: AxisAttributes): AxisAttributes {
-    const scaleWithOffset = this.scaleWithOffset(this.previous)
-    return defaults({
-      x: this.isXAxis ? scaleWithOffset : 0,
-      y: this.isXAxis ? 0 : scaleWithOffset,
-    })(attributes)
+    const startAttributes = cloneDeep(attributes)
+    startAttributes[this.isXAxis ? "x" : "y"] = this.scaleWithOffset(this.previous)
+    return startAttributes
   }
 
   private getTickAttributes() {

--- a/packages/visualizations/src/Chart/axes/categorical_axis.ts
+++ b/packages/visualizations/src/Chart/axes/categorical_axis.ts
@@ -273,7 +273,8 @@ class CategoricalAxis implements AxisClass<string> {
 
   private getStartAttributes(attributes: AxisAttributes): AxisAttributes {
     const startAttributes = cloneDeep(attributes)
-    startAttributes[this.isXAxis ? "x" : "y"] = this.scaleWithOffset(this.previous)
+    startAttributes[this.isXAxis ? "x" : "y"] = (d: string) =>
+      this.scaleWithOffset(this.previous)(d) || this.scaleWithOffset(this.computed)(d)
     return startAttributes
   }
 

--- a/packages/visualizations/src/Chart/axes/quant_axis.ts
+++ b/packages/visualizations/src/Chart/axes/quant_axis.ts
@@ -229,10 +229,10 @@ class QuantAxis implements AxisClass<number> {
     labels
       .enter()
       .append("svg:text")
-      .call(setTextAttributes, startAttributes)
-      .merge(labels)
       .attr("class", styles.label)
+      .merge(labels)
       .style("font-size", `${this.options.fontSize}px`)
+      .call(setTextAttributes, startAttributes)
       .call(setTextAttributes, attributes, config.duration)
 
     labels
@@ -286,10 +286,9 @@ class QuantAxis implements AxisClass<number> {
   }
 
   private getStartAttributes(attributes: AxisAttributes): AxisAttributes {
-    return defaults(attributes)({
-      x: this.isXAxis ? this.previous.scale : 0,
-      y: this.isXAxis ? 0 : this.previous.scale,
-    })
+    const startAttributes = cloneDeep(attributes)
+    startAttributes[this.isXAxis ? "x" : "y"] = this.previous.scale
+    return startAttributes
   }
 
   private getTickAttributes() {

--- a/packages/visualizations/src/Chart/axes/time_axis.ts
+++ b/packages/visualizations/src/Chart/axes/time_axis.ts
@@ -322,12 +322,12 @@ class TimeAxis implements AxisClass<Date> {
     labels
       .enter()
       .append("svg:text")
-      .call(setTextAttributes, startAttributes)
-      .merge(labels)
       .attr("class", styles.label)
+      .merge(labels)
       // @TODO
       // .attr("class", (d: string | number, i: number): string => "tick " + this.tickClass(d, i))
       .style("font-size", `${this.options.fontSize}px`)
+      .call(setTextAttributes, startAttributes)
       .call(setTextAttributes, attributes, config.duration)
 
     labels
@@ -373,10 +373,9 @@ class TimeAxis implements AxisClass<Date> {
   }
 
   private getStartAttributes(attributes: AxisAttributes): AxisAttributes {
-    return defaults(attributes)({
-      x: this.isXAxis ? this.previous.scale : 0,
-      y: this.isXAxis ? 0 : this.previous.scale,
-    })
+    const startAttributes = cloneDeep(attributes)
+    startAttributes[this.isXAxis ? "x" : "y"] = this.previous.scale
+    return startAttributes
   }
 
   private getTickAttributes() {


### PR DESCRIPTION
Chart bottom padding seems to be computed incorrectly after data update.

![image](https://user-images.githubusercontent.com/200647/41354162-8b76e708-6f1e-11e8-973a-94073ecf7ede.png)
