### PR TITLE
Deal with Page and router

### DIFF
--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -98,11 +98,10 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
 
   onTabClick(index: number) {
     this.setState({ activeTab: index })
-    if (isStringArray(this.props.tabs)) {
-      this.props.onTabChange && this.props.onTabChange(this.props.tabs[index].toLowerCase())
-    } else {
-      this.props.onTabChange && this.props.onTabChange(this.props.tabs[index].name.toLowerCase())
-    }
+
+    if (!this.props.onTabChange) return
+    const tabName = isStringArray(this.props.tabs) ? this.props.tabs[index] : this.props.tabs[index].name
+    this.props.onTabChange(tabName.toLowerCase())
   }
 
   render() {

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -28,7 +28,7 @@ export interface Props {
   /**
    * Active tab name
    *
-   * Useful for easy router mapping
+   * If set, the component become controlled
    */
   activeTabName?: string
   /**
@@ -155,7 +155,7 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
 
       return index === -1 ? 0 : index
     }
-    return 0
+    return this.state.activeTab
   }
 }
 

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -110,6 +110,7 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
     const activeTab = this.getActiveTabIndex()
     const grid = React.Children.count(children) > 1 ? "main side" : "main"
     const CurrentTab = tabs && !isStringArray(tabs) && tabs[activeTab].component
+    const tabsNames = tabs && (isStringArray(tabs) ? tabs : tabs.map(({ name }) => name))
 
     return (
       <Container>
@@ -122,17 +123,11 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
         {tabs ? (
           <>
             <TabsBar>
-              {isStringArray(tabs)
-                ? tabs.map((name, i) => (
-                    <Tab key={i} active={i === activeTab} onClick={() => this.onTabClick(i)}>
-                      {name}
-                    </Tab>
-                  ))
-                : tabs.map(({ name }, i) => (
-                    <Tab key={i} active={i === activeTab} onClick={() => this.onTabClick(i)}>
-                      {name}
-                    </Tab>
-                  ))}
+              {tabsNames.map((name, i) => (
+                <Tab key={i} active={i === activeTab} onClick={() => this.onTabClick(i)}>
+                  {name}
+                </Tab>
+              ))}
             </TabsBar>
             <ViewContainer isInTab>{isStringArray(tabs) ? children : <CurrentTab />}</ViewContainer>
           </>

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -94,20 +94,7 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
     fill: false,
   }
 
-  constructor(props: Props) {
-    super(props)
-    if (props.activeTabName && props.tabs) {
-      const index = isStringArray(props.tabs)
-        ? props.tabs.findIndex(name => name.toLowerCase() === props.activeTabName.toLowerCase())
-        : props.tabs.findIndex(({ name }) => name.toLowerCase() === props.activeTabName.toLowerCase())
-      this.state = {
-        ...initialState,
-        activeTab: index === -1 ? 0 : index,
-      }
-    } else {
-      this.state = initialState
-    }
-  }
+  state = initialState
 
   onTabClick(index: number) {
     this.setState({ activeTab: index })
@@ -120,7 +107,7 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
 
   render() {
     const { children, title, actions, tabs, areas, fill } = this.props
-    const { activeTab } = this.state
+    const activeTab = this.getActiveTabIndex()
     const grid = React.Children.count(children) > 1 ? "main side" : "main"
     const CurrentTab = tabs && !isStringArray(tabs) && tabs[activeTab].component
 
@@ -158,6 +145,17 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
         )}
       </Container>
     )
+  }
+
+  private getActiveTabIndex = () => {
+    if (this.props.activeTabName && this.props.tabs) {
+      const index = isStringArray(this.props.tabs)
+        ? this.props.tabs.findIndex(name => name.toLowerCase() === this.props.activeTabName.toLowerCase())
+        : this.props.tabs.findIndex(({ name }) => name.toLowerCase() === this.props.activeTabName.toLowerCase())
+
+      return index === -1 ? 0 : index
+    }
+    return 0
   }
 }
 

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -94,7 +94,7 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
     fill: false,
   }
 
-  state = initialState
+  readonly state = initialState
 
   onTabClick(index: number) {
     this.setState({ activeTab: index })

--- a/packages/components/src/Page/README.md
+++ b/packages/components/src/Page/README.md
@@ -131,3 +131,54 @@ const Tab = n => () => (
   </PageArea>
 </Page>
 ```
+
+### With tabs and router
+
+The idea here is to just give strings as tabs, and give the switch responsability to react-router for example.
+
+```jsx
+class Routes extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentRoute: "overview",
+    }
+
+    this.onChange = this.onChange.bind(this)
+  }
+
+  onChange(name) {
+    this.setState({ currentRoute: name })
+  }
+
+  render() {
+    const Switch = {
+      overview: () => <Card title="Overview" />,
+      jobs: () => <Card title="Jobs" />,
+      functions: () => (
+        <Card title="Functions">
+          <Button color="primary" onClick={() => this.onChange("functionDetail")}>
+            Go to function detail
+          </Button>
+        </Card>
+      ),
+      functionDetail: () => <Card title="Function Detail" />,
+    }[this.state.currentRoute]
+
+    return (
+      <Page
+        title="With a router"
+        onTabChange={this.onChange}
+        activeTabName={this.state.currentRoute}
+        tabs={["overview", "jobs", "functions"]}
+      >
+        <PageContent>
+          <Switch />
+        </PageContent>
+      </Page>
+    )
+  }
+}
+
+;<Routes />
+```

--- a/packages/components/src/Page/README.md
+++ b/packages/components/src/Page/README.md
@@ -157,19 +157,19 @@ class Routes extends React.Component {
       jobs: () => <Card title="Jobs" />,
       functions: () => (
         <Card title="Functions">
-          <Button color="primary" onClick={() => this.onChange("functionDetail")}>
+          <Button color="primary" onClick={() => this.onChange("functions/myfunction")}>
             Go to function detail
           </Button>
         </Card>
       ),
-      functionDetail: () => <Card title="Function Detail" />,
+      "functions/myfunction": () => <Card title="Function Detail" />,
     }[this.state.currentRoute]
 
     return (
       <Page
         title="With a router"
         onTabChange={this.onChange}
-        activeTabName={this.state.currentRoute}
+        activeTabName={this.state.currentRoute.split("/")[0]}
         tabs={["overview", "jobs", "functions"]}
       >
         <PageContent>


### PR DESCRIPTION
As we have some sub-pages in our product, we need a way to inject router logics into `Page` component.

For this, I have the following proposition:

```jsx
<Page
  title="With a router"
  onTabChange={this.onChange}
  activeTabName={/* router -> tabs matching */}
  tabs={["overview", "jobs", "functions"]}
>
  <Switch>
    <Route path="overview" render={() => <Card title="overview" /> } />
    <Route path="jobs" render={() => <Card title="jobs" /> } />
    <Route path="functions" render={() => <Card title="functions" /> } />
    <Route path="functions/:id" render={() => <Card title="functions/:id" /> } />
  </Switch>
</Page>
```

So it's not link internally to the router, but we can play with the `Page` and `react-router` together to deal with the most advanced routing patterns.