### PR TITLE
Close select when selecting single item

### DIFF
--- a/packages/components/src/Select/README.md
+++ b/packages/components/src/Select/README.md
@@ -1,5 +1,9 @@
 The Select component presents users with a list of information with single-choice or multiple-choice options. Select elements can have options filled onClick, and also support filters.
 
+### Basic usage
+
+If the component is used with a string `value` prop, it behaves as a single select. Every time the value is changed, the options pop-up closes automatically.
+
 ```js
 const options = [
   { label: "Option 1", value: "one" },
@@ -9,14 +13,14 @@ const options = [
   { label: "Option 5", value: "five" },
   { label: "Option 6", value: "six" },
   { label: "Option 7", value: "seven" },
-  { label: "Option 8", value: "eight" }
+  { label: "Option 8", value: "eight" },
 ]
 
 class ComponentWithSelect extends React.Component {
   constructor(props) {
-      super(props);
-      this.state = {
-        value: []
+    super(props)
+    this.state = {
+      value: "one",
     }
   }
 
@@ -30,7 +34,7 @@ class ComponentWithSelect extends React.Component {
         placeholder="Choose an option"
         onChange={newValue => {
           this.setState(prevState => ({
-            value: newValue
+            value: newValue,
           }))
         }}
       />
@@ -38,8 +42,55 @@ class ComponentWithSelect extends React.Component {
   }
 }
 
-<OperationalUI withBaseStyles>
-    <ComponentWithSelect />
+;<OperationalUI withBaseStyles>
+  <ComponentWithSelect />
+</OperationalUI>
+```
+
+### Usage as multiselect
+
+Using an array prop in the `value` makes the component work as multiselect. The pop-up stays open so that additional values may be added.
+
+```js
+const options = [
+  { label: "Option 1", value: "one" },
+  { label: "Option 2", value: "two" },
+  { label: "Option 3", value: "three" },
+  { label: "Option 4", value: "four" },
+  { label: "Option 5", value: "five" },
+  { label: "Option 6", value: "six" },
+  { label: "Option 7", value: "seven" },
+  { label: "Option 8", value: "eight" },
+]
+
+class ComponentWithSelect extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      value: [],
+    }
+  }
+
+  render() {
+    return (
+      <Select
+        label="Select label"
+        value={this.state.value}
+        options={options}
+        filterable
+        placeholder="Choose an option"
+        onChange={newValue => {
+          this.setState(prevState => ({
+            value: newValue,
+          }))
+        }}
+      />
+    )
+  }
+}
+
+;<OperationalUI withBaseStyles>
+  <ComponentWithSelect />
 </OperationalUI>
 ```
 
@@ -51,6 +102,6 @@ array, the component automatically becomes a multi-select. The shape of an Optio
 ```js static
 const option = {
   label: "any_string",
-  value: "Any String"
+  value: "Any String",
 }
 ```

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -212,6 +212,9 @@ class Select extends React.Component<Props, State> {
     }
 
     if (!Array.isArray(this.props.value)) {
+      this.setState(prevState => ({
+        open: false,
+      }))
       onChange(this.props.value === option.value ? null : option.value)
       return
     }
@@ -278,7 +281,9 @@ class Select extends React.Component<Props, State> {
                     (option.label || String(option.value)).match(RegExp(search)) && (
                       <SelectOption
                         key={String(option.value)}
-                        onClick={() => this.selectOption(option)}
+                        onClick={() => {
+                          this.selectOption(option)
+                        }}
                         selected={this.isOptionSelected(option)}
                       >
                         {option.label || String(option.value)}


### PR DESCRIPTION
Fixes an issue where the `select` popup doesn't close when selecting a single item. This feature is enabled automatically when the select is not multiselect.

![select](https://user-images.githubusercontent.com/6738398/41916483-6dde02aa-7958-11e8-9673-90e866161c6a.gif)
