### PR TITLE
Fix CardHeader icon handling

### DIFF
--- a/packages/components/src/CardHeader/CardHeader.tsx
+++ b/packages/components/src/CardHeader/CardHeader.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants } from "@operational/theme"
-import Icon from "../Icon/Icon"
 
 export interface Props {
   id?: string
@@ -44,7 +43,6 @@ const Container = styled("div")(({ theme }: { theme?: OperationalStyleConstants 
     textDecoration: "none",
   },
   "& svg": {
-    marginTop: -3,
     marginLeft: theme.space.base,
     width: 12,
     height: 12,

--- a/packages/components/src/CardHeader/README.md
+++ b/packages/components/src/CardHeader/README.md
@@ -6,12 +6,11 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
 ```jsx
 <Card>
   <CardHeader>Title for my card</CardHeader>
-  <p>Here is a bare card with custom padding.</p>
-  <img alt="Cat" src="https://images.unsplash.com/photo-1491485880348-85d48a9e5312?w=500" />
+  <p>Content for my card</p>
 </Card>
 ```
 
-### With action
+### With actions
 
 ```jsx
 <Card>
@@ -19,6 +18,9 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
     action={
       <div>
         <Button condensed>Button</Button>
+        <Button condensed color="primary">
+          Button <Icon name="Plus" />
+        </Button>
         <a href="#">
           Link <Icon name="ExternalLink" />
         </a>
@@ -27,26 +29,16 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
   >
     Title for my card
   </CardHeader>
-  <p>Here is a bare card with custom padding.</p>
-  <img alt="Cat" src="https://images.unsplash.com/photo-1491485880348-85d48a9e5312?w=500" />
+  <p>Content for my card</p>
 </Card>
 ```
 
-### With title prop
+### With a Title prop
 
 ```jsx
 <Card>
-  <CardHeader
-    action={
-      <div>
-        <Button condensed>Button</Button>
-        <a href="#">Link</a>
-      </div>
-    }
-    title="Title for my card"
-  />
-  <p>Here is a bare card with custom padding.</p>
-  <img alt="Cat" src="https://images.unsplash.com/photo-1491485880348-85d48a9e5312?w=500" />
+  <CardHeader title="Title for my card" />
+  <p>Content for my card</p>
 </Card>
 ```
 
@@ -63,7 +55,16 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
     }
     title={
       <>
-        This is <b> a bold</b> title
+        This is a{" "}
+        <span style={{ color: "#feb901" }}>
+          <strong>
+            <em>
+              <u>special</u>
+            </em>{" "}
+            ✨
+          </strong>
+        </span>{" "}
+        title
       </>
     }
   />

--- a/packages/components/src/CardHeader/README.md
+++ b/packages/components/src/CardHeader/README.md
@@ -10,7 +10,7 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
 </Card>
 ```
 
-### With actions
+### With `action` prop
 
 ```jsx
 <Card>
@@ -33,7 +33,7 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
 </Card>
 ```
 
-### With a Title prop
+### With `title` prop
 
 ```jsx
 <Card>


### PR DESCRIPTION
Currently, the plus is a little misaligned on the Bundles List [here](https://labs.fe.ctmo.io). This fixes that.