### PR TITLE
Paginator redesign.

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -56,7 +56,7 @@ const containerStyles: Interpolation<Props> = ({
   const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color)
   return {
     backgroundColor,
-    lineHeight: `${condensed ? 26 : 34}px`,
+    lineHeight: `${condensed ? 28 : 36}px`,
     label: "button",
     fontSize: theme.font.size.small,
     fontFamily: theme.font.family.main,

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -65,7 +65,7 @@ const containerStyles: Interpolation<Props> = ({
     borderRadius: theme.borderRadius,
     border: 0,
     boxShadow: isWhite(backgroundColor) && `0 0 0 1px ${theme.color.border.disabled} inset`,
-    cursor: disabled ? "auto" : "pointer",
+    cursor: disabled ? "not-allowed" : "pointer",
     opacity: disabled ? 0.6 : 1.0,
     outline: "none",
     position: "relative",

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -79,10 +79,6 @@ const containerStyles: Interpolation<Props> = ({
           ":hover": {
             backgroundColor: darken(backgroundColor, 5),
           },
-          ":focus": {
-            outline: 0,
-            boxShadow: `0 0 0 3px ${lighten(backgroundColor, 35)}`,
-          },
         }
       : {}),
     marginRight: theme.space.small,

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -64,7 +64,7 @@ const containerStyles: Interpolation<Props> = ({
     padding: `0 ${condensed ? theme.space.small : theme.space.content}px`,
     borderRadius: theme.borderRadius,
     border: 0,
-    boxShadow: isWhite(backgroundColor) && `0 0 0 1px ${theme.color.border.default} inset`,
+    boxShadow: isWhite(backgroundColor) && `0 0 0 1px ${theme.color.border.disabled} inset`,
     cursor: disabled ? "auto" : "pointer",
     opacity: disabled ? 0.6 : 1.0,
     outline: "none",

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -74,30 +74,40 @@ const PaginatorControl = ({ children, itemCount, itemsPerPage, page, onChange, t
     onChange && onChange(Math.ceil(itemCount / itemsPerPage))
   }
 
-  let handler
-
   switch (type) {
     case "previous":
-      handler = handlePrevious
-      break
+      return (
+        <NavigationButton condensed onClick={handlePrevious}>
+          {children}
+        </NavigationButton>
+      )
 
     case "first":
-      handler = handleFirst
-      break
+      return (
+        <NavigationButton condensed onClick={handleFirst}>
+          {children}
+        </NavigationButton>
+      )
 
     case "next":
-      handler = handleNext
-      break
+      return (
+        <NavigationButton condensed onClick={handleNext}>
+          {children}
+        </NavigationButton>
+      )
+
+    case "last":
+      return (
+        <NavigationButton condensed onClick={handleLast}>
+          {children}
+        </NavigationButton>
+      )
 
     default:
-      handler = handleLast
+      throw new Error(
+        "No handler specified for NavigationButton in Paginator component\nPlease refer to the docs: http://operational-ui.js.org/docs/#paginator",
+      )
   }
-
-  return (
-    <NavigationButton condensed onClick={handler}>
-      {children}
-    </NavigationButton>
-  )
 }
 
 const getRange = ({ page, itemCount, itemsPerPage }: Props) => {

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -49,10 +49,12 @@ interface ControlProps {
 const NavigationButton = styled(Button)(({ theme }: { theme?: OperationalStyleConstants }) => ({
   width: 56,
   marginRight: 3,
-  padding: `0 ${theme.space.base}px`,
+  padding: 0,
   "& svg": {
     verticalAlign: "middle",
-    margin: "0 0 0 3px",
+  },
+  "& span": {
+    padding: "0 3px",
   },
 }))
 
@@ -106,7 +108,8 @@ const Paginator: React.SFC<Props> = props => {
         first
       </PaginatorControl>
       <PaginatorControl type="previous" {...controlProps} isDisabled={isFirstDisabled}>
-        <Icon.ChevronsLeft size="11" /> <span>prev</span>
+        <Icon.ChevronsLeft size="11" />
+        <span>prev</span>
       </PaginatorControl>
       <PaginatorSpan key={props.page}>
         <span>{getRange({ page: props.page, itemCount: props.itemCount, itemsPerPage: props.itemsPerPage })}</span> of{" "}

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -3,25 +3,20 @@ import * as Icon from "react-feather"
 import styled from "react-emotion"
 import { OperationalStyleConstants } from "@operational/theme"
 import { Css, CssStatic } from "../types"
-import { Button } from "../"
+import Button from "../Button/Button"
 
 export interface Props {
   id?: string
   /** `css` prop as expected in a glamorous component */
-
   css?: Css
   className?: string
   /** Function to be executed after changing page */
-
   onChange?: (page: number) => void
   /** Index of the current selected page */
-
   page?: number
   /** Total number of items */
-
   itemCount: number
   /** Number of items per page */
-
   itemsPerPage: number
 }
 

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -7,29 +7,25 @@ import { Button } from "../"
 
 export interface Props {
   id?: string
-
   /** `css` prop as expected in a glamorous component */
+
   css?: Css
-
   className?: string
-
-  /** Disable the component */
-  disabled?: boolean
-
   /** Function to be executed after changing page */
+
   onChange?: (page: number) => void
-
   /** Index of the current selected page */
+
   page?: number
-
   /** Total number of items */
-  itemCount: number
 
+  itemCount: number
   /** Number of items per page */
+
   itemsPerPage: number
 }
 
-const ItemSummary = styled("div")(
+const PaginatorSpan = styled("div")(
   ({ theme }: { theme?: OperationalStyleConstants }): CssStatic => ({
     fontFamily: theme.font.family.main,
     fontSize: theme.font.size.small,
@@ -47,6 +43,7 @@ interface ControlProps {
   children: any
   onChange?: (page: number) => void
   page: number
+  isDisabled: boolean
   itemCount: number
   itemsPerPage: number
   type: "first" | "previous" | "next" | "last"
@@ -54,61 +51,27 @@ interface ControlProps {
 
 const NavigationButton = styled(Button)(({ theme }: { theme?: OperationalStyleConstants }) => ({
   width: 56,
-  marginRight: 2,
+  marginRight: 3,
   padding: `0 ${theme.space.base}px`,
 }))
 
-const PaginatorControl = ({ children, itemCount, itemsPerPage, page, onChange, type }: ControlProps) => {
-  const handleFirst = (): void => {
-    onChange && onChange(1)
+const PaginatorControl = ({ children, itemCount, itemsPerPage, page, onChange, type, isDisabled }: ControlProps) => {
+  const pageChanges = {
+    first: 1,
+    previous: page - 1,
+    next: page + 1,
+    last: Math.ceil(itemCount / itemsPerPage),
   }
 
-  const handlePrevious = (): void => {
-    onChange && onChange(page - 1)
+  const clickHandler = (): void => {
+    onChange && onChange(pageChanges[type])
   }
 
-  const handleNext = (): void => {
-    onChange && onChange(page + 1)
-  }
-
-  const handleLast = (): void => {
-    onChange && onChange(Math.ceil(itemCount / itemsPerPage))
-  }
-
-  switch (type) {
-    case "previous":
-      return (
-        <NavigationButton condensed onClick={handlePrevious}>
-          {children}
-        </NavigationButton>
-      )
-
-    case "first":
-      return (
-        <NavigationButton condensed onClick={handleFirst}>
-          {children}
-        </NavigationButton>
-      )
-
-    case "next":
-      return (
-        <NavigationButton condensed onClick={handleNext}>
-          {children}
-        </NavigationButton>
-      )
-
-    case "last":
-      return (
-        <NavigationButton condensed onClick={handleLast}>
-          {children}
-        </NavigationButton>
-      )
-
-    default:
-      throw new Error(
-        "No handler specified for NavigationButton in Paginator component\nPlease refer to the docs: http://operational-ui.js.org/docs/#paginator",
-      )
-  }
+  return (
+    <NavigationButton disabled={isDisabled} condensed onClick={clickHandler}>
+      {children}
+    </NavigationButton>
+  )
 }
 
 const getRange = ({ page, itemCount, itemsPerPage }: Props) => {
@@ -134,34 +97,26 @@ const Paginator: React.SFC<Props> = props => {
     page: props.page,
     onChange: props.onChange,
   }
-  const shouldDisplayFirst = props.page !== 1
-  const shouldDisplayLast = props.itemsPerPage * props.page < props.itemCount
+  const isFirstDisabled = props.page === 1
+  const isLastDisabled = props.itemsPerPage * props.page >= props.itemCount
   return (
     <Container id={props.id} css={props.css} className={props.className}>
-      {shouldDisplayFirst && (
-        <PaginatorControl type="first" {...controlProps}>
-          first
-        </PaginatorControl>
-      )}
-      {shouldDisplayFirst && (
-        <PaginatorControl type="previous" {...controlProps}>
-          <Icon.ChevronsLeft size="11" /> prev
-        </PaginatorControl>
-      )}
-      <ItemSummary key={props.page}>
+      <PaginatorControl type="first" {...controlProps} isDisabled={isFirstDisabled}>
+        first
+      </PaginatorControl>
+      <PaginatorControl type="previous" {...controlProps} isDisabled={isFirstDisabled}>
+        <Icon.ChevronsLeft size="11" /> prev
+      </PaginatorControl>
+      <PaginatorSpan key={props.page}>
         <span>{getRange({ page: props.page, itemCount: props.itemCount, itemsPerPage: props.itemsPerPage })}</span> of{" "}
         {props.itemCount}
-      </ItemSummary>
-      {shouldDisplayLast && (
-        <PaginatorControl type="next" {...controlProps}>
-          next<Icon.ChevronsRight size="11" />
-        </PaginatorControl>
-      )}
-      {shouldDisplayLast && (
-        <PaginatorControl type="last" {...controlProps}>
-          last
-        </PaginatorControl>
-      )}
+      </PaginatorSpan>
+      <PaginatorControl type="next" {...controlProps} isDisabled={isLastDisabled}>
+        next<Icon.ChevronsRight size="11" />
+      </PaginatorControl>
+      <PaginatorControl type="last" {...controlProps} isDisabled={isLastDisabled}>
+        last
+      </PaginatorControl>
     </Container>
   )
 }

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -27,6 +27,8 @@ const PaginatorSpan = styled("div")(
     padding: `0 ${theme.space.content}px`,
     display: "inline-flex",
     color: theme.color.text.lighter,
+    minWidth: 120,
+    justifyContent: "center",
     "& span": {
       color: theme.color.text.dark,
       paddingRight: 3,

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -48,6 +48,10 @@ const NavigationButton = styled(Button)(({ theme }: { theme?: OperationalStyleCo
   width: 56,
   marginRight: 3,
   padding: `0 ${theme.space.base}px`,
+  "& svg": {
+    verticalAlign: "middle",
+    margin: "0 0 0 3px",
+  },
 }))
 
 const PaginatorControl = ({ children, itemCount, itemsPerPage, page, onChange, type, isDisabled }: ControlProps) => {
@@ -100,14 +104,15 @@ const Paginator: React.SFC<Props> = props => {
         first
       </PaginatorControl>
       <PaginatorControl type="previous" {...controlProps} isDisabled={isFirstDisabled}>
-        <Icon.ChevronsLeft size="11" /> prev
+        <Icon.ChevronsLeft size="11" /> <span>prev</span>
       </PaginatorControl>
       <PaginatorSpan key={props.page}>
         <span>{getRange({ page: props.page, itemCount: props.itemCount, itemsPerPage: props.itemsPerPage })}</span> of{" "}
         {props.itemCount}
       </PaginatorSpan>
       <PaginatorControl type="next" {...controlProps} isDisabled={isLastDisabled}>
-        next<Icon.ChevronsRight size="11" />
+        <span>next</span>
+        <Icon.ChevronsRight size="11" />
       </PaginatorControl>
       <PaginatorControl type="last" {...controlProps} isDisabled={isLastDisabled}>
         last

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -7,28 +7,29 @@ import { Button } from "../"
 
 export interface Props {
   id?: string
+
   /** `css` prop as expected in a glamorous component */
-
   css?: Css
+
   className?: string
+
   /** Disable the component */
-
   disabled?: boolean
+
   /** Function to be executed after changing page */
-
   onChange?: (page: number) => void
+
   /** Index of the current selected page */
-
   page?: number
+
   /** Total number of items */
-
   itemCount: number
-  /** Number of items per page */
 
+  /** Number of items per page */
   itemsPerPage: number
 }
 
-const PaginatorSpan = styled("div")(
+const ItemSummary = styled("div")(
   ({ theme }: { theme?: OperationalStyleConstants }): CssStatic => ({
     fontFamily: theme.font.family.main,
     fontSize: theme.font.size.small,
@@ -147,10 +148,10 @@ const Paginator: React.SFC<Props> = props => {
           <Icon.ChevronsLeft size="11" /> prev
         </PaginatorControl>
       )}
-      <PaginatorSpan key={props.page}>
+      <ItemSummary key={props.page}>
         <span>{getRange({ page: props.page, itemCount: props.itemCount, itemsPerPage: props.itemsPerPage })}</span> of{" "}
         {props.itemCount}
-      </PaginatorSpan>
+      </ItemSummary>
       {shouldDisplayLast && (
         <PaginatorControl type="next" {...controlProps}>
           next<Icon.ChevronsRight size="11" />

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -17,9 +17,7 @@ export interface Props {
   /** Function to be executed after changing page */
 
   onChange?: (page: number) => void
-  /** Index of the current selected page
-   * @default 1
-   */
+  /** Index of the current selected page */
 
   page?: number
   /** Total number of items */
@@ -118,17 +116,17 @@ const Container = styled("div")({
   },
 })
 
-const Paginator = ({ itemCount, page = 1, itemsPerPage, onChange, id, css, className }: Props) => {
+const Paginator: React.SFC<Props> = props => {
   const controlProps = {
-    itemCount,
-    itemsPerPage,
-    page,
-    onChange,
+    itemCount: props.itemCount,
+    itemsPerPage: props.itemsPerPage,
+    page: props.page,
+    onChange: props.onChange,
   }
-  const displayFirst = page !== 1
-  const displayLast = itemsPerPage * page < itemCount
+  const displayFirst = props.page !== 1
+  const displayLast = props.itemsPerPage * props.page < props.itemCount
   return (
-    <Container id={id} css={css} className={className}>
+    <Container id={props.id} css={props.css} className={props.className}>
       {displayFirst && (
         <PaginatorControl type="first" {...controlProps}>
           first
@@ -139,8 +137,9 @@ const Paginator = ({ itemCount, page = 1, itemsPerPage, onChange, id, css, class
           <Icon.ChevronsLeft size="11" /> prev
         </PaginatorControl>
       )}
-      <PaginatorSpan key={page}>
-        <span>{getRange({ page, itemCount, itemsPerPage })}</span> of {itemCount}
+      <PaginatorSpan key={props.page}>
+        <span>{getRange({ page: props.page, itemCount: props.itemCount, itemsPerPage: props.itemsPerPage })}</span> of{" "}
+        {props.itemCount}
       </PaginatorSpan>
       {displayLast && (
         <PaginatorControl type="next" {...controlProps}>
@@ -154,6 +153,10 @@ const Paginator = ({ itemCount, page = 1, itemsPerPage, onChange, id, css, class
       )}
     </Container>
   )
+}
+
+Paginator.defaultProps = {
+  page: 1,
 }
 
 export default Paginator

--- a/packages/components/src/Paginator/Paginator.tsx
+++ b/packages/components/src/Paginator/Paginator.tsx
@@ -52,8 +52,8 @@ interface ControlProps {
 }
 
 const NavigationButton = styled(Button)(({ theme }: { theme?: OperationalStyleConstants }) => ({
-  width: "56px",
-  marginRight: "2px",
+  width: 56,
+  marginRight: 2,
   padding: `0 ${theme.space.base}px`,
 }))
 
@@ -123,16 +123,16 @@ const Paginator: React.SFC<Props> = props => {
     page: props.page,
     onChange: props.onChange,
   }
-  const displayFirst = props.page !== 1
-  const displayLast = props.itemsPerPage * props.page < props.itemCount
+  const shouldDisplayFirst = props.page !== 1
+  const shouldDisplayLast = props.itemsPerPage * props.page < props.itemCount
   return (
     <Container id={props.id} css={props.css} className={props.className}>
-      {displayFirst && (
+      {shouldDisplayFirst && (
         <PaginatorControl type="first" {...controlProps}>
           first
         </PaginatorControl>
       )}
-      {displayFirst && (
+      {shouldDisplayFirst && (
         <PaginatorControl type="previous" {...controlProps}>
           <Icon.ChevronsLeft size="11" /> prev
         </PaginatorControl>
@@ -141,12 +141,12 @@ const Paginator: React.SFC<Props> = props => {
         <span>{getRange({ page: props.page, itemCount: props.itemCount, itemsPerPage: props.itemsPerPage })}</span> of{" "}
         {props.itemCount}
       </PaginatorSpan>
-      {displayLast && (
+      {shouldDisplayLast && (
         <PaginatorControl type="next" {...controlProps}>
           next<Icon.ChevronsRight size="11" />
         </PaginatorControl>
       )}
-      {displayLast && (
+      {shouldDisplayLast && (
         <PaginatorControl type="last" {...controlProps}>
           last
         </PaginatorControl>

--- a/packages/components/src/Paginator/README.md
+++ b/packages/components/src/Paginator/README.md
@@ -1,4 +1,4 @@
-Pagination is a predictable and expressive way to handle datasets that don't fit in a single view.  They are a straightforward alternative to infinite scrolling and lazy-loading interface elements, which take a long time to get cross-browser effective and accessible. This page describes how to use Operational UI's paginators.
+Pagination is a predictable and expressive way to handle datasets that don't fit in a single view. They are a straightforward alternative to infinite scrolling and lazy-loading interface elements, which take a long time to get cross-browser effective and accessible. This page describes how to use Operational UI's paginators.
 
 ### Usage
 
@@ -7,7 +7,7 @@ class ComponentWithPaginator extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      page: 1
+      page: 1,
     }
   }
 
@@ -16,9 +16,11 @@ class ComponentWithPaginator extends React.Component {
   }
 
   render() {
-    return <Paginator pageCount={30} page={this.state.page} onChange={page => this.handleChange(page)} />
+    return (
+      <Paginator itemCount={258} itemsPerPage={50} page={this.state.page} onChange={page => this.handleChange(page)} />
+    )
   }
 }
 
-<ComponentWithPaginator />
+;<ComponentWithPaginator />
 ```

--- a/packages/components/src/Paginator/README.md
+++ b/packages/components/src/Paginator/README.md
@@ -7,7 +7,7 @@ class ComponentWithPaginator extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      page: 1,
+      page: undefined,
     }
   }
 

--- a/packages/components/src/Paginator/README.md
+++ b/packages/components/src/Paginator/README.md
@@ -6,9 +6,7 @@ Pagination is a predictable and expressive way to handle datasets that don't fit
 class ComponentWithPaginator extends React.Component {
   constructor(props) {
     super(props)
-    this.state = {
-      page: undefined,
-    }
+    this.state = {}
   }
 
   handleChange(page) {

--- a/packages/components/src/__tests__/Paginator.test.tsx
+++ b/packages/components/src/__tests__/Paginator.test.tsx
@@ -7,6 +7,6 @@ const Paginator = wrapDefaultTheme(ThemelessPaginator)
 
 describe("Paginator Component", () => {
   it("Should initialize properly", () => {
-    expect(render(<Paginator pageCount={10} />)).toMatchSnapshot()
+    expect(render(<Paginator page={3} itemCount={258} itemsPerPage={50} />)).toMatchSnapshot()
   })
 })

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-15huq32-button"
+  class="css-1par3jt-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-1yqoqjq-button"
+  class="css-15huq32-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-kn2km2-button"
+  class="css-1yqoqjq-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-15huq32-button"
+    class="css-1par3jt-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-kn2km2-button"
+    class="css-1yqoqjq-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-1yqoqjq-button"
+    class="css-15huq32-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-15jfuhv-button"
+    class="css-fjjpc-button"
   >
     first
   </button>
   <button
-    class="css-15jfuhv-button"
+    class="css-fjjpc-button"
   >
     <svg
       fill="none"
@@ -41,7 +41,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-15jfuhv-button"
+    class="css-fjjpc-button"
   >
     next
     <svg
@@ -64,7 +64,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-15jfuhv-button"
+    class="css-fjjpc-button"
   >
     last
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-cfniik-button"
+    class="css-12atfri-button"
   >
     first
   </button>
   <button
-    class="css-cfniik-button"
+    class="css-12atfri-button"
   >
     <svg
       fill="none"
@@ -44,7 +44,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-cfniik-button"
+    class="css-12atfri-button"
   >
     <span>
       next
@@ -69,7 +69,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-cfniik-button"
+    class="css-12atfri-button"
   >
     last
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-fjjpc-button"
+    class="css-cfniik-button"
   >
     first
   </button>
   <button
-    class="css-fjjpc-button"
+    class="css-cfniik-button"
   >
     <svg
       fill="none"
@@ -30,7 +30,10 @@ exports[`Paginator Component Should initialize properly 1`] = `
         points="18 17 13 12 18 7"
       />
     </svg>
-     prev
+     
+    <span>
+      prev
+    </span>
   </button>
   <div
     class="css-3ts6iq"
@@ -41,9 +44,11 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-fjjpc-button"
+    class="css-cfniik-button"
   >
-    next
+    <span>
+      next
+    </span>
     <svg
       fill="none"
       height="11"
@@ -64,7 +69,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-fjjpc-button"
+    class="css-cfniik-button"
   >
     last
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-hyh68k-button"
+    class="css-1mxdzwt-button"
   >
     first
   </button>
   <button
-    class="css-hyh68k-button"
+    class="css-1mxdzwt-button"
   >
     <svg
       fill="none"
@@ -44,7 +44,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-hyh68k-button"
+    class="css-1mxdzwt-button"
   >
     <span>
       next
@@ -69,7 +69,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-hyh68k-button"
+    class="css-1mxdzwt-button"
   >
     last
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -4,8 +4,13 @@ exports[`Paginator Component Should initialize properly 1`] = `
 <div
   class="css-1pxqklq-paginator"
 >
-  <div
-    class="css-1yc9hmn"
+  <button
+    class="css-15jfuhv-button"
+  >
+    first
+  </button>
+  <button
+    class="css-15jfuhv-button"
   >
     <svg
       fill="none"
@@ -25,73 +30,20 @@ exports[`Paginator Component Should initialize properly 1`] = `
         points="18 17 13 12 18 7"
       />
     </svg>
-  </div>
+     prev
+  </button>
   <div
-    class="css-1yc9hmn"
+    class="css-3ts6iq"
   >
-    <svg
-      fill="none"
-      height="11"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      viewbox="0 0 24 24"
-      width="11"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <polyline
-        points="15 18 9 12 15 6"
-      />
-    </svg>
+    <span>
+      101-150
+    </span>
+     of 258
   </div>
-  <div
-    class="css-1x7rcf2"
+  <button
+    class="css-15jfuhv-button"
   >
-    1
-  </div>
-  <div
-    class="css-1yc9hmn"
-  >
-    2
-  </div>
-  <div
-    class="css-1yc9hmn"
-  >
-    3
-  </div>
-  <div
-    class="css-1yc9hmn"
-  >
-    ...
-  </div>
-  <div
-    class="css-1yc9hmn"
-  >
-    10
-  </div>
-  <div
-    class="css-1yc9hmn"
-  >
-    <svg
-      fill="none"
-      height="11"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      viewbox="0 0 24 24"
-      width="11"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <polyline
-        points="9 18 15 12 9 6"
-      />
-    </svg>
-  </div>
-  <div
-    class="css-1yc9hmn"
-  >
+    next
     <svg
       fill="none"
       height="11"
@@ -110,6 +62,11 @@ exports[`Paginator Component Should initialize properly 1`] = `
         points="6 17 11 12 6 7"
       />
     </svg>
-  </div>
+  </button>
+  <button
+    class="css-15jfuhv-button"
+  >
+    last
+  </button>
 </div>
 `;

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </span>
   </button>
   <div
-    class="css-3ts6iq"
+    class="css-f4o2iy"
   >
     <span>
       101-150

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-1mxdzwt-button"
+    class="css-1yysifb-button"
   >
     first
   </button>
   <button
-    class="css-1mxdzwt-button"
+    class="css-1yysifb-button"
   >
     <svg
       fill="none"
@@ -30,7 +30,6 @@ exports[`Paginator Component Should initialize properly 1`] = `
         points="18 17 13 12 18 7"
       />
     </svg>
-     
     <span>
       prev
     </span>
@@ -44,7 +43,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-1mxdzwt-button"
+    class="css-1yysifb-button"
   >
     <span>
       next
@@ -69,7 +68,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-1mxdzwt-button"
+    class="css-1yysifb-button"
   >
     last
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-12atfri-button"
+    class="css-hyh68k-button"
   >
     first
   </button>
   <button
-    class="css-12atfri-button"
+    class="css-hyh68k-button"
   >
     <svg
       fill="none"
@@ -44,7 +44,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-12atfri-button"
+    class="css-hyh68k-button"
   >
     <span>
       next
@@ -69,7 +69,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-12atfri-button"
+    class="css-hyh68k-button"
   >
     last
   </button>

--- a/packages/website/src/Sections/Components/Paginators.tsx
+++ b/packages/website/src/Sections/Components/Paginators.tsx
@@ -8,8 +8,27 @@ export const docsUrl = `${constants.docsBaseUrl}/#paginator`
 
 export const snippetUrl = `${constants.snippetBaseUrl}/Components/Paginators.tsx`
 
-export const Component = () => (
-  <>
-    <Paginator page={2} pageCount={10} />
-  </>
-)
+export interface State {
+  page: number
+}
+
+export class Component extends React.Component<{}, State> {
+  state = {
+    page: 2,
+  }
+
+  render() {
+    return (
+      <>
+        <Paginator
+          page={this.state.page}
+          itemCount={345}
+          itemsPerPage={100}
+          onChange={(page: number) => {
+            this.setState(prevState => ({ page }))
+          }}
+        />
+      </>
+    )
+  }
+}

--- a/packages/website/src/Sections/Components/Paginators.tsx
+++ b/packages/website/src/Sections/Components/Paginators.tsx
@@ -19,16 +19,14 @@ export class Component extends React.Component<{}, State> {
 
   render() {
     return (
-      <>
-        <Paginator
-          page={this.state.page}
-          itemCount={345}
-          itemsPerPage={100}
-          onChange={(page: number) => {
-            this.setState(prevState => ({ page }))
-          }}
-        />
-      </>
+      <Paginator
+        page={this.state.page}
+        itemCount={345}
+        itemsPerPage={100}
+        onChange={(page: number) => {
+          this.setState({ page })
+        }}
+      />
     )
   }
 }

--- a/packages/website/src/Sections/Components/index.ts
+++ b/packages/website/src/Sections/Components/index.ts
@@ -42,6 +42,7 @@ export default [
   messages,
   modals,
   pages,
+  paginators,
   progress,
   records,
   selects,


### PR DESCRIPTION
- Navigation through buttons with `first`, `prev`, `next` and `last` labels rather than clickable icons.
- Navigation buttons only displayed if they will actually change the items displayed (i.e. if items 1 - 50 are being displayed, the `first` and `prev` will not be rendered)
- Displays range of item numbers that are being displayed, rather than page numbers