### PR TITLE
Convert color constants to hex.

### DIFF
--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-1iqekuh-button"
+  class="css-j26hxv-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-1iqekuh-button"
+    class="css-j26hxv-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Card.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Card Should render 1`] = `
 <div
-  class="css-1b4wqmx"
+  class="css-1h3wh5n"
 >
   hi
 </div>

--- a/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Chip Should render 1`] = `
 <div
-  class="css-2ie7h0-chip"
+  class="css-1j2avz3-chip"
 >
   <div
     class="css-1k6isyt"

--- a/packages/components/src/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Input.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Input Should initialize 1`] = `
   class="css-wgfiur"
 >
   <input
-    class="hi css-1xt7m3n-input"
+    class="hi css-c8tup6-input"
     name="bienvenue"
     placeholder="hello"
     value="How are you?"

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-16kh43x-button"
+    class="css-1pwb8ty-button"
   >
     first
   </button>
   <button
-    class="css-16kh43x-button"
+    class="css-1pwb8ty-button"
   >
     <svg
       fill="none"
@@ -35,7 +35,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </span>
   </button>
   <div
-    class="css-18cz1fu"
+    class="css-1fzcbye"
   >
     <span>
       101-150
@@ -43,7 +43,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-16kh43x-button"
+    class="css-1pwb8ty-button"
   >
     <span>
       next
@@ -68,7 +68,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-16kh43x-button"
+    class="css-1pwb8ty-button"
   >
     last
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Select.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Select Should render correctly 1`] = `
 <div
-  class="css-1ma0alw-select"
+  class="css-2xp493-select"
   role="listbox"
   tabindex="-2"
 >

--- a/packages/components/src/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Table.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Table Component Should render 1`] = `
 <table
-  class="css-s7lm2v"
+  class="css-39fsjl"
 >
   <thead>
     <tr
@@ -14,7 +14,7 @@ exports[`Table Component Should render 1`] = `
       class="css-szcvmb"
     >
       <td
-        class="css-if432c"
+        class="css-5t6k2w"
         colspan="0"
       >
         There are no records available

--- a/packages/components/src/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`Tabs Should render 1`] = `
     class="css-u71hb6"
   >
     <li
-      class="css-1v7kwch"
-      color="hsl(197, 82%, 44%)"
+      class="css-pks5d5"
+      color="#1499cc"
     />
   </ul>
   <div

--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -21,49 +21,37 @@ import { operational } from "./constants/deprecatedTheme"
  * to achieve subtle, yet effective shading
  * effects and readable typography.
  */
-export type Grey =
-  | 96 // #f6f6f6
-  | 93 // #ececec
-  | 91 // #e8e8e8
-  | 75 // #c0c0c0
-  | 56 // #909090
-  | 45 // #747474
-  | 40 // #666
-  | 33 // #545454
-  | 24 // #3e3e3e
-  | 20 // #333
 
 // These constants are shared across many object definitions.
-const grey = (lightness: Grey) => `hsl(0, 0%, ${lightness}%)`
-const primaryColor = "hsl(197, 82%, 44%)"
-const whiteColor = "hsl(0, 0%, 100%)"
+const primaryColor = "#1499cc"
+const whiteColor = "#fff"
 
 /**
  * A specialized color palette for backgrounds.
  */
 const backgroundColors = {
-  dark: grey(24),
-  light: grey(93),
-  lighter: grey(96),
+  dark: "#3e3e3e",
+  light: "#ececec",
+  lighter: "#f6f6f6",
 }
 
 /**
  * A specialized color palette for separators.
  */
 const separatorColors = {
-  default: grey(91),
-  light: grey(93),
+  default: "#e8e8e8",
+  light: "#ececec",
 }
 
 /**
  * A specialized color palette for typography.
  */
 const textColors = {
-  dark: grey(20),
-  default: grey(33),
-  light: grey(40),
-  lighter: grey(45),
-  lightest: grey(56),
+  dark: "#333",
+  default: "#545454",
+  light: "#666",
+  lighter: "#747474",
+  lightest: "#909090",
   action: primaryColor,
   white: whiteColor,
 }
@@ -72,35 +60,26 @@ const textColors = {
  * A specialized color palette for borders.
  */
 const borderColors = {
-  default: grey(75),
-  disabled: grey(91),
+  default: "#c0c0c0",
+  disabled: "#e8e8e8",
 }
 
 /**
  * A collection of colors used throughout the library.
- * We've chosen HSL syntax for color descriptions because they
- * allow for fine tuning and allow a more transparent way to
- * observe color variation, verbosely describing the hue,
- * saturation, and lightness of a color.
+ * We've chosen HEX syntax for color descriptions to ensure consistency
+ * with design colors.
  *
  * hsla is used where alpha blending is involved.
  */
 const color = {
-  /**
-   * Greys exist on a spectrum of 0-100.
-   *
-   * Current _official_ greys are:
-   * 96, 93, 56, 45, 40, 33, 24, 20
-   */
-  grey,
   primary: primaryColor,
-  disabled: "hsl(0, 0%, 96%)",
-  success: "hsl(127, 86%, 36%)",
-  error: "hsl(0, 100%, 30%)",
-  basic: "hsl(0, 0%, 39%)",
+  disabled: "#f5f5f5",
+  success: "#0c991d",
+  error: "#9a0000",
+  basic: "#636363",
   ghost: "hsla(0, 0%, 100%, 0.2)",
   white: whiteColor,
-  black: "hsl(0, 0%, 0%)",
+  black: "#000",
   background: backgroundColors,
   separators: separatorColors,
   text: textColors,


### PR DESCRIPTION
- All colors are now in HEX format, except `ghost` which remains in hsla.
- Greys are now hardcoded.
- The `success` color has been updated to `"#0C991D"`