### PR TITLE
Fix Icon left/right props

### DIFF
--- a/packages/components/src/Button/README.md
+++ b/packages/components/src/Button/README.md
@@ -15,6 +15,7 @@ Using buttons is as simple as including the component with a text node as a chil
 </div>
 <div style={{ marginBottom: 10 }}>
   <Button color="success" icon="ExternalLink">Icon</Button>
+  <Button color="success" icon="Labs">Icon</Button>
   <Button condensed icon="ExternalLink">Icon</Button>
   <Button loading>Loading</Button>
 </div>

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -50,27 +50,24 @@ export interface PropsWithTheme extends Props {
   theme?: OperationalStyleConstants
 }
 
-const style = (Component: React.SFC<Props>) =>
-  styled(Component)(({ left, right, theme }: PropsWithTheme) => ({
-    marginLeft: right ? theme.space.small : 0,
-    marginRight: left ? theme.space.small : 0,
-  }))
-
 const Icon = withTheme(({ left, right, ...props }: PropsWithTheme) => {
   const color: string = expandColor(props.theme, props.color) || "currentColor"
   const defaultSize = 32
 
   if (ReactFeather[props.name]) {
-    const Comp = style(ReactFeather[props.name])
+    const Comp = ReactFeather[props.name]
     return <Comp {...props} size={props.size || defaultSize} color={color} />
   }
 
   if (BrandIcons[props.name]) {
-    const Comp = style(BrandIcons[props.name])
+    const Comp = BrandIcons[props.name]
     return <Comp {...props} size={props.size || defaultSize} color={color} />
   }
 
   return null
 })
 
-export default styled(Icon)()
+export default styled(Icon)(({ left, right, theme }: PropsWithTheme) => ({
+  marginLeft: right ? theme.space.small : 0,
+  marginRight: left ? theme.space.small : 0,
+}))

--- a/packages/components/src/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`ContextMenu Component Should render 1`] = `
     stroke-linecap="round"
     stroke-linejoin="round"
     stroke-width="2"
+    theme="[object Object]"
     viewbox="0 0 24 24"
     width="16"
     xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/src/__tests__/__snapshots__/Icon.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Icon.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Icon Component Renders an <svg> tag 1`] = `
   stroke-linecap="round"
   stroke-linejoin="round"
   stroke-width="2"
+  theme="[object Object]"
   viewbox="0 0 24 24"
   width="32"
   xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/src/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Message.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Message Component Should render 1`] = `
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="2"
+      theme="[object Object]"
       viewbox="0 0 24 24"
       width="32"
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Turns out our icons broke everywhere.

@fabien0102 [please be more careful next time](https://github.com/contiamo/operational-ui/blame/master/packages/components/src/Icon/Icon.tsx#L59) as all the icons broke on all UIs everywhere.

I will be more careful to visually test things as well.

I also added a visual test case for `BrandIcon`s as they are different to default feather icons.