### PR TITLE
Fix SidenavItem active state

### DIFF
--- a/packages/components/src/SidenavItem/README.md
+++ b/packages/components/src/SidenavItem/README.md
@@ -5,3 +5,9 @@ See `Sidenav` for usage examples in a broader context.
 ```jsx
 <SidenavItem label="My Account" icon="User" />
 ```
+
+### Active State
+
+```jsx
+<SidenavItem label="My Account" icon="User" active />
+```

--- a/packages/components/src/SidenavItem/SidenavItem.tsx
+++ b/packages/components/src/SidenavItem/SidenavItem.tsx
@@ -30,9 +30,9 @@ const containerStyles: Interpolation<{
   alignItems: "center",
   justifyContent: "flex-start",
   whiteSpace: "nowrap",
-  color: theme.color.text.light,
   userSelect: "none",
   fontSize: theme.font.size.body,
+  color: isActive ? theme.color.primary : theme.color.text.lightest,
   fontWeight: 400,
   // Specificity is piled up here to override default styles
   "a:link&, a:visited&": {
@@ -66,7 +66,7 @@ const Label = styled("span")(
 
 const SidenavItem = (props: Props) => {
   const ContainerComponent = props.to ? ContainerLink : Container
-  const isActive = !!props.active || window.location.pathname === props.to
+  const isActive = !!props.active
   return (
     <ContextConsumer>
       {(ctx: Context) => (


### PR DESCRIPTION
Fixes an bug where SidenavItem active state does not show up visually unless a `to` prop is provided. Also removing `window.location` checks to determine whether an item is active or not.