### PR TITLE
Update buttons

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -63,6 +63,7 @@ const containerStyles = ({
   const foregroundColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
   const spacing = theme.space.content
   const padding = condensed ? theme.space.small : spacing
+  const computedBorderColor = active ? activeBackgroundColor : backgroundColor
 
   return {
     lineHeight: `${condensed ? 26 : 34}px`,
@@ -73,11 +74,7 @@ const containerStyles = ({
     padding: `0 ${icon ? padding / 2 : padding}px 0 ${padding}px`,
     borderRadius: theme.borderRadius,
     border: "1px solid",
-    borderColor: isWhite(backgroundColor)
-      ? theme.color.border.default
-      : active
-        ? activeBackgroundColor
-        : backgroundColor,
+    borderColor: isWhite(backgroundColor) ? theme.color.border.default : computedBorderColor,
     cursor: disabled ? "auto" : "pointer",
     backgroundColor: active ? activeBackgroundColor : backgroundColor,
     opacity: disabled ? 0.6 : 1.0,

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -62,12 +62,10 @@ const containerStyles = ({
   const activeBackgroundColor: string = darken(backgroundColor, 5)
   const foregroundColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
   const spacing = theme.space.content
-  const height = condensed ? 28 : 36
   const padding = condensed ? theme.space.small : spacing
 
   return {
-    height,
-    lineHeight: `${height}px`,
+    lineHeight: `${condensed ? 26 : 34}px`,
     label: "button",
     fontSize: theme.font.size.small,
     fontFamily: theme.font.family.main,

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { readableTextColor, darken, lighten } from "@operational/utils"
-import { OperationalStyleConstants, Theme, expandColor } from "@operational/theme"
+import { readableTextColor, darken, lighten, expandColor } from "@operational/utils"
+import { OperationalStyleConstants, Theme } from "@operational/theme"
 import { isWhite, isModifiedEvent } from "../utils"
-import { WithTheme, Css, CssStatic } from "../types"
+import { Css, CssStatic } from "../types"
 import { ContextConsumer, Context } from "../"
 import Spinner from "../Spinner/Spinner"
 
@@ -20,7 +20,7 @@ export interface Props {
   /** Navigation property à la react-router <Link/> */
 
   to?: string
-  /** Color assigned to the avatar circle (hex or named color from `theme.colors`) */
+  /** Color assigned to the avatar circle (hex or named color from `theme.color`) */
 
   color?: string
   /** Loading flag - if enabled, the text hides and a spinner appears in the center */
@@ -46,29 +46,32 @@ const containerStyles = ({
   condensed,
   loading,
 }: {
-  theme?: OperationalStyleConstants & {
-    deprecated: Theme
-  }
+  theme?: OperationalStyleConstants
   color?: string
   active?: boolean
   disabled?: boolean
   condensed?: boolean
   loading?: boolean
 }): CssStatic => {
-  const defaultColor: string = theme.deprecated.colors.white
-  const backgroundColor: string = expandColor(theme.deprecated, color) || defaultColor
+  const defaultColor: string = theme.color.white
+  const backgroundColor: string = expandColor(theme, color) || defaultColor
   const activeBackgroundColor: string = darken(backgroundColor, 5)
-  const foregroundColor = readableTextColor(backgroundColor, [theme.deprecated.colors.text, "white"])
-  const spacing = theme.deprecated.spacing
+  const foregroundColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
+  const spacing = theme.space.content
+  const height = condensed ? 28 : 36
+
   return {
+    height,
+    lineHeight: `${height}px`,
     label: "button",
-    ...theme.deprecated.typography.body,
+    fontSize: theme.font.size.small,
+    fontFamily: theme.font.family.main,
     display: "inline-block",
-    padding: condensed ? `${spacing / 8}px ${spacing / 2}px` : `${spacing * 0.375}px ${spacing * 1.5}px`,
-    borderRadius: theme.deprecated.borderRadius,
+    padding: `0 ${condensed ? theme.space.small : spacing}px`,
+    borderRadius: theme.borderRadius,
     border: "1px solid",
     borderColor: isWhite(backgroundColor)
-      ? theme.deprecated.colors.gray
+      ? theme.color.border.default
       : active
         ? activeBackgroundColor
         : backgroundColor,

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -42,12 +42,16 @@ export interface Props {
 
 type PropsWithTheme = Props & { theme?: OperationalStyleConstants }
 
-const makeColors = (theme: OperationalStyleConstants, color: string) => {
+const makeColors = (theme: OperationalStyleConstants, color: string, active?: boolean) => {
   const defaultColor: string = theme.color.white
-  const backgroundColor: string = expandColor(theme, color) || defaultColor
+  const grey: string = theme.color.background[active ? "light" : "lighter"]
+  const greyText: string = theme.color.text[active ? "action" : "lightest"]
+  const backgroundColor: string = color === "grey" ? grey : expandColor(theme, color) || defaultColor
+  const textColor: string =
+    color === "grey" ? greyText : readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
   return {
     background: backgroundColor,
-    foreground: readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white]),
+    foreground: textColor,
   }
 }
 
@@ -60,7 +64,7 @@ const containerStyles: Interpolation<Props> = ({
   loading,
   icon,
 }: PropsWithTheme) => {
-  const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color)
+  const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color, active)
   const activeBackgroundColor: string = darken(backgroundColor, 5)
   const spacing = theme.space.content
   const padding = condensed ? theme.space.small : spacing

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -4,7 +4,7 @@ import { readableTextColor, darken, lighten, expandColor } from "@operational/ut
 import { OperationalStyleConstants, Theme } from "@operational/theme"
 import { isWhite, isModifiedEvent } from "../utils"
 import { Css, CssStatic } from "../types"
-import { ContextConsumer, Context } from "../"
+import { ContextConsumer, Context, Icon, IconName } from "../"
 import Spinner from "../Spinner/Spinner"
 
 export interface Props {
@@ -23,6 +23,8 @@ export interface Props {
   /** Color assigned to the avatar circle (hex or named color from `theme.color`) */
 
   color?: string
+  /** Icon to display on right of button (optional) */
+  icon?: string | React.ReactNode
   /** Loading flag - if enabled, the text hides and a spinner appears in the center */
 
   loading?: boolean
@@ -45,6 +47,7 @@ const containerStyles = ({
   disabled,
   condensed,
   loading,
+  icon,
 }: {
   theme?: OperationalStyleConstants
   color?: string
@@ -52,6 +55,7 @@ const containerStyles = ({
   disabled?: boolean
   condensed?: boolean
   loading?: boolean
+  icon?: string | React.ReactNode
 }): CssStatic => {
   const defaultColor: string = theme.color.white
   const backgroundColor: string = expandColor(theme, color) || defaultColor
@@ -59,6 +63,7 @@ const containerStyles = ({
   const foregroundColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
   const spacing = theme.space.content
   const height = condensed ? 28 : 36
+  const padding = condensed ? theme.space.small : spacing
 
   return {
     height,
@@ -67,7 +72,7 @@ const containerStyles = ({
     fontSize: theme.font.size.small,
     fontFamily: theme.font.family.main,
     display: "inline-block",
-    padding: `0 ${condensed ? theme.space.small : spacing}px`,
+    padding: `0 ${icon ? padding / 2 : padding}px 0 ${padding}px`,
     borderRadius: theme.borderRadius,
     border: "1px solid",
     borderColor: isWhite(backgroundColor)
@@ -107,6 +112,14 @@ const containerStyles = ({
 const Container = styled("button")(containerStyles)
 const ContainerLink = styled("a")(containerStyles)
 
+const IconContainer = styled("div")(({ theme, condensed }: CompProps) => ({
+  marginLeft: condensed ? theme.space.small : theme.space.small,
+  float: "right",
+  "& svg": {
+    verticalAlign: "text-bottom",
+  },
+}))
+
 const Button = (props: Props) => {
   const ContainerComponent = props.to ? ContainerLink : Container
   return (
@@ -136,9 +149,19 @@ const Button = (props: Props) => {
           active={props.active}
           disabled={props.disabled}
           condensed={props.condensed}
+          icon={props.icon}
           title={props.loading && props.children === String(props.children) ? String(props.children) : undefined}
         >
           {props.children}
+          {props.icon && (
+            <IconContainer condensed={props.condensed}>
+              {typeof props.icon === "string" ? (
+                <Icon name={props.icon as IconName} size={props.condensed ? 16 : 20} />
+              ) : (
+                props.icon
+              )}
+            </IconContainer>
+          )}
           {props.loading && (
             <Spinner
               className="op_button-spinner"

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -72,7 +72,7 @@ const containerStyles: Interpolation<Props> = ({
     fontSize: theme.font.size.small,
     fontFamily: theme.font.family.main,
     display: "inline-block",
-    padding: `0 ${icon ? padding / 2 : padding}px 0 ${padding}px`,
+    padding: `0 ${padding}px`,
     borderRadius: theme.borderRadius,
     border: "1px solid",
     borderColor: isWhite(backgroundColor) ? theme.color.border.default : computedBorderColor,
@@ -106,7 +106,7 @@ const Container = styled("button")(containerStyles)
 const ContainerLink = styled("a")(containerStyles)
 
 const IconContainer = styled("div")(({ theme, condensed }: Css) => ({
-  marginLeft: condensed ? theme.space.small : theme.space.small,
+  marginLeft: theme.space.small,
   float: "right",
   "& svg": {
     verticalAlign: "text-bottom",

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -112,7 +112,7 @@ const containerStyles = ({
 const Container = styled("button")(containerStyles)
 const ContainerLink = styled("a")(containerStyles)
 
-const IconContainer = styled("div")(({ theme, condensed }: CompProps) => ({
+const IconContainer = styled("div")(({ theme, condensed }: Css) => ({
   marginLeft: condensed ? theme.space.small : theme.space.small,
   float: "right",
   "& svg": {

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -162,11 +162,7 @@ const Button = (props: Props) => {
           {props.children}
           {props.icon && (
             <IconContainer condensed={props.condensed}>
-              {typeof props.icon === "string" ? (
-                <Icon name={props.icon as IconName} size={props.condensed ? 16 : 20} />
-              ) : (
-                props.icon
-              )}
+              {typeof props.icon === "string" ? <Icon name={props.icon as IconName} size={16} /> : props.icon}
             </IconContainer>
           )}
           {props.loading && <ButtonSpinner containerColor={props.color} />}

--- a/packages/components/src/Button/README.md
+++ b/packages/components/src/Button/README.md
@@ -5,15 +5,24 @@ Buttons are used heavily throughout an operational interface, and they often req
 Using buttons is as simple as including the component with a text node as a child. Colors may be specified as hex strings, or as a pre-defined color key from the theme.
 
 ```jsx
-<Button>Default</Button>
-<Button color="primary">Set color</Button>
-<Button color="#393939">Custom color</Button>
-<Button color="success" disabled>Disabled</Button>
-<Button disabled>Disabled</Button>
-<Button condensed>Condensed</Button>
-<Button color="success" icon="ExternalLink">Icon</Button>
-<Button condensed icon="ExternalLink">Icon</Button>
-<Button loading>Loading</Button>
+<div style={{marginBottom:"10px"}}>
+  <Button>Default</Button>
+  <Button color="primary">Set color</Button>
+  <Button color="#393939">Custom color</Button>
+  <Button color="success" disabled>Disabled</Button>
+  <Button disabled>Disabled</Button>
+  <Button condensed>Condensed</Button>
+</div>
+<div style={{marginBottom:"10px"}}>
+  <Button color="success" icon="ExternalLink">Icon</Button>
+  <Button condensed icon="ExternalLink">Icon</Button>
+  <Button loading>Loading</Button>
+</div>
+<div>
+  <Button color="grey">Update</Button>
+  <Button color="grey" active>Test</Button>
+  <Button color="error">Delete this bundle</Button>
+</div>
 ```
 
 ### Usage with links
@@ -21,5 +30,7 @@ Using buttons is as simple as including the component with a text node as a chil
 Using a `to` prop navigates automatically, and render proper anchor tags with hrefs. See `OperationalUI` docs for a one-time configuration you need to do to have pushstate navigation working out-of-the-box.
 
 ```jsx
-<Button color="info" to="/some-url">Button One</Button>
+<Button color="info" to="/some-url">
+  Button One
+</Button>
 ```

--- a/packages/components/src/Button/README.md
+++ b/packages/components/src/Button/README.md
@@ -5,12 +5,15 @@ Buttons are used heavily throughout an operational interface, and they often req
 Using buttons is as simple as including the component with a text node as a child. Colors may be specified as hex strings, or as a pre-defined color key from the theme.
 
 ```jsx
-<Button>Default button</Button>
-<Button color="primary">Predefined color</Button>
+<Button>Default</Button>
+<Button color="primary">Set color</Button>
 <Button color="#393939">Custom color</Button>
 <Button color="success" disabled>Disabled</Button>
 <Button disabled>Disabled</Button>
 <Button condensed>Condensed</Button>
+<Button color="success" icon="ExternalLink">Icon</Button>
+<Button condensed icon="ExternalLink">Icon</Button>
+<Button loading>Loading</Button>
 ```
 
 ### Usage with links

--- a/packages/components/src/Button/README.md
+++ b/packages/components/src/Button/README.md
@@ -5,9 +5,12 @@ Buttons are used heavily throughout an operational interface, and they often req
 Using buttons is as simple as including the component with a text node as a child. Colors may be specified as hex strings, or as a pre-defined color key from the theme.
 
 ```jsx
-<Button color="info">Button One</Button>
-<Button color="#393939">Button Two</Button>
-<Button disabled>Button Three</Button>
+<Button>Default button</Button>
+<Button color="primary">Predefined color</Button>
+<Button color="#393939">Custom color</Button>
+<Button color="success" disabled>Disabled</Button>
+<Button disabled>Disabled</Button>
+<Button condensed>Condensed</Button>
 ```
 
 ### Usage with links

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -7,9 +7,6 @@ import { WithTheme, Css, CssStatic } from "../types"
 export interface Props {
   id?: string
   /** `css` prop as expected in a glamorous component */
-
-  css?: Css
-  className?: string
   color?: string
 }
 
@@ -26,13 +23,11 @@ const size = 20
 const animationTimeUnit: number = 0.6
 const f: number = 0.25
 
-const Container = styled("div")(
-  (): CssStatic => ({
-    label: "spinner",
-    width: size,
-    height: size,
-  }),
-)
+const Container = styled("div")({
+  label: "spinner",
+  width: size,
+  height: size,
+})
 
 const PulsingCube = styled("div")(
   ({
@@ -44,7 +39,7 @@ const PulsingCube = styled("div")(
     }
     color?: string
   }): CssStatic => {
-    const backgroundColor: string = expandColor(theme.deprecated, color) || theme.deprecated.colors.info
+    const backgroundColor: string = expandColor(theme.deprecated, color) || "currentColor"
     return {
       backgroundColor,
       fontSize: 0,
@@ -77,9 +72,7 @@ const PulsingCube = styled("div")(
 )
 
 const Spinner = (props: Props) => (
-  <Container id={props.id} css={props.css} className={props.className} color={props.color}>
-    {[0, 1, 2, 3].map(index => <PulsingCube key={index} color={props.color} />)}
-  </Container>
+  <Container {...props}>{[0, 1, 2, 3].map(index => <PulsingCube key={index} color={props.color} />)}</Container>
 )
 
 export default Spinner

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-1b5jt9t-button"
+  class="css-1raqec9-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-5za29o-button"
+  class="css-1an7dzt-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-qq0ts5-button"
+  class="css-sqaiul-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-1raqec9-button"
+  class="css-5za29o-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-sqaiul-button"
+  class="css-1b5jt9t-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-1raqec9-button"
+    class="css-5za29o-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-5za29o-button"
+    class="css-1an7dzt-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-1b5jt9t-button"
+    class="css-1raqec9-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-qq0ts5-button"
+    class="css-sqaiul-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-sqaiul-button"
+    class="css-1b5jt9t-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Spinner.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`Spinner Component Should render 1`] = `
   class="css-i5a8z9-spinner"
 >
   <div
-    class="css-ultagy"
+    class="css-10qb0ui"
   />
   <div
-    class="css-ultagy"
+    class="css-10qb0ui"
   />
   <div
-    class="css-ultagy"
+    class="css-10qb0ui"
   />
   <div
-    class="css-ultagy"
+    class="css-10qb0ui"
   />
 </div>
 `;

--- a/packages/components/src/utils/color.ts
+++ b/packages/components/src/utils/color.ts
@@ -1,1 +1,2 @@
-export const isWhite = (color: string) => ["white", "#fff", "#ffffff"].indexOf(color.toLowerCase()) > -1
+export const isWhite = (color: string) =>
+  ["white", "#fff", "#ffffff", "hsl(0, 0%, 100%)"].indexOf(color.toLowerCase()) > -1

--- a/packages/theme/src/constants.ts
+++ b/packages/theme/src/constants.ts
@@ -103,6 +103,7 @@ export interface OperationalStyleConstants {
   readonly color: OperationalColors
   readonly font: OperationalFont
   readonly space: OperationalSpace
+  readonly borderRadius: number
 }
 
 const makeConstants = (): OperationalStyleConstants => ({
@@ -115,6 +116,7 @@ const makeConstants = (): OperationalStyleConstants => ({
     text: textColors,
     border: borderColors,
   },
+  borderRadius: 2,
 })
 
 /**

--- a/packages/theme/src/utils.ts
+++ b/packages/theme/src/utils.ts
@@ -4,6 +4,10 @@ import { Theme } from "./index"
  * Expands a color expressed either as a custom hex value
  * or a color key to pick from within the theme.colors object.
  */
+/*
+ * This version is for use with the old theme, and is deprecated in favour of the version
+ * in @operational/utils which can be used for components that use OperationalStyleConstants rather than Theme
+ */
 export const expandColor = (theme: Theme, color?: string): string | null => {
   if (!color) {
     return null

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -1,4 +1,5 @@
 import * as colorCalculator from "tinycolor2"
+import { OperationalStyleConstants } from "@operational/theme"
 
 const getBrightestColor = (colors: ColorFormats.HSLA[]): ColorFormats.HSLA =>
   colors.reduce((acc, curr) => {
@@ -43,3 +44,20 @@ export const transparentize = (color: string) => (percentage: number): string =>
   (({ r, g, b }) => {
     return `rgba(${r}, ${g}, ${b}, ${(255 * (100 - percentage)) / 100})`
   })(colorCalculator(color).toRgb())
+
+/*
+ * Expands a color expressed either as a custom hex value
+ * or a color key to pick from within the style constants object.
+*/
+export const expandColor = (theme: OperationalStyleConstants, color?: string): string | null => {
+  if (!color) {
+    return null
+  }
+  const hexRegEx = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)|currentColor/i
+  const isHex = hexRegEx.test(color)
+  if (isHex) {
+    return color
+  }
+  // || null is necessary to coerce undefineds into nulls
+  return (theme.color as any)[color] || (null as string | null)
+}

--- a/packages/website/src/Sections/Components/Colors.tsx
+++ b/packages/website/src/Sections/Components/Colors.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import glamorous from "glamorous"
 import { Button } from "@operational/components"
-import { operational } from "@operational/theme"
+import { constants as styleConstants } from "@operational/theme"
 import * as constants from "../../constants"
 
 export const title = "Colors"
@@ -13,20 +13,20 @@ export const snippetUrl = `${constants.snippetBaseUrl}/Components/Colors.tsx`
 export const Component = () => (
   <>
     <div>
-      <Button color="info">{`info / ${operational.colors.info}`}</Button>
-      <Button color="navBackground">{`nav / ${operational.colors.navBackground}`}</Button>
-      <Button color="background">{`background / ${operational.colors.background}`}</Button>
+      <Button condensed color="primary">{`primary / ${styleConstants.color.primary}`}</Button>
+      <Button condensed color="disabled">{`disabled / ${styleConstants.color.disabled}`}</Button>
     </div>
     <div>
-      <Button color="success">{`success / ${operational.colors.success}`}</Button>
-      <Button color="warning">{`warning / ${operational.colors.warning}`}</Button>
-      <Button color="error">{`error / ${operational.colors.error}`}</Button>
+      <Button condensed color="success">{`success / ${styleConstants.color.success}`}</Button>
+      <Button condensed color="error">{`error / ${styleConstants.color.error}`}</Button>
     </div>
     <div>
-      <Button color="gray">{`gray / ${operational.colors.gray}`}</Button>
-      <Button color="lightGray">{`lightGray / ${operational.colors.lightGray}`}</Button>
-      <Button color="border">{`border / ${operational.colors.border}`}</Button>
-      <Button color="separator">{`separator / ${operational.colors.separator}`}</Button>
+      <Button condensed color="basic">{`basic / ${styleConstants.color.basic}`}</Button>
+      <Button condensed color="ghost">{`ghost / ${styleConstants.color.ghost}`}</Button>
+    </div>
+    <div>
+      <Button condensed color="white">{`white / ${styleConstants.color.white}`}</Button>
+      <Button condensed color="black">{`black / ${styleConstants.color.black}`}</Button>
     </div>
   </>
 )


### PR DESCRIPTION
- Redefined button styles using new style constants rather than old theme.
- Migration from glamorous to emotion.
- An icon prop can now be passed to the button as either a string (icon name) or React component - icon sizing and margins are dependent on the value of the `condensed` prop.

The icons look slightly different to in the demos in Zeplin - not sure why. Icon sizes are therefore as close as I could get to the examples but couldn't figure out exactly what they were meant to be (@micha-f, thoughts?) 
![image](https://user-images.githubusercontent.com/14272822/41538534-ea53f716-730b-11e8-8803-f5cf32f5006e.png)
