### PR TITLE
Remove all React warnings

### DIFF
--- a/packages/components/src/CardColumns/CardColumns.tsx
+++ b/packages/components/src/CardColumns/CardColumns.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants } from "@operational/theme"
 
-const StyledCardColumns = styled("div")(
+export const CardColumns = styled("div")(
   ({ children, theme }: React.Props<{}> & { theme?: OperationalStyleConstants }) => ({
     display: "flex",
     flexWrap: "wrap",
@@ -12,7 +12,5 @@ const StyledCardColumns = styled("div")(
     },
   }),
 )
-
-const CardColumns: React.SFC = props => <StyledCardColumns {...props} />
 
 export default CardColumns

--- a/packages/components/src/CardItem/CardItem.tsx
+++ b/packages/components/src/CardItem/CardItem.tsx
@@ -12,8 +12,9 @@ export interface Props {
 const CardItemTitle = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
   color: theme.color.text.lightest,
   fontFamily: theme.font.family.main,
-  fontWeight: "bold",
+  fontWeight: 500,
   fontSize: theme.font.size.fineprint,
+  textTransform: "uppercase",
 }))
 
 const CardItemBody = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({

--- a/packages/components/src/Checkbox/README.md
+++ b/packages/components/src/Checkbox/README.md
@@ -5,7 +5,7 @@ class ComponentWithCheckbox extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      selected: ["1"]
+      selected: ["1"],
     }
   }
   render() {
@@ -16,7 +16,7 @@ class ComponentWithCheckbox extends React.Component {
         selected={this.state.selected}
         onChange={n => {
           this.setState(p => ({
-            selected: n
+            selected: n,
           }))
         }}
       />
@@ -24,13 +24,5 @@ class ComponentWithCheckbox extends React.Component {
   }
 }
 
-<ComponentWithCheckbox />
+;<ComponentWithCheckbox />
 ```
-
-## Props
-
-| Name     | Description                                                               | Type                            | Default    | Required |
-| :------- | :------------------------------------------------------------------------ | :------------------------------ | :--------- | :------- |
-| options  | All checkbox options                                                      | string[]                        |            | No       |
-| selected | Selected options                                                          | string[]                        |            | No       |
-| onChange | Change callback, passing a full list of the new current selected options. | (newSelected: string[]) => void | () => void | Yes      |

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -56,7 +56,7 @@ const style = (Component: React.SFC<Props>) =>
     marginRight: left ? theme.space.small : 0,
   }))
 
-const Icon = withTheme((props: PropsWithTheme) => {
+const Icon = withTheme(({ left, right, ...props }: PropsWithTheme) => {
   const color: string = expandColor(props.theme, props.color) || "currentColor"
   const defaultSize = 32
 

--- a/packages/components/src/Page/README.md
+++ b/packages/components/src/Page/README.md
@@ -21,7 +21,7 @@ Here is a simple usage example:
   <Page title="Settings Page">
     {Array(2)
       .fill("Hello, this is page content")
-      .map(({ text, index }) => <Card key={index}>{text}</Card>)}
+      .map((text, index) => <Card key={index}>{text}</Card>)}
   </Page>
 </div>
 ```
@@ -35,7 +35,7 @@ Here is a simple usage example:
   <Page title="Settings Page">
     {Array(50)
       .fill("Hello, this is page content")
-      .map(({ text, index }) => <Card key={index}>{text}</Card>)}
+      .map((text, index) => <Card key={index}>{text}</Card>)}
   </Page>
 </div>
 ```
@@ -79,7 +79,7 @@ const Tab = n => () => (
   <PageContent areas="side main">
     {Array(50)
       .fill("Hello, this is page content")
-      .map(({ text, index }) => <Card key={index}>{text}</Card>)}
+      .map((text, index) => <Card key={index}>{text}</Card>)}
   </PageContent>
 )
 ;<div style={{ height: 200 }}>

--- a/packages/components/src/PageArea/PageArea.tsx
+++ b/packages/components/src/PageArea/PageArea.tsx
@@ -8,8 +8,8 @@ export interface PageAreaProps {
   children?: React.ReactNode
 }
 
-const Area = styled("div")(({ name }: PageAreaProps) => ({
+export const PageArea = styled("div")(({ name }: PageAreaProps) => ({
   gridArea: name,
 }))
 
-export default (props: PageAreaProps) => <Area {...props} />
+export default PageArea

--- a/packages/components/src/PageContent/PageContent.tsx
+++ b/packages/components/src/PageContent/PageContent.tsx
@@ -10,12 +10,7 @@ export interface Props {
 }
 
 const StyledPageContent = styled("div")(
-  (
-    props: {
-      children?: React.ReactNode
-      theme?: OperationalStyleConstants
-    } & Props,
-  ) => {
+  (props: { theme?: OperationalStyleConstants; areas?: Props["areas"]; isFill?: boolean }) => {
     const gridTemplateColumns = {
       main: "auto",
       "main side": "auto 280px",
@@ -28,7 +23,7 @@ const StyledPageContent = styled("div")(
       alignItems: "start",
       gridTemplateAreas: `"${props.areas}"`,
       gridGap: props.theme.space.content,
-      maxWidth: props.fill ? "none" : 1150,
+      maxWidth: props.isFill ? "none" : 1150,
       minWidth: 800,
       width: "100%",
       height: `calc(100% - ${props.theme.titleHeight}px)`,
@@ -37,6 +32,7 @@ const StyledPageContent = styled("div")(
   },
 )
 
-const PageContent: React.SFC<Props> = props => <StyledPageContent {...props} />
+// `fill` must be rename internally to avoid conflict with the native `fill` DOM attribute
+const PageContent: React.SFC<Props> = ({ fill, ...props }) => <StyledPageContent {...props} isFill={fill} />
 
 export default PageContent

--- a/packages/components/src/SidenavHeader/SidenavHeader.tsx
+++ b/packages/components/src/SidenavHeader/SidenavHeader.tsx
@@ -73,7 +73,7 @@ const Content = styled("div")(
   }),
 )
 
-const LabelText = styled("p")`
+const LabelText = styled("div")`
   position: relative;
   font-weight: 500;
   letter-spacing: 0.25;
@@ -116,7 +116,7 @@ const CloseButton = styled("div")(
   }),
 )
 
-const IconContainer = styled("p")`
+const IconContainer = styled("div")`
   display: inline-block;
   vertical-align: middle;
   ${({ theme }: { theme?: OperationalStyleConstants }) => `margin: 0 0 0 ${theme.space.small}px;`} width: 18px;

--- a/packages/components/src/Status/Status.tsx
+++ b/packages/components/src/Status/Status.tsx
@@ -21,7 +21,7 @@ const getColorFromProps = ({ success, error, theme }: Props): string => {
   return theme.color.background.dark
 }
 
-const Status = styled("div")((props: Props) => ({
+export const Status = styled("div")((props: Props) => ({
   display: "inline-block",
   marginRight: props.theme.space.small,
   width: props.theme.space.small,
@@ -34,4 +34,4 @@ const Status = styled("div")((props: Props) => ({
   backgroundColor: getColorFromProps(props),
 }))
 
-export default (props: Props) => <Status {...props} />
+export default Status


### PR DESCRIPTION
After a long fight, no more react warnings (keys, nestead `p`…)

Special thank to @TejasQ to have introduce this very tricky bug (https://github.com/contiamo/operational-ui/commit/2ae3d6455a55417bf27f6594bb9f29926b82fb10) it was quite hard to find ^^ But I found it! 🤠 