### PR TITLE
Add opacity to chip backgrounds.

### DIFF
--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -68,7 +68,7 @@ const Action = styled("div")(
   ({ theme }: { theme?: OperationalStyleConstants }): {} => {
     return {
       borderLeft: `1px solid ${theme.color.ghost}`,
-      width: theme.space.content,
+      width: theme.space.element,
       display: "flex",
       alignItems: "center",
       justifyContent: "center",

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -32,7 +32,7 @@ const Container = styled("div")(
     return {
       backgroundColor: transparentize(expandColor(theme, color) || theme.color.primary)(0.1),
       fontSize: theme.font.size.small,
-      fontWeight: theme.font.weight.bold,
+      fontWeight: theme.font.weight.medium,
       label: "chip",
       position: "relative",
       height: theme.space.element,

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -3,7 +3,7 @@ import styled from "react-emotion"
 import { OperationalStyleConstants, expandColor } from "../utils/constants"
 import { Icon, IconName } from "../"
 import { WithTheme, Css } from "../types"
-import * as colorCalculator from "tinycolor2"
+import colorCalculator from "tinycolor2"
 
 export interface Props {
   /** Id */

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { readableTextColor } from "@operational/utils"
+import { transparentize } from "@operational/utils"
 import { OperationalStyleConstants, expandColor } from "../utils/constants"
 import { Icon, IconName } from "../"
 import { WithTheme, Css } from "../types"
@@ -29,10 +29,10 @@ export interface Props {
 
 const Container = styled("div")(
   ({ theme, color }: { theme?: OperationalStyleConstants; color?: string }): {} => {
-    const backgroundColor = expandColor(theme, color) || theme.color.primary
     return {
-      backgroundColor,
+      backgroundColor: transparentize(expandColor(theme, color) || theme.color.primary)(0.1),
       fontSize: theme.font.size.small,
+      fontWeight: theme.font.weight.bold,
       label: "chip",
       position: "relative",
       height: theme.space.element,
@@ -43,7 +43,7 @@ const Container = styled("div")(
       borderRadius: 2,
       cursor: "pointer",
       overflow: "hidden",
-      color: readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white]),
+      color: theme.color.text.default,
       margin: `0px ${theme.space.small}px 0px 0px`,
     }
   },

--- a/packages/components/src/Chip/Chip.tsx
+++ b/packages/components/src/Chip/Chip.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { transparentize } from "@operational/utils"
 import { OperationalStyleConstants, expandColor } from "../utils/constants"
 import { Icon, IconName } from "../"
 import { WithTheme, Css } from "../types"
+import * as colorCalculator from "tinycolor2"
 
 export interface Props {
   /** Id */
@@ -29,8 +29,11 @@ export interface Props {
 
 const Container = styled("div")(
   ({ theme, color }: { theme?: OperationalStyleConstants; color?: string }): {} => {
+    const backgroundColor = colorCalculator(expandColor(theme, color) || theme.color.primary)
+      .setAlpha(0.1)
+      .toString()
     return {
-      backgroundColor: transparentize(expandColor(theme, color) || theme.color.primary)(0.1),
+      backgroundColor,
       fontSize: theme.font.size.small,
       fontWeight: theme.font.weight.medium,
       label: "chip",

--- a/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Chip Should render 1`] = `
 <div
-  class="css-1j2avz3-chip"
+  class="css-t1h0j7-chip"
 >
   <div
     class="css-1k6isyt"

--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -113,7 +113,10 @@ const font = {
     regular: 400,
 
     /** 500 */
-    bold: 500,
+    medium: 500,
+
+    /** 600 */
+    bold: 600,
   },
 }
 

--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -108,6 +108,13 @@ const font = {
     /** 12px */
     fineprint: 12,
   },
+  weight: {
+    /** 400 */
+    regular: 400,
+
+    /** 500 */
+    bold: 500,
+  },
 }
 
 /**

--- a/packages/utils/src/__tests__/color.test.ts
+++ b/packages/utils/src/__tests__/color.test.ts
@@ -1,4 +1,4 @@
-import { readableTextColor, darken, lighten, transparentize, setBrightness } from "../index"
+import { readableTextColor, darken, lighten, setBrightness } from "../index"
 
 xdescribe("Color utils", () => {
   it("Should give me a readable text color against a presented background color", () => {
@@ -18,10 +18,6 @@ xdescribe("Color utils", () => {
 
   it("Should lighten a color by a percentage", () => {
     expect(lighten("#808080", 50)).toEqual("#ffffff")
-  })
-
-  it("Should transparentize a color by a percentage", () => {
-    expect(transparentize("red")(100)).toEqual("rgba(255, 0, 0, 0)")
   })
 
   it("Should set a color's value", () => {

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -41,8 +41,3 @@ export const setBrightness = (color: string, targetBrightness: number): string =
   const brightness = c.getBrightness()
   return c.brighten((targetBrightness / brightness) * 100 - 100).toString()
 }
-
-export const transparentize = (color: string) => (percentage: number): string =>
-  (({ r, g, b }) => {
-    return `rgba(${r}, ${g}, ${b}, ${percentage})`
-  })(colorCalculator(color).toRgb())

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -44,5 +44,5 @@ export const setBrightness = (color: string, targetBrightness: number): string =
 
 export const transparentize = (color: string) => (percentage: number): string =>
   (({ r, g, b }) => {
-    return `rgba(${r}, ${g}, ${b}, ${(255 * (100 - percentage)) / 100})`
+    return `rgba(${r}, ${g}, ${b}, ${percentage})`
   })(colorCalculator(color).toRgb())


### PR DESCRIPTION
Chip background colors now have an opacity of 0.1.

Also added: constant font weights.