### PR TITLE
Fix datepicker input ref propagation

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.styles.ts
+++ b/packages/components/src/DatePicker/DatePicker.styles.ts
@@ -170,7 +170,7 @@ export const Input = styled("input")(
     cursor: "pointer",
     border: "1px solid",
     borderColor: "rgb(208, 217, 229)",
-    width: 200,
+    width: "100%",
     position: "relative",
     "&:focus": mixins.inputFocus({
       theme,

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -143,7 +143,6 @@ class DatePicker extends React.Component<Props, State> {
     const { onChange, placeholder, start, end, label, id, css, className } = this.props
     const { isExpanded, month, year } = this.state
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
-    const FullWidthInput = styled(Input)({ width: "100%" })
 
     const datePickerWithoutLabel = (
       <Container
@@ -167,11 +166,11 @@ class DatePicker extends React.Component<Props, State> {
             <Icon name="X" size={14} />
           </Toggle>
         )}
-        <FullWidthInput
+        <Input
           isExpanded={this.state.isExpanded}
           id={domId}
           readOnly
-          innerRef={node => {
+          innerRef={(node: HTMLElement) => {
             this.inputNode = node
           }}
           value={[start, end].filter(s => !!s).join(" - ")}


### PR DESCRIPTION
Currently, `DatePicker`'s popup doesn't open on master because of an error with `innerRef` propagation. This PR fixes this issue.