### PR TITLE
Enhance sidenav

### DIFF
--- a/packages/components/src/Layout/Layout.tsx
+++ b/packages/components/src/Layout/Layout.tsx
@@ -19,9 +19,6 @@ const Content = styled("div")(
     display: "grid",
     overflow: "auto",
   },
-  ({ theme }: { theme?: OperationalStyleConstants }) => ({
-    gridTemplateColumns: `${theme.sidebarWidth}px auto`,
-  }),
 )
 
 const Main = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({

--- a/packages/components/src/Layout/README.md
+++ b/packages/components/src/Layout/README.md
@@ -48,3 +48,50 @@ const sidebar = (
   />
 </div>
 ```
+
+### Loading Data
+
+```jsx
+const sidebar = (
+  <Sidenav>
+    <SidenavHeader condensed icon="Home" label="Project Home" />
+    <SidenavHeader label="The Prize" active>
+      <SidenavItem label="The First Prize" icon="Settings" />
+      <SidenavItem label="The Second Prize" icon="Settings" />
+      <SidenavItem label="The Third Prize" icon="Settings" />
+    </SidenavHeader>
+    <SidenavHeader label="Let It Snow">
+      <SidenavItem label="The First Prize" icon="Settings" />
+      <SidenavItem label="The Second Prize" icon="Settings" />
+      <SidenavItem label="The Third Prize" icon="Settings" />
+    </SidenavHeader>
+  </Sidenav>
+)
+;<div style={{ height: 300 }}>
+  <Layout
+    loading
+    sidenav={sidebar}
+    header={
+      <HeaderBar
+        logo={<ContiamoLogo />}
+        main={<Select naked options={[{ value: "Contiamo" }]} value="Contiamo" placeholder="Select Project..." />}
+        end={<Avatar name="Tejas Kumar" />}
+      />
+    }
+    main={
+      <Page
+        title="Page Title"
+        actions={
+          <Button condensed color="ghost">
+            Help
+          </Button>
+        }
+      >
+        {Array(10)
+          .fill("Hello!!!!")
+          .map((value, i) => <Card key={i}>{value}</Card>)}
+      </Page>
+    }
+  />
+</div>
+```

--- a/packages/components/src/Layout/README.md
+++ b/packages/components/src/Layout/README.md
@@ -4,78 +4,25 @@ This component lays out an opinionated application frame with side navigation, a
 
 ```jsx
 const sidebar = (
-  <Sidebar expanded>
-    <SidebarHeader label="Links">
-      <SidebarItem
-        onClick={() => {
-          window.alert("Hello!")
-        }}
-      >
-        Link 1
-      </SidebarItem>
-      <SidebarItem>Link 2</SidebarItem>
-    </SidebarHeader>
-    <SidebarHeader label="Links 2" open>
-      <SidebarItem active>Link 3</SidebarItem>
-      <SidebarItem>Link 4</SidebarItem>
-    </SidebarHeader>
-  </Sidebar>
+  <Sidenav>
+    <SidenavHeader condensed icon="Home" label="Project Home" />
+    <SidenavHeader label="The Prize" active>
+      <SidenavItem label="The First Prize" icon="Settings" />
+      <SidenavItem label="The Second Prize" icon="Settings" />
+      <SidenavItem label="The Third Prize" icon="Settings" />
+    </SidenavHeader>
+    <SidenavHeader label="Let It Snow">
+      <SidenavItem label="The First Prize" icon="Settings" />
+      <SidenavItem label="The Second Prize" icon="Settings" />
+      <SidenavItem label="The Third Prize" icon="Settings" />
+    </SidenavHeader>
+  </Sidenav>
 )
 
 // Container must set the height explicitly.
 // This component will set height to 100%.
 ;<div style={{ height: 300 }}>
   <Layout
-    sidenav={sidebar}
-    header={
-      <HeaderBar
-        logo={<ContiamoLogo />}
-        main={<Select naked options={[{ value: "Contiamo" }]} value="Contiamo" placeholder="Select Project..." />}
-        end={<Avatar name="Tejas Kumar" />}
-      />
-    }
-    main={
-      <Page
-        title="Page Title"
-        actions={
-          <Button condensed color="ghost">
-            Help
-          </Button>
-        }
-      >
-        {Array(10)
-          .fill("Hello!!!!")
-          .map((value, i) => <Card key={i}>{value}</Card>)}
-      </Page>
-    }
-  />
-</div>
-```
-
-### Loading Data
-
-```jsx
-const sidebar = (
-  <Sidebar expanded>
-    <SidebarHeader label="Links">
-      <SidebarItem
-        onClick={() => {
-          window.alert("Hello!")
-        }}
-      >
-        Link 1
-      </SidebarItem>
-      <SidebarItem>Link 2</SidebarItem>
-    </SidebarHeader>
-    <SidebarHeader label="Links 2" open>
-      <SidebarItem active>Link 3</SidebarItem>
-      <SidebarItem>Link 4</SidebarItem>
-    </SidebarHeader>
-  </Sidebar>
-)
-;<div style={{ height: 300 }}>
-  <Layout
-    loading
     sidenav={sidebar}
     header={
       <HeaderBar

--- a/packages/components/src/Sidenav/README.md
+++ b/packages/components/src/Sidenav/README.md
@@ -6,15 +6,15 @@ Typical usage includes `to` props to navigate and to manage highlighted/active s
 
 ```jsx
 <Sidenav>
-  <SidenavHeader to="/one" label="The Prize">
-    <SidenavItem label="The First Prize" icon="Settings" to="/one/1" />
-    <SidenavItem label="The Second Prize" icon="Settings" to="/one/2" />
-    <SidenavItem label="The Third Prize" icon="Settings" to="/one/3" />
+  <SidenavHeader label="The Prize">
+    <SidenavItem label="The First Prize" icon="Settings" />
+    <SidenavItem label="The Second Prize" icon="Settings" />
+    <SidenavItem label="The Third Prize" icon="Settings" />
   </SidenavHeader>
-  <SidenavHeader label="Let It Snow" to="/two">
-    <SidenavItem label="The First Prize" icon="Settings" to="/two/1" />
-    <SidenavItem label="The Second Prize" icon="Settings" to="/two/2" />
-    <SidenavItem label="The Third Prize" icon="Settings" to="/two/3" />
+  <SidenavHeader label="Let It Snow">
+    <SidenavItem label="The First Prize" icon="Settings" />
+    <SidenavItem label="The Second Prize" icon="Settings" />
+    <SidenavItem label="The Third Prize" icon="Settings" />
   </SidenavHeader>
 </Sidenav>
 ```

--- a/packages/components/src/Sidenav/README.md
+++ b/packages/components/src/Sidenav/README.md
@@ -6,6 +6,7 @@ Typical usage includes `to` props to navigate and to manage highlighted/active s
 
 ```jsx
 <Sidenav>
+  <SidenavHeader condensed icon="Home" label="Project Home" />
   <SidenavHeader label="The Prize">
     <SidenavItem label="The First Prize" icon="Settings" />
     <SidenavItem label="The Second Prize" icon="Settings" />

--- a/packages/components/src/Sidenav/README.md
+++ b/packages/components/src/Sidenav/README.md
@@ -5,17 +5,48 @@ Sidenavs render a two-level hierarchical navigation element comprised of headers
 Typical usage includes `to` props to navigate and to manage highlighted/active state automatically.
 
 ```jsx
-<Sidenav>
-  <SidenavHeader condensed icon="Home" label="Project Home" />
-  <SidenavHeader label="The Prize" active>
-    <SidenavItem label="The First Prize" icon="Settings" />
-    <SidenavItem label="The Second Prize" icon="Settings" />
-    <SidenavItem label="The Third Prize" icon="Settings" />
-  </SidenavHeader>
-  <SidenavHeader label="Let It Snow">
-    <SidenavItem label="The First Prize" icon="Settings" />
-    <SidenavItem label="The Second Prize" icon="Settings" />
-    <SidenavItem label="The Third Prize" icon="Settings" />
-  </SidenavHeader>
-</Sidenav>
+class StatefulSidenav extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      activeHeaders: [1],
+    }
+  }
+
+  toggle(index) {
+    this.setState(prevState => ({
+      activeHeaders: prevState.activeHeaders.includes(index)
+        ? prevState.activeHeaders.filter(headerIndex => headerIndex !== index)
+        : [...prevState.activeHeaders, index],
+    }))
+  }
+
+  render() {
+    return (
+      <Sidenav>
+        <SidenavHeader condensed icon="Home" label="Project Home" />
+        <SidenavHeader
+          label="The Prize"
+          active={this.state.activeHeaders.includes(1)}
+          onToggle={this.toggle.bind(this, 1)}
+        >
+          <SidenavItem label="The First Prize" icon="Settings" />
+          <SidenavItem label="The Second Prize" icon="Settings" />
+          <SidenavItem label="The Third Prize" icon="Settings" />
+        </SidenavHeader>
+        <SidenavHeader
+          label="Let It Snow"
+          active={this.state.activeHeaders.includes(2)}
+          onToggle={this.toggle.bind(this, 2)}
+        >
+          <SidenavItem label="The First Prize" icon="Settings" />
+          <SidenavItem label="The Second Prize" icon="Settings" />
+          <SidenavItem label="The Third Prize" icon="Settings" />
+        </SidenavHeader>
+      </Sidenav>
+    )
+  }
+}
+
+;<StatefulSidenav />
 ```

--- a/packages/components/src/Sidenav/README.md
+++ b/packages/components/src/Sidenav/README.md
@@ -7,7 +7,7 @@ Typical usage includes `to` props to navigate and to manage highlighted/active s
 ```jsx
 <Sidenav>
   <SidenavHeader condensed icon="Home" label="Project Home" />
-  <SidenavHeader label="The Prize">
+  <SidenavHeader label="The Prize" active>
     <SidenavItem label="The First Prize" icon="Settings" />
     <SidenavItem label="The Second Prize" icon="Settings" />
     <SidenavItem label="The Third Prize" icon="Settings" />

--- a/packages/components/src/Sidenav/Sidenav.tsx
+++ b/packages/components/src/Sidenav/Sidenav.tsx
@@ -8,6 +8,11 @@ import { WithTheme, Css, CssStatic } from "../types"
 
 export interface Props {
   id?: string
+<<<<<<< HEAD
+=======
+  /** `css` prop as expected in a glamorous component */
+  css?: Css
+>>>>>>> Add truncated summary
   className?: string
   children?: React.ReactNode
   /**
@@ -15,14 +20,12 @@ export interface Props {
    *
    * @deprecated this prop is ignored as per design decision (all sidenavs are expanded)
    */
-
   expanded?: boolean
   /**
    * Specifies whether sidenav should expand on hover
    *
    * @deprecated this prop is ignored as per design decision (all sidenavs are expanded)
    */
-
   expandOnHover?: boolean
 }
 

--- a/packages/components/src/Sidenav/Sidenav.tsx
+++ b/packages/components/src/Sidenav/Sidenav.tsx
@@ -8,11 +8,6 @@ import { WithTheme, Css, CssStatic } from "../types"
 
 export interface Props {
   id?: string
-<<<<<<< HEAD
-=======
-  /** `css` prop as expected in a glamorous component */
-  css?: Css
->>>>>>> Add truncated summary
   className?: string
   children?: React.ReactNode
   /**
@@ -47,7 +42,7 @@ const Container = styled("div")(
     return {
       color,
       background: theme.deprecated.colors.white,
-      width: sidenavExpandedWidth,
+      width: theme.sidebarWidth,
       borderRight: "1px solid",
       borderRightColor: theme.deprecated.colors.separator,
       zIndex: theme.deprecated.baseZIndex + 100,

--- a/packages/components/src/Sidenav/Sidenav.tsx
+++ b/packages/components/src/Sidenav/Sidenav.tsx
@@ -1,9 +1,8 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { lighten, readableTextColor } from "@operational/utils"
-import { OperationalStyleConstants, Theme, expandColor } from "@operational/theme"
+import { readableTextColor } from "@operational/utils"
+import { OperationalStyleConstants } from "@operational/theme"
 import deprecate from "../utils/deprecate"
-import { WithTheme, Css, CssStatic } from "../types"
 
 export interface Props {
   id?: string
@@ -27,31 +26,21 @@ export interface State {
   isHovered: boolean
 }
 
-const Container = styled("div")(
-  ({
-    theme,
-  }: {
-    theme?: OperationalStyleConstants & {
-      deprecated: Theme
-    }
-  }): CssStatic => {
-    const backgroundColor = theme.deprecated.colors.white
-    const lighterBackgroundColor = lighten(theme.deprecated.colors.navBackground, 8)
-    const color = readableTextColor(backgroundColor, [theme.deprecated.colors.text, theme.deprecated.colors.white])
-    return {
-      color,
-      background: theme.deprecated.colors.white,
-      width: theme.sidebarWidth,
-      borderRight: "1px solid",
-      borderRightColor: theme.deprecated.colors.separator,
-      zIndex: theme.deprecated.baseZIndex + 100,
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "flex-start",
-      height: "100%",
-    }
-  },
-)
+const Container = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => {
+  const backgroundColor = theme.color.white
+  const color = readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
+  return {
+    color,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    width: theme.sidebarWidth,
+    height: "100%",
+    borderRight: "1px solid",
+    borderRightColor: theme.color.separators.default,
+    background: theme.color.white,
+  }
+})
 
 export class Sidenav extends React.Component<Props, State> {
   render() {

--- a/packages/components/src/Sidenav/Sidenav.tsx
+++ b/packages/components/src/Sidenav/Sidenav.tsx
@@ -47,7 +47,6 @@ const Container = styled("div")(
     return {
       color,
       background: theme.deprecated.colors.white,
-      label: "sidenav",
       width: sidenavExpandedWidth,
       borderRight: "1px solid",
       borderRightColor: theme.deprecated.colors.separator,

--- a/packages/components/src/Sidenav/Sidenav.tsx
+++ b/packages/components/src/Sidenav/Sidenav.tsx
@@ -3,7 +3,6 @@ import styled from "react-emotion"
 import { lighten, readableTextColor } from "@operational/utils"
 import { OperationalStyleConstants, Theme, expandColor } from "@operational/theme"
 import deprecate from "../utils/deprecate"
-import { sidenavExpandedWidth } from "../constants"
 import { WithTheme, Css, CssStatic } from "../types"
 
 export interface Props {

--- a/packages/components/src/SidenavHeader/README.md
+++ b/packages/components/src/SidenavHeader/README.md
@@ -6,6 +6,12 @@ Used as headers (top-level links) inside a `Sidenav`.
 <SidenavHeader label="Chapter One" />
 ```
 
+### Usage with icon
+
+```jsx
+<SidenavHeader label="Chapter One" icon="User" />
+```
+
 ### Usage with items
 
 ```jsx

--- a/packages/components/src/SidenavHeader/README.md
+++ b/packages/components/src/SidenavHeader/README.md
@@ -2,14 +2,24 @@ Used as headers (top-level links) inside a `Sidenav`.
 
 ### Usage
 
-```js
-<SidenavHeader label="Chapter One"/>
+```jsx
+<SidenavHeader label="Chapter One" />
+```
+
+### Usage with items
+
+```jsx
+<SidenavHeader label="Chapter One">
+  <SidenavItem icon="Settings" label="Settings" />
+  <SidenavItem icon="Terminal" label="Code" />
+  <SidenavItem icon="User" label="Account" />
+</SidenavHeader>
 ```
 
 ### Usage with links
 
 Using a `to` prop navigates automatically, and render proper anchor tags with hrefs. See `OperationalUI` docs for a one-time configuration you need to do to have pushstate navigation working out-of-the-box.
 
-```js
+```jsx
 <SidenavHeader label="Chapter One" to="/one" />
 ```

--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -22,6 +22,8 @@ export interface Props {
   condensed?: boolean
   /** Active state - renders colored strip on the left */
   active?: boolean
+  /** Callback called when the active state changes */
+  onToggle?: (newActiveState: boolean) => void
   /**
    * Expanded state
    *
@@ -35,9 +37,7 @@ export interface Props {
   children?: React.ReactNode
 }
 
-export interface State {
-  isOpen: boolean
-}
+export interface State {}
 
 const containerStyles = ({
   theme,
@@ -183,18 +183,15 @@ const truncate = (maxLength: number) => (text: string) => {
 }
 
 export class SidenavHeader extends React.Component<Props, State> {
-  state = {
-    isOpen: false,
-  }
+  state = {}
 
   render() {
     const hasChildren = Boolean(this.props.children)
     const hasChildLinks = React.Children.toArray(this.props.children).some(child =>
       Boolean((child as { props: SidenavItemProps }).props.to),
     )
-    const isActive =
-      Boolean(this.state.isOpen || (this.props.to && window.location.pathname.match(`^${this.props.to}`))) &&
-      hasChildren
+
+    const isActive = Boolean(this.props.active)
 
     // Actual `to` prop should invalidate if the element has sublinks and is active
     const to = isActive && hasChildLinks ? undefined : this.props.to
@@ -212,9 +209,7 @@ export class SidenavHeader extends React.Component<Props, State> {
               className={[this.props.className, "op_sidenavheader"].filter(cls => Boolean(cls)).join(" ")}
               onClick={(ev: React.SyntheticEvent<Node>) => {
                 this.props.onClick && this.props.onClick()
-                this.setState(prevState => ({
-                  isOpen: !prevState.isOpen,
-                }))
+                this.props.onToggle && this.props.onToggle(!this.props.active)
 
                 if (!isModifiedEvent(ev) && ctx.pushState && this.props.to) {
                   ev.preventDefault()
@@ -242,12 +237,10 @@ export class SidenavHeader extends React.Component<Props, State> {
                   onClick={(ev: React.SyntheticEvent<Node>) => {
                     // Prevent clicks on parent in order to avoid conflicting behavior
                     ev.stopPropagation()
-                    this.setState(prevState => ({
-                      isOpen: !prevState.isOpen,
-                    }))
+                    this.props.onToggle && this.props.onToggle(!this.props.active)
                   }}
                 >
-                  <Icon name={this.state.isOpen ? "ChevronUp" : "ChevronDown"} />
+                  <Icon name={this.props.active ? "ChevronUp" : "ChevronDown"} />
                 </CloseButton>
               )}
               {isActive && <ItemsContainer>{this.props.children}</ItemsContainer>}

--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -58,12 +58,6 @@ const containerStyles = ({
     borderLeft: "4px solid",
     borderLeftColor: isActive ? stripColor : "transparent",
     borderBottomColor: theme.deprecated.colors.separator,
-
-    /** @todo Add to theme once colors are updated across codebase */
-    backgroundColor: isActive ? "#F8F8F8" : "transparent",
-    ":hover": {
-      backgroundColor: "#F8F8F8",
-    },
   }
 }
 
@@ -116,6 +110,7 @@ const ItemsContainer = styled("div")(
       deprecated: Theme
     }
   }): {} => ({
+    animation: `${fadeIn} .15s forwards ease`,
     position: "relative",
     top: -16,
     marginTop: -10,

--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -74,10 +74,12 @@ const ContainerLink = styled("a")(containerStyles)
 const Content = styled("div")(
   ({
     theme,
+    isCondensed,
   }: {
     theme?: OperationalStyleConstants & {
       deprecated: Theme
     }
+    isCondensed: boolean
   }): CssStatic => ({
     textDecoration: "none",
     cursor: "pointer",
@@ -86,7 +88,7 @@ const Content = styled("div")(
     flexDirection: "column",
     alignItems: "flex-start",
     justifyContent: "center",
-    height: 73,
+    height: isCondensed ? 60 : 73,
     overflow: "hidden",
     padding: `0 ${theme.space.content}px`,
     width: "100%",
@@ -224,7 +226,7 @@ export class SidenavHeader extends React.Component<Props, State> {
                 }
               }}
             >
-              <Content onClick={this.props.onClick}>
+              <Content onClick={this.props.onClick} isCondensed={Boolean(this.props.condensed)}>
                 <LabelText isActive={isActive}>
                   {this.props.label}
                   <IconContainer>

--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -5,6 +5,7 @@ import { fadeIn } from "@operational/utils"
 import { deprecate, isModifiedEvent } from "../utils"
 import { Icon, IconName, ContextConsumer, Context } from "../"
 import { WithTheme, Css, CssStatic } from "../types"
+import { Props as SidenavItemProps } from "../SidenavItem/SidenavItem"
 
 export interface Props {
   id?: string
@@ -97,20 +98,14 @@ const Content = styled("div")(
 
 const LabelText = styled("p")`
   position: relative;
-  color: #333333;
   font-weight: 500;
   letter-spacing: 0.25;
-  font-size: 14;
   text-transform: uppercase;
   white-space: nowrap;
   margin: 0;
-  ${({ isActive }: { isActive: boolean }) =>
-    isActive
-      ? `
-    top: -5px;
-    `
-      : `
-    margin-top: 8px;
+  ${({ isActive, theme }: { isActive: boolean; theme?: OperationalStyleConstants }) => `
+    color: ${theme.color.text.dark},
+    font-size: ${theme.font.size.body}px,
   `};
 `
 
@@ -123,7 +118,8 @@ const ItemsContainer = styled("div")(
     }
   }): {} => ({
     position: "relative",
-    top: -theme.space.content - 6,
+    top: -16,
+    marginTop: -10,
   }),
 )
 
@@ -142,7 +138,7 @@ const CloseButton = styled("div")(
     justifyContent: "center",
     width: theme.space.content * 1.5,
     height: theme.space.content * 1.5,
-    top: theme.space.content * 1.5,
+    top: theme.space.content * 1,
     right: theme.space.content,
     color: theme.deprecated.colors.info,
     ".op_sidenavheader:hover &": {
@@ -158,8 +154,7 @@ const CloseButton = styled("div")(
 const IconContainer = styled("p")`
   display: inline-block;
   vertical-align: middle;
-  margin: 0 0 0 8px;
-  width: 18px;
+  ${({ theme }: { theme?: OperationalStyleConstants }) => `margin: 0 0 0 ${theme.space.small}px;`} width: 18px;
   height: 18px;
   & > svg {
     position: relative;
@@ -172,10 +167,11 @@ const Summary = styled("div")`
   font-weight: normal;
   text-transform: none;
   margin-top: 4px;
-  ${({ theme }: { theme?: OperationalStyleConstants }) => `
+  ${({ theme, isActive }: { theme?: OperationalStyleConstants; isActive: boolean }) => `
     font-size: ${theme.font.size.fineprint}px;
     color: ${theme.color.text.lightest};
     left: ${theme.space.content}px;
+    visibility: ${isActive ? "hidden" : "visible"};
   `};
 `
 
@@ -192,8 +188,10 @@ export class SidenavHeader extends React.Component<Props, State> {
   }
 
   render() {
-    const hasChildren = React.Children.count(this.props.children) > 0
-    const hasChildLinks = React.Children.toArray(this.props.children).some(child => (child as any).props.to)
+    const hasChildren = Boolean(this.props.children)
+    const hasChildLinks = React.Children.toArray(this.props.children).some(child =>
+      Boolean((child as { props: SidenavItemProps }).props.to),
+    )
     const isActive =
       Boolean(this.state.isOpen || (this.props.to && window.location.pathname.match(`^${this.props.to}`))) &&
       hasChildren
@@ -237,7 +235,7 @@ export class SidenavHeader extends React.Component<Props, State> {
                     )}
                   </IconContainer>
                 </LabelText>
-                {!isActive && <Summary>{truncate(24)(childLabels.join(", "))}</Summary>}
+                {!this.props.condensed && <Summary isActive={isActive}>{truncate(24)(childLabels.join(", "))}</Summary>}
               </Content>
               {React.Children.count(this.props.children) > 0 && (
                 <CloseButton
@@ -252,7 +250,7 @@ export class SidenavHeader extends React.Component<Props, State> {
                   <Icon name={this.state.isOpen ? "ChevronUp" : "ChevronDown"} />
                 </CloseButton>
               )}
-              {isActive && this.state.isOpen && <ItemsContainer>{this.props.children}</ItemsContainer>}
+              {isActive && <ItemsContainer>{this.props.children}</ItemsContainer>}
             </ContainerComponent>
           )
         }}

--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -153,6 +153,18 @@ const CloseButton = styled("div")(
   }),
 )
 
+const IconContainer = styled("p")`
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 0 0 8px;
+  width: 18px;
+  height: 18px;
+  & > svg {
+    position: relative;
+    top: -2px;
+  }
+`
+
 const Summary = styled("div")`
   display: block;
   font-weight: normal;
@@ -178,10 +190,11 @@ export class SidenavHeader extends React.Component<Props, State> {
   }
 
   render() {
+    const hasChildren = React.Children.count(this.props.children) > 0
     const hasChildLinks = React.Children.toArray(this.props.children).some(child => (child as any).props.to)
-    const isActive = Boolean(
-      this.state.isOpen || (this.props.to && window.location.pathname.match(`^${this.props.to}`)),
-    )
+    const isActive =
+      Boolean(this.state.isOpen || (this.props.to && window.location.pathname.match(`^${this.props.to}`))) &&
+      hasChildren
 
     // Actual `to` prop should invalidate if the element has sublinks and is active
     const to = isActive && hasChildLinks ? undefined : this.props.to
@@ -212,7 +225,16 @@ export class SidenavHeader extends React.Component<Props, State> {
               }}
             >
               <Content onClick={this.props.onClick}>
-                <LabelText isActive={isActive}>{this.props.label}</LabelText>
+                <LabelText isActive={isActive}>
+                  {this.props.label}
+                  <IconContainer>
+                    {this.props.icon === String(this.props.icon) ? (
+                      <Icon name={this.props.icon as IconName} size={18} />
+                    ) : (
+                      this.props.icon
+                    )}
+                  </IconContainer>
+                </LabelText>
                 {!isActive && <Summary>{truncate(24)(childLabels.join(", "))}</Summary>}
               </Content>
               {React.Children.count(this.props.children) > 0 && (

--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -1,10 +1,9 @@
 import * as React from "react"
-import styled from "react-emotion"
-import { OperationalStyleConstants, Theme, expandColor } from "@operational/theme"
-import { fadeIn } from "@operational/utils"
-import { deprecate, isModifiedEvent } from "../utils"
+import styled, { Interpolation } from "react-emotion"
+import { OperationalStyleConstants } from "@operational/theme"
+import { expandColor, fadeIn } from "@operational/utils"
+import { isModifiedEvent } from "../utils"
 import { Icon, IconName, ContextConsumer, Context } from "../"
-import { WithTheme, Css, CssStatic } from "../types"
 import { Props as SidenavItemProps } from "../SidenavItem/SidenavItem"
 
 export interface Props {
@@ -37,18 +36,12 @@ export interface Props {
   children?: React.ReactNode
 }
 
-const containerStyles = ({
-  theme,
-  color,
-  isActive,
-}: {
-  theme?: OperationalStyleConstants & {
-    deprecated: Theme
-  }
+const containerStyles: Interpolation<{
+  theme?: OperationalStyleConstants
   color?: string
   isActive: boolean
-}): CssStatic => {
-  const stripColor: string = expandColor(theme.deprecated, color) || theme.deprecated.colors.info
+}> = ({ theme, color, isActive }) => {
+  const stripColor: string = expandColor(theme, color) || theme.color.primary
   return {
     label: "sidenavheader",
     textDecoration: "none",
@@ -57,7 +50,7 @@ const containerStyles = ({
     borderBottom: "1px solid",
     borderLeft: "4px solid",
     borderLeftColor: isActive ? stripColor : "transparent",
-    borderBottomColor: theme.deprecated.colors.separator,
+    borderBottomColor: theme.color.separators.default,
   }
 }
 
@@ -65,15 +58,7 @@ const Container = styled("div")(containerStyles)
 const ContainerLink = styled("a")(containerStyles)
 
 const Content = styled("div")(
-  ({
-    theme,
-    isCondensed,
-  }: {
-    theme?: OperationalStyleConstants & {
-      deprecated: Theme
-    }
-    isCondensed: boolean
-  }): CssStatic => ({
+  ({ theme, isCondensed }: { theme?: OperationalStyleConstants; isCondensed: boolean }) => ({
     textDecoration: "none",
     cursor: "pointer",
     position: "relative",
@@ -96,35 +81,21 @@ const LabelText = styled("p")`
   white-space: nowrap;
   user-select: none;
   margin: 0;
-  ${({ isActive, theme }: { isActive: boolean; theme?: OperationalStyleConstants }) => `
+  ${({ theme }: { isActive: boolean; theme?: OperationalStyleConstants }) => `
     color: ${theme.color.text.dark};
     font-size: ${theme.font.size.body}px;
   `};
 `
 
-const ItemsContainer = styled("div")(
-  ({
-    theme,
-  }: {
-    theme?: OperationalStyleConstants & {
-      deprecated: Theme
-    }
-  }): {} => ({
-    animation: `${fadeIn} .15s forwards ease`,
-    position: "relative",
-    top: -16,
-    marginTop: -10,
-  }),
-)
+const ItemsContainer = styled("div")({
+  animation: `${fadeIn} .15s forwards ease`,
+  position: "relative",
+  top: -16,
+  marginTop: -10,
+})
 
 const CloseButton = styled("div")(
-  ({
-    theme,
-  }: {
-    theme?: OperationalStyleConstants & {
-      deprecated: Theme
-    }
-  }): {} => ({
+  ({ theme }: { theme?: OperationalStyleConstants }): {} => ({
     position: "absolute",
     cursor: "pointer",
     display: "none",
@@ -134,13 +105,13 @@ const CloseButton = styled("div")(
     height: 24,
     top: 16,
     right: theme.space.content,
-    color: theme.deprecated.colors.info,
+    color: theme.color.primary,
     ".op_sidenavheader:hover &": {
       display: "flex",
     },
     "& svg": {
-      width: theme.deprecated.spacing,
-      height: theme.deprecated.spacing,
+      width: 16,
+      height: 16,
     },
   }),
 )

--- a/packages/components/src/SidenavItem/README.md
+++ b/packages/components/src/SidenavItem/README.md
@@ -1,1 +1,7 @@
-TODO: Add some nice docs for this amazing component
+See `Sidenav` for usage examples in a broader context.
+
+### Basic Usage
+
+```jsx
+<SidenavItem label="My Account" icon="User" />
+```

--- a/packages/components/src/SidenavItem/SidenavItem.tsx
+++ b/packages/components/src/SidenavItem/SidenavItem.tsx
@@ -31,6 +31,7 @@ const containerStyles = ({
   display: "flex",
   padding: `0 ${theme.space.content * 0.5}px`,
   height: size,
+  cursor: "pointer",
   position: "relative",
   width: "100%",
   alignItems: "center",
@@ -43,13 +44,11 @@ const containerStyles = ({
   // Specificity is piled up here to override default styles
   "a:link&, a:visited&": {
     textDecoration: "none",
-
-    /** @todo Add to theme once colors are updated across codebase */
-    color: isActive ? theme.deprecated.colors.linkText : theme.color.text.lightest,
+    color: isActive ? theme.color.primary : theme.color.text.lightest,
   },
   "&:hover": {
-    /** @todo Add to theme once colors are updated across codebase */
-    backgroundColor: theme.color.background.light,
+    backgroundColor: theme.color.background.lighter,
+    color: isActive ? theme.color.primary : theme.color.text.dark,
   },
 })
 

--- a/packages/components/src/SidenavItem/SidenavItem.tsx
+++ b/packages/components/src/SidenavItem/SidenavItem.tsx
@@ -11,7 +11,6 @@ export interface Props {
   className?: string
   onClick?: () => void
   /** Navigation property à la react-router <Link/> */
-
   to?: string
   active?: boolean
   icon?: IconName | React.ReactNode

--- a/packages/components/src/SidenavItem/SidenavItem.tsx
+++ b/packages/components/src/SidenavItem/SidenavItem.tsx
@@ -1,8 +1,6 @@
 import * as React from "react"
-import styled from "react-emotion"
-import { OperationalStyleConstants, Theme } from "@operational/theme"
-import { lighten } from "@operational/utils"
-import { WithTheme, Css, CssStatic } from "../types"
+import styled, { Interpolation } from "react-emotion"
+import { OperationalStyleConstants } from "@operational/theme"
 import { Icon, IconName, ContextConsumer, Context } from "../"
 import { isModifiedEvent } from "../utils"
 
@@ -19,15 +17,10 @@ export interface Props {
 
 const size: number = 36
 
-const containerStyles = ({
-  theme,
-  isActive,
-}: {
-  theme?: OperationalStyleConstants & {
-    deprecated: Theme
-  }
+const containerStyles: Interpolation<{
+  theme?: OperationalStyleConstants
   isActive: boolean
-}): CssStatic => ({
+}> = ({ theme, isActive }) => ({
   display: "flex",
   padding: `0 ${theme.space.content * 0.5}px`,
   height: size,
@@ -55,25 +48,19 @@ const containerStyles = ({
 const Container = styled("div")(containerStyles)
 const ContainerLink = styled("a")(containerStyles)
 
-const IconContainer = styled("span")(() => ({
+const IconContainer = styled("span")({
   width: size,
   height: size,
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
   flex: `0 0 ${size}px`,
-}))
+})
 
 const Label = styled("span")(
-  ({
-    theme,
-  }: {
-    theme?: OperationalStyleConstants & {
-      deprecated: Theme
-    }
-  }): {} => ({
+  ({ theme }: { theme?: OperationalStyleConstants }): {} => ({
     display: "inline-block",
-    paddingLeft: theme.deprecated.spacing / 4,
+    paddingLeft: theme.space.base,
   }),
 )
 

--- a/packages/components/src/SidenavItem/SidenavItem.tsx
+++ b/packages/components/src/SidenavItem/SidenavItem.tsx
@@ -29,15 +29,16 @@ const containerStyles = ({
   isActive: boolean
 }): CssStatic => ({
   display: "flex",
-  padding: `0 ${theme.deprecated.spacing * 0.5}px`,
-  label: "sidenavitem",
+  padding: `0 ${theme.space.content * 0.5}px`,
   height: size,
   position: "relative",
   width: "100%",
   alignItems: "center",
   justifyContent: "flex-start",
   whiteSpace: "nowrap",
-  fontSize: 14,
+  color: theme.color.text.light,
+  userSelect: "none",
+  fontSize: theme.font.size.body,
   fontWeight: 400,
   // Specificity is piled up here to override default styles
   "a:link&, a:visited&": {
@@ -88,11 +89,11 @@ const SidenavItem = (props: Props) => {
           id={props.id}
           className={props.className}
           onClick={(ev: React.SyntheticEvent<Node>) => {
+            ev.stopPropagation()
             props.onClick && props.onClick()
 
             if (!isModifiedEvent(ev) && props.to && ctx.pushState) {
               ev.preventDefault()
-              ev.stopPropagation()
               ctx.pushState(props.to)
             }
           }}

--- a/packages/components/src/constants.ts
+++ b/packages/components/src/constants.ts
@@ -1,2 +1,1 @@
-export const sidenavExpandedWidth = 240
 export const inputDefaultWidth = 240


### PR DESCRIPTION
Adds missing features to the side nav:
* [x] truncated summary items in `SidenavHeader`
* [x] `SidenavHeader` icon
* [x] condensed `SidenavHeader`
* [x] active state fully controlled with `active` and `onToggle` props
* [x] polish + adjust spacing to exactly match designs

<img width="241" alt="screen shot 2018-06-20 at 4 03 21 pm" src="https://user-images.githubusercontent.com/6738398/41663564-07b605f8-74a4-11e8-89fd-14bff1fbc1f1.png">