### PR TITLE
Chip redesign.

### DIFF
--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -1,10 +1,9 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { darken, readableTextColor, expandColor } from "@operational/utils"
-import { OperationalStyleConstants, Theme } from "@operational/theme"
+import { readableTextColor, expandColor } from "@operational/utils"
+import { OperationalStyleConstants } from "@operational/theme"
 import { Icon, IconName } from "../"
-import { isWhite } from "../utils/color"
-import { WithTheme, Css, CssStatic } from "../types"
+import { WithTheme, Css } from "../types"
 
 export interface Props {
   /** Id */

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { darken, readableTextColor } from "@operational/utils"
-import { OperationalStyleConstants, Theme, expandColor } from "@operational/theme"
+import { darken, readableTextColor, expandColor } from "@operational/utils"
+import { OperationalStyleConstants, Theme } from "@operational/theme"
 import { Icon, IconName } from "../"
 import { isWhite } from "../utils/color"
 import { WithTheme, Css, CssStatic } from "../types"
@@ -13,11 +13,17 @@ export interface Props {
 
   css?: Css
   /**
-   * What color of chip would you like? It can be a hex value or a named theme color
-   * @default  The `primary` color of your theme.
+   * What color of chip would you like? It can be a hex value, a named theme color, or a number
+   * @default  0, the first of the default chip colors
    */
 
   color?: string
+  /**
+   * Color index - overridden by `color` prop, if provided
+   * @default 0
+   */
+
+  colorIndex?: number
   /** Handle clicks on the chip's body. This is never triggered when the icon bar is clicked. When an icon is not specified, however, this basically turns into a full element click handler. */
 
   onClick?: () => void
@@ -33,26 +39,19 @@ export interface Props {
   icon?: IconName | React.ReactNode
 }
 
+const colors = ["#ffdfb2", "#a3d0e2", "#c3eac1"]
+
 const Container = styled("div")(
-  ({
-    theme,
-    color,
-    hasChip,
-  }: {
-    theme?: OperationalStyleConstants & {
-      deprecated: Theme
-    }
-    color?: string
-    hasChip: boolean
-  }): {} => {
-    const backgroundColor = expandColor(theme.deprecated, color) || theme.deprecated.colors.info
-    const border = isWhite(backgroundColor) ? `1px solid ${theme.deprecated.colors.lightGray}` : "0"
+  ({ theme, color, colorIndex }: { theme?: OperationalStyleConstants; color?: string; colorIndex?: number }): {} => {
+    const definedColor = expandColor(theme, color)
+    const definedTextColor =
+      definedColor && readableTextColor(definedColor, [theme.color.text.default, theme.color.white])
     return {
-      backgroundColor,
-      border,
+      backgroundColor: definedColor || colors[(colorIndex || 0) % colors.length],
+      fontSize: theme.font.size.small,
       label: "chip",
       position: "relative",
-      height: theme.deprecated.spacing * 1.5,
+      height: theme.space.element,
       display: "inline-flex",
       alignItems: "center",
       boxSizing: "border-box",
@@ -60,8 +59,8 @@ const Container = styled("div")(
       borderRadius: 2,
       cursor: "pointer",
       overflow: "hidden",
-      color: readableTextColor(backgroundColor, ["black", "white"]),
-      margin: `0px ${theme.deprecated.spacing / 2}px 0px 0px`,
+      color: definedTextColor || theme.color.text.default,
+      margin: `0px ${theme.space.small}px 0px 0px`,
     }
   },
 )
@@ -71,7 +70,7 @@ const Content = styled("div")(
     height: "100%",
     display: "flex",
     alignItems: "center",
-    padding: `0px ${theme.deprecated.spacing / 2}px`,
+    padding: `0px ${theme.space.base}px`,
     "&:hover": {
       backgroundColor: "rgba(0, 0, 0, 0.1)",
     },
@@ -79,21 +78,10 @@ const Content = styled("div")(
 )
 
 const Action = styled("div")(
-  ({
-    theme,
-    color,
-  }: {
-    theme?: OperationalStyleConstants & {
-      deprecated: Theme
-    }
-    color?: string
-  }): {} => {
-    const backgroundColor = expandColor(theme.deprecated, color) || theme.deprecated.colors.info
-    const borderColor = isWhite(backgroundColor) ? theme.deprecated.colors.lightGray : "rgba(255, 255, 255, 0.15)"
+  ({ theme }: { theme?: OperationalStyleConstants }): {} => {
     return {
-      borderLeft: `1px solid ${borderColor}`,
-      color: readableTextColor(backgroundColor, ["black", "white"]),
-      width: theme.deprecated.spacing * 1.5,
+      borderLeft: `1px solid ${theme.color.ghost}`,
+      width: theme.space.content,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
@@ -105,11 +93,17 @@ const Action = styled("div")(
   },
 )
 
-const Chip = (props: Props) => (
-  <Container id={props.id} className={props.className} css={props.css} color={props.color} hasChip={!!props.onClick}>
+const Chip: React.SFC<Props> = (props: Props) => (
+  <Container
+    id={props.id}
+    className={props.className}
+    css={props.css}
+    color={props.color}
+    colorIndex={props.colorIndex}
+  >
     <Content onClick={props.onClick}>{props.children}</Content>
     {props.onIconClick && (
-      <Action color={props.color} onClick={props.onIconClick}>
+      <Action onClick={props.onIconClick}>
         {typeof props.icon === "string" ? <Icon name={props.icon as IconName} size={12} /> : props.icon}
       </Action>
     )}

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -8,45 +8,33 @@ import { WithTheme, Css } from "../types"
 export interface Props {
   /** Id */
   id?: string
+
   /** `css` prop as expected in a glamorous component */
-
   css?: Css
-  /**
-   * What color of chip would you like? It can be a hex value, a named theme color, or a number
-   * @default  0, the first of the default chip colors
-   */
 
+  /** Chip color, provided as a hex value or a named theme color */
   color?: string
-  /**
-   * Color index - overridden by `color` prop, if provided
-   * @default 0
-   */
 
-  colorIndex?: number
   /** Handle clicks on the chip's body. This is never triggered when the icon bar is clicked. When an icon is not specified, however, this basically turns into a full element click handler. */
-
   onClick?: () => void
+
   /** Handle clicks on the chip's icon area on the right. */
-
   onIconClick?: () => void
+
   /** Class name */
-
   className?: string
-  children: React.ReactNode
-  /** The name of the icon shown in the right icon bar area of the chip. A typical use here would be the `X` icon for closing the chip. Note that this icon is only displayed if there is an `onIconClick` prop present.  */
 
+  children: React.ReactNode
+
+  /** The name of the icon shown in the right icon bar area of the chip. A typical use here would be the `X` icon for closing the chip. Note that this icon is only displayed if there is an `onIconClick` prop present.  */
   icon?: IconName | React.ReactNode
 }
 
-const colors = ["#ffdfb2", "#a3d0e2", "#c3eac1"]
-
 const Container = styled("div")(
-  ({ theme, color, colorIndex }: { theme?: OperationalStyleConstants; color?: string; colorIndex?: number }): {} => {
-    const definedColor = expandColor(theme, color)
-    const definedTextColor =
-      definedColor && readableTextColor(definedColor, [theme.color.text.default, theme.color.white])
+  ({ theme, color }: { theme?: OperationalStyleConstants; color?: string }): {} => {
+    const backgroundColor = expandColor(theme, color) || theme.color.primary
     return {
-      backgroundColor: definedColor || colors[(colorIndex || 0) % colors.length],
+      backgroundColor,
       fontSize: theme.font.size.small,
       label: "chip",
       position: "relative",
@@ -58,7 +46,7 @@ const Container = styled("div")(
       borderRadius: 2,
       cursor: "pointer",
       overflow: "hidden",
-      color: definedTextColor || theme.color.text.default,
+      color: readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white]),
       margin: `0px ${theme.space.small}px 0px 0px`,
     }
   },
@@ -93,13 +81,7 @@ const Action = styled("div")(
 )
 
 const Chip: React.SFC<Props> = (props: Props) => (
-  <Container
-    id={props.id}
-    className={props.className}
-    css={props.css}
-    color={props.color}
-    colorIndex={props.colorIndex}
-  >
+  <Container id={props.id} className={props.className} css={props.css} color={props.color}>
     <Content onClick={props.onClick}>{props.children}</Content>
     {props.onIconClick && (
       <Action onClick={props.onIconClick}>

--- a/packages/components/src/Chip/README.md
+++ b/packages/components/src/Chip/README.md
@@ -6,7 +6,30 @@ along with a symbol for the button that will be displayed if click behavior is d
 
 ```jsx
 <div style={{ display: "flex" }}>
-  <Chip color="info">Hello!</Chip>
-  <Chip color="success" icon="X" onIconClick={() => window.alert("Buonasera")} onClick={() => window.alert("Good evening!")}>Ciao!</Chip>
+  <Chip>Hello!</Chip>
+  <Chip
+    colorIndex="1"
+    icon="X"
+    onIconClick={() => window.alert("Buonasera")}
+    onClick={() => window.alert("Good evening!")}
+  >
+    Ciao!
+  </Chip>
+  <Chip
+    colorIndex="2"
+    icon="X"
+    onIconClick={() => window.alert("Buonasera")}
+    onClick={() => window.alert("Good evening!")}
+  >
+    Ciao!
+  </Chip>
+  <Chip
+    color="primary"
+    icon="X"
+    onIconClick={() => window.alert("Buonasera")}
+    onClick={() => window.alert("Good evening!")}
+  >
+    Ciao!
+  </Chip>
 </div>
 ```

--- a/packages/components/src/Chip/README.md
+++ b/packages/components/src/Chip/README.md
@@ -6,9 +6,17 @@ along with a symbol for the button that will be displayed if click behavior is d
 
 ```jsx
 <div style={{ display: "flex" }}>
-  <Chip>Hello!</Chip>
+  <Chip>Default color</Chip>
   <Chip
-    colorIndex="1"
+    color="basic"
+    icon="X"
+    onIconClick={() => window.alert("Buonasera")}
+    onClick={() => window.alert("Good evening!")}
+  >
+    With icon
+  </Chip>
+  <Chip
+    color="success"
     icon="X"
     onIconClick={() => window.alert("Buonasera")}
     onClick={() => window.alert("Good evening!")}
@@ -16,20 +24,12 @@ along with a symbol for the button that will be displayed if click behavior is d
     Ciao!
   </Chip>
   <Chip
-    colorIndex="2"
+    color="error"
     icon="X"
     onIconClick={() => window.alert("Buonasera")}
     onClick={() => window.alert("Good evening!")}
   >
-    Ciao!
-  </Chip>
-  <Chip
-    color="primary"
-    icon="X"
-    onIconClick={() => window.alert("Buonasera")}
-    onClick={() => window.alert("Good evening!")}
-  >
-    Ciao!
+    Hello!
   </Chip>
 </div>
 ```

--- a/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`Chip Should render 1`] = `
 <div
-  class="css-13p12am-chip"
+  class="css-1o8ba35-chip"
 >
   <div
-    class="css-1xopt49"
+    class="css-1k6isyt"
   >
     Hi
   </div>

--- a/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Chip Should render 1`] = `
 <div
-  class="css-1o8ba35-chip"
+  class="css-2ie7h0-chip"
 >
   <div
     class="css-1k6isyt"

--- a/packages/website/src/Sections/Components/Chips.tsx
+++ b/packages/website/src/Sections/Components/Chips.tsx
@@ -11,13 +11,13 @@ export const snippetUrl = `${constants.snippetBaseUrl}/Components/Chips.tsx`
 export const Component = () => (
   <>
     <Chip icon="X" onIconClick={() => {}}>
-      Simple
+      Default color
     </Chip>
-    <Chip icon="X" color="white" onIconClick={() => {}}>
-      Lighter
+    <Chip icon="X" colorIndex="1" onIconClick={() => {}}>
+      2nd default color
     </Chip>
     <Chip icon="X" color="#454545" onIconClick={() => {}}>
-      Darker
+      Custom color
     </Chip>
   </>
 )


### PR DESCRIPTION
- [x] `props.color` can be used to assign a color directly, using a name of a color defined in the constants (e.g. `primary`), or a hex string.
- [x] General style improvements have been made, including removing all references to the deprecated theme. 
- [x] Update website