### PR TITLE
Fix internal style adjustments

### DIFF
--- a/packages/components/src/Breakdown/Breakdown.tsx
+++ b/packages/components/src/Breakdown/Breakdown.tsx
@@ -164,7 +164,7 @@ const Number = styled("div")(
   }),
 )
 
-const Span = styled("span")()
+const Span = styled("span")({ fontFeatureSettings: "'tnum'" })
 
 const Breakdown: React.SFC<Props> = props => (
   <Container
@@ -179,13 +179,7 @@ const Breakdown: React.SFC<Props> = props => (
     <Content>
       <Label>{props.children}</Label>
       <Bar color={props.color} fill={props.fill}>
-        <Span
-          css={{
-            fontFeatureSettings: "'tnum'",
-          }}
-        >
-          {props.label}
-        </Span>
+        <Span>{props.label}</Span>
       </Bar>
     </Content>
   </Container>

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -3,7 +3,7 @@ import styled, { Interpolation } from "react-emotion"
 import { readableTextColor, darken, lighten, expandColor } from "@operational/utils"
 import { OperationalStyleConstants } from "@operational/theme"
 import { isWhite, isModifiedEvent } from "../utils"
-import { Css, CssStatic } from "../types"
+import { Css } from "../types"
 import { ContextConsumer, Context, Icon, IconName } from "../"
 import Spinner from "../Spinner/Spinner"
 

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -164,6 +164,9 @@ class DatePicker extends React.Component<Props, State> {
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
     const placeholderDays = monthStartDay(year, month)
     const daysInCurrentMonth = daysInMonth(month, year)
+    const FullWidthInput = styled(Input)`
+      width: 100%;
+    `
     const datePickerWithoutLabel = (
       <Container
         innerRef={(node: React.ReactNode) => {
@@ -186,7 +189,7 @@ class DatePicker extends React.Component<Props, State> {
             <Icon name="X" size={14} />
           </Toggle>
         )}
-        <Input
+        <FullWidthInput
           isExpanded={this.state.isExpanded}
           id={domId}
           readOnly
@@ -206,9 +209,6 @@ class DatePicker extends React.Component<Props, State> {
                 }
               },
             )
-          }}
-          css={{
-            width: "100%",
           }}
         />
         <DatePickerCard isExpanded={isExpanded}>

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,31 +1,12 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { OperationalStyleConstants, Theme } from "@operational/theme"
-import { WithTheme, Css, CssStatic } from "../types"
+import { Css } from "../types"
 import { Label, LabelText } from "../utils/mixins"
 import { Card, Icon } from "../"
 
-import {
-  Container,
-  ClearButton,
-  Toggle,
-  MonthNav,
-  IconContainer,
-  Days,
-  Day,
-  Input,
-  DatePickerCard,
-} from "./DatePicker.styles"
+import { Container, Toggle, MonthNav, IconContainer, Input, DatePickerCard } from "./DatePicker.styles"
 
-import {
-  months,
-  daysInMonth,
-  range,
-  toDate,
-  monthStartDay,
-  toYearMonthDay,
-  validateDateString,
-} from "./DatePicker.utils"
+import { months, toYearMonthDay, validateDateString } from "./DatePicker.utils"
 
 import Month from "./DatePicker.Month"
 
@@ -162,11 +143,8 @@ class DatePicker extends React.Component<Props, State> {
     const { onChange, placeholder, start, end, label, id, css, className } = this.props
     const { isExpanded, month, year } = this.state
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
-    const placeholderDays = monthStartDay(year, month)
-    const daysInCurrentMonth = daysInMonth(month, year)
-    const FullWidthInput = styled(Input)`
-      width: 100%;
-    `
+    const FullWidthInput = styled(Input)({ width: "100%" })
+
     const datePickerWithoutLabel = (
       <Container
         innerRef={(node: React.ReactNode) => {

--- a/packages/components/src/Input/Input.tsx
+++ b/packages/components/src/Input/Input.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants, Theme } from "@operational/theme"
-import { lighten } from "@operational/utils"
-import { WithTheme, Css, CssStatic } from "../types"
-import { Icon, Tooltip } from "../"
+import { Css } from "../types"
+import { Icon } from "../"
+import Tooltip from "../Tooltip/Tooltip" // Styled components appears to have an internal bug that breaks when this is imported from index.ts
 import { Label, LabelText, inputFocus, FormFieldControls, FormFieldControl, FormFieldError } from "../utils/mixins"
 import { inputDefaultWidth } from "../constants"
 
@@ -61,11 +61,14 @@ const InputField = styled("input")(
     disabled: boolean
     isStandalone: boolean
     isError: boolean
-  }): CssStatic => ({
+  }) => ({
     ...theme.deprecated.typography.body,
-    // If the input field is standalone without a label, it should not specify any display properties
-    // to avoid input fields that span the screen. Min width should take care of presentable
-    // default looks.
+    /**
+     * If the input field is standalone without a label, it should not specify any display properties
+     * to avoid input fields that span the screen. Min width should take care of presentable
+     * default looks.
+     */
+
     ...(isStandalone
       ? {}
       : {
@@ -88,10 +91,10 @@ const InputField = styled("input")(
   }),
 )
 
-const HelpTooltip = styled(Tooltip)`
-  min-width: 100px;
-  width: fit-content;
-`
+const HelpTooltip = styled(Tooltip)({
+  minWidth: 100,
+  width: "fit-content",
+})
 
 const Input = (props: Props) => {
   const forAttributeId = props.label && props.labelId
@@ -110,7 +113,6 @@ const Input = (props: Props) => {
       props.onChange && props.onChange(e.target.value)
     },
   }
-
 
   if (props.label) {
     return (

--- a/packages/components/src/Input/Input.tsx
+++ b/packages/components/src/Input/Input.tsx
@@ -70,6 +70,7 @@ const InputField = styled("input")(
       ? {}
       : {
           display: "block",
+          width: "100%",
         }),
     label: "input",
     minWidth: inputDefaultWidth,
@@ -86,6 +87,11 @@ const InputField = styled("input")(
     }),
   }),
 )
+
+const HelpTooltip = styled(Tooltip)`
+  min-width: 100px;
+  width: fit-content;
+`
 
 const Input = (props: Props) => {
   const forAttributeId = props.label && props.labelId
@@ -105,6 +111,7 @@ const Input = (props: Props) => {
     },
   }
 
+
   if (props.label) {
     return (
       <Label id={props.id} htmlFor={forAttributeId} css={props.css} className={props.className}>
@@ -113,15 +120,7 @@ const Input = (props: Props) => {
           {props.hint ? (
             <FormFieldControl>
               <Icon name="HelpCircle" size={14} />
-              <Tooltip
-                right
-                css={{
-                  minWidth: 100,
-                  width: "fit-content",
-                }}
-              >
-                {props.hint}
-              </Tooltip>
+              <HelpTooltip right>{props.hint}</HelpTooltip>
             </FormFieldControl>
           ) : null}
           {props.onToggle ? (
@@ -134,15 +133,7 @@ const Input = (props: Props) => {
             </FormFieldControl>
           ) : null}
         </FormFieldControls>
-        <InputField
-          {...commonInputProps}
-          id={forAttributeId}
-          autoComplete={props.autoComplete}
-          css={{
-            display: "block",
-            width: "100%",
-          }}
-        />
+        <InputField {...commonInputProps} id={forAttributeId} autoComplete={props.autoComplete} />
         {props.error ? <FormFieldError>{props.error}</FormFieldError> : null}
       </Label>
     )

--- a/packages/components/src/Input/README.md
+++ b/packages/components/src/Input/README.md
@@ -26,3 +26,9 @@ class StatefulInput extends React.Component {
 
 <StatefulInput />
 ```
+
+### With help tooltip
+
+```jsx
+<Input value="12" label="Phone number" hint="Please use country code" />
+```

--- a/packages/components/src/Layout/Layout.tsx
+++ b/packages/components/src/Layout/Layout.tsx
@@ -63,26 +63,21 @@ const Main = styled("div")(
   }),
 )
 
-const Div = styled("div")()
+/* 
+ * This placeholder element is added to the dom in case there is no
+ * <Progress /> element, allowing the CSS to target children by the same
+ * nth-child identifier regardless of whether the loader is present.
+ * Absolute positioning is required to remove it from document flow
+ * so that it doesn't affect the grid.
+ */
+const CssPlaceholder = styled("div")({
+  position: "absolute"
+})
 
 const Layout = (props: Props) => {
-  /* 
-   * This placeholder element is added to the dom in case there is no
-   * <Progress /> element, allowing the CSS to target children by the same
-   * nth-child identifier regardless of whether the loader is present.
-   * Absolute positioning is required to remove it from document flow
-   * so that it doesn't affect the grid.
-   */
-  const cssPlaceholder = (
-    <Div
-      css={{
-        position: "absolute",
-      }}
-    />
-  )
   return (
     <Container css={props.css} className={props.className}>
-      {props.loading ? <Progress /> : cssPlaceholder}
+      {props.loading ? <Progress /> : <CssPlaceholder />}
       {props.sidenav}
       <Main>{props.main}</Main>
     </Container>

--- a/packages/components/src/Layout/Layout.tsx
+++ b/packages/components/src/Layout/Layout.tsx
@@ -71,7 +71,7 @@ const Main = styled("div")(
  * so that it doesn't affect the grid.
  */
 const CssPlaceholder = styled("div")({
-  position: "absolute"
+  position: "absolute",
 })
 
 const Layout = (props: Props) => {

--- a/packages/components/src/Record/README.md
+++ b/packages/components/src/Record/README.md
@@ -4,13 +4,12 @@ Records are general-purpose displays of resources, composed of a header element 
 
 ```js
 const { Tile } = require("../")
-
 ;<Record title="Deutsche Bahn (German Railway Company)">
   Deutsche Bahn AG is a German railway company. It is federally owned and employs around 300,000 people.
 </Record>
 ```
 
-## Props
+### Props
 
 | Name              | Description                                                                                           | Type               | Default | Required |
 | :---------------- | :---------------------------------------------------------------------------------------------------- | :----------------- | :------ | :------- |

--- a/packages/components/src/Textarea/Textarea.tsx
+++ b/packages/components/src/Textarea/Textarea.tsx
@@ -1,9 +1,11 @@
 import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants, Theme } from "@operational/theme"
+
 import { Label, LabelText, FormFieldControls, FormFieldControl, FormFieldError, inputFocus } from "../utils/mixins"
-import { Icon, Tooltip } from "../"
-import { WithTheme, Css, CssStatic } from "../types"
+import { Icon } from "../"
+import Tooltip from "../Tooltip/Tooltip" // Styled components appears to have an internal bug that breaks when this is imported from index.ts
+import { Css, CssStatic } from "../types"
 
 export interface Props {
   id?: string
@@ -94,10 +96,10 @@ const TextareaComp = styled("textarea")(
   },
 )
 
-const HelpTooltip = styled(Tooltip)`
-  min-width: 100px;
-  width: fit-content;
-`
+const HelpTooltip = styled(Tooltip)({
+  minWidth: 100,
+  width: "fit-content",
+})
 
 const Textarea = (props: Props) => {
   return (
@@ -107,11 +109,7 @@ const Textarea = (props: Props) => {
         {props.hint ? (
           <FormFieldControl>
             <Icon name="HelpCircle" size={14} />
-            <HelpTooltip
-              right
-            >
-              {props.hint}
-            </HelpTooltip>
+            <HelpTooltip right>{props.hint}</HelpTooltip>
           </FormFieldControl>
         ) : null}
       </FormFieldControls>

--- a/packages/components/src/Textarea/Textarea.tsx
+++ b/packages/components/src/Textarea/Textarea.tsx
@@ -94,6 +94,11 @@ const TextareaComp = styled("textarea")(
   },
 )
 
+const HelpTooltip = styled(Tooltip)`
+  min-width: 100px;
+  width: fit-content;
+`
+
 const Textarea = (props: Props) => {
   return (
     <Label css={props.css} className={props.className} id={props.id}>
@@ -102,15 +107,11 @@ const Textarea = (props: Props) => {
         {props.hint ? (
           <FormFieldControl>
             <Icon name="HelpCircle" size={14} />
-            <Tooltip
+            <HelpTooltip
               right
-              css={{
-                minWidth: 100,
-                width: "fit-content",
-              }}
             >
               {props.hint}
-            </Tooltip>
+            </HelpTooltip>
           </FormFieldControl>
         ) : null}
       </FormFieldControls>

--- a/packages/components/src/Timeline/README.md
+++ b/packages/components/src/Timeline/README.md
@@ -1,10 +1,4 @@
-# Timelines
-
-Display information vertically on a timeline from top to bottom.
-
-## Usage
-
-A timeline is composed of multiple TimeLineItem componenets nested inside a container Timeline component. Items may contain any children.
+Display information vertically on a timeline from top to bottom. A timeline is composed of multiple TimeLineItem componenets nested inside a container Timeline component. Items may contain any children.
 
 ```jsx
 <Timeline>
@@ -27,9 +21,9 @@ A timeline is composed of multiple TimeLineItem componenets nested inside a cont
 </Timeline>
 ```
 
-## Props
+### Props
 
-| Name | Description | Type | Default | Required | 
-| :--- | :--- | :--- | :---| :--- |
-| color | It can be a named theme color or a hex value. | string | info | Yes |
-| icon | Icon name, see https://feathericons.com/ (convert name to PascalCase) | string | '' | Yes |
+| Name  | Description                                                           | Type   | Default | Required |
+| :---- | :-------------------------------------------------------------------- | :----- | :------ | :------- |
+| color | It can be a named theme color or a hex value.                         | string | info    | Yes      |
+| icon  | Icon name, see https://feathericons.com/ (convert name to PascalCase) | string | ''      | Yes      |

--- a/packages/components/src/Tooltip/README.md
+++ b/packages/components/src/Tooltip/README.md
@@ -1,14 +1,14 @@
 Tooltips give helpful hints about actions an end-user can perform. They are designed to be reusable, elegant and unobtrusive. Tooltips are great for UX, so we try to make them as versatile as possible.
 
-## Usage
+### Usage
 
 ```jsx
-<div style={{display: "flex", flexDirection: "column", alignItems: "center"}}>
-  <div style={{position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80}}>
+<div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+  <div style={{ position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80 }}>
     <p>I am a box full of mysteries.</p>
     <Tooltip>I uncover them all.</Tooltip>
   </div>
-  <div style={{position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80}}>
+  <div style={{ position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80 }}>
     <p>I am a box full of mysteries.</p>
     <Tooltip bottom>I can be on bottom instead!</Tooltip>
     <Tooltip left>I can be on left instead!</Tooltip>

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { readableTextColor } from "@operational/utils"
 import { OperationalStyleConstants, Theme } from "@operational/theme"
-import { Css, CssStatic } from "../types"
+import { readableTextColor } from "@operational/utils"
+import { Css } from "../types"
 
 /**
  * Accepting top/left/right/bottom props is a bit redundant, but it makes for a nice casual API:
@@ -50,7 +50,7 @@ const Container = styled("div")(
     theme?: OperationalStyleConstants & {
       deprecated: Theme
     }
-  }): CssStatic => {
+  }) => {
     const backgroundColor = theme.deprecated.colors.black
     return {
       backgroundColor,
@@ -176,6 +176,16 @@ class Tooltip extends React.Component<Props, State> {
 
   containerNode: HTMLElement
 
+  componentDidMount() {
+    const bbRect = this.containerNode.getBoundingClientRect()
+    this.setState(prevState => ({
+      bbTop: bbRect.top,
+      bbBottom: bbRect.bottom,
+      bbLeft: bbRect.left,
+      bbRight: bbRect.right,
+    }))
+  }
+
   render() {
     let position: Position = "top"
 
@@ -206,8 +216,6 @@ class Tooltip extends React.Component<Props, State> {
 
     return (
       <Container
-        className={this.props.className}
-        css={this.props.css}
         position={position}
         innerRef={node => {
           this.containerNode = node
@@ -216,16 +224,6 @@ class Tooltip extends React.Component<Props, State> {
         {this.props.children}
       </Container>
     )
-  }
-
-  componentDidMount() {
-    const bbRect = this.containerNode.getBoundingClientRect()
-    this.setState(prevState => ({
-      bbTop: bbRect.top,
-      bbBottom: bbRect.bottom,
-      bbLeft: bbRect.left,
-      bbRight: bbRect.right,
-    }))
   }
 }
 

--- a/packages/components/src/__tests__/__snapshots__/Breakdown.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Breakdown.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Breakdown Component Should initialize properly 1`] = `
       fill="0.5"
     >
       <span
-        class="css-0"
+        class="css-o9u70j"
       >
         hello
       </span>

--- a/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltip Component Should intialize without problems 1`] = `
 <div
-  class="test css-19croas-tooltip"
+  class="css-19croas-tooltip"
 >
   Hello
 </div>


### PR DESCRIPTION
This PR replaces

```
<Input css={{ width: "100%" }} />
```

with 

```
const FullWidthInput =styled(Input)`
  width: 100%;
`

<FullWidthInput />
```

To fix all internal broken styles from the emotion upgrade (8 locations total).