### PR TITLE
Copy CNAME file to gh-pages deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:website": "lerna run --scope @operational/website build && cp -r packages/website/dist .",
     "build:visual-test": "lerna run --scope @operational/visual-tests build && cp -r packages/visual-tests/dist/ ./dist/visual-tests",
     "build:components": "lerna run --scope @operational/components docs:build && cp -r packages/components/styleguide ./dist/docs",
+    "build:cname": "cp CNAME dist",
     "clean": "lerna clean",
     "test": "run-s \"test:* -- -- --maxWorkers=$JEST_MAX_WORKERS\"",
     "test:components": "cd packages/components && npm run test",


### PR DESCRIPTION
This PR fixes https://operational-ui.js.org, which is broken because the `CNAME` file is only present on the `master` branch. It is coped into the `dist` folder before the `gh-pages` binary does the deploy.