### PR TITLE
Tooltip enhancements

### DIFF
--- a/packages/components/src/Input/Input.tsx
+++ b/packages/components/src/Input/Input.tsx
@@ -116,11 +116,6 @@ const InputField = styled("input")(
   }),
 )
 
-const HelpTooltip = styled(Tooltip)({
-  minWidth: 100,
-  width: "fit-content",
-})
-
 export const initialState = {
   showTooltip: false,
 }
@@ -191,7 +186,7 @@ class Input extends React.Component<PropsWithoutCopy | PropsWithCopy, State> {
             {props.hint ? (
               <FormFieldControl>
                 <Icon name="Question" size={14} />
-                <HelpTooltip right>{props.hint}</HelpTooltip>
+                <Tooltip right>{props.hint}</Tooltip>
               </FormFieldControl>
             ) : null}
             {props.onToggle ? (

--- a/packages/components/src/Tooltip/README.md
+++ b/packages/components/src/Tooltip/README.md
@@ -6,14 +6,14 @@ Tooltips give helpful hints about actions an end-user can perform. They are desi
 <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
   <div style={{ position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80 }}>
     <p>I am a box full of mysteries.</p>
-    <Tooltip>I uncover them all.</Tooltip>
-    <Tooltip right>A short one!</Tooltip>
+    <Tooltip top>All is clearer with tooltips</Tooltip>
+    <Tooltip right>Even short ones</Tooltip>
   </div>
   <div style={{ position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80 }}>
     <p>I am a box full of mysteries.</p>
-    <Tooltip bottom>I can be at the bottom instead!</Tooltip>
-    <Tooltip left>I can be on left instead!</Tooltip>
-    <Tooltip right>I can be on right instead!</Tooltip>
+    <Tooltip bottom>Bottom-positioned tooltip</Tooltip>
+    <Tooltip left>Tooltip from the left</Tooltip>
+    <Tooltip right>Tooltip from the right</Tooltip>
   </div>
 </div>
 ```

--- a/packages/components/src/Tooltip/README.md
+++ b/packages/components/src/Tooltip/README.md
@@ -7,10 +7,11 @@ Tooltips give helpful hints about actions an end-user can perform. They are desi
   <div style={{ position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80 }}>
     <p>I am a box full of mysteries.</p>
     <Tooltip>I uncover them all.</Tooltip>
+    <Tooltip right>A short one!</Tooltip>
   </div>
   <div style={{ position: "relative", border: "1px solid black", margin: 20, padding: 5, width: 80 }}>
     <p>I am a box full of mysteries.</p>
-    <Tooltip bottom>I can be on bottom instead!</Tooltip>
+    <Tooltip bottom>I can be at the bottom instead!</Tooltip>
     <Tooltip left>I can be on left instead!</Tooltip>
     <Tooltip right>I can be on right instead!</Tooltip>
   </div>

--- a/packages/components/src/Tooltip/Tooltip.Container.tsx
+++ b/packages/components/src/Tooltip/Tooltip.Container.tsx
@@ -1,0 +1,144 @@
+import * as React from "react"
+import styled from "react-emotion"
+import colorCalculator from "tinycolor2"
+
+import { OperationalStyleConstants } from "../utils/constants"
+import { Css } from "../types"
+
+export type Position = "top" | "left" | "right" | "bottom"
+
+const makeContainerPositionStyles = (position: Position) => {
+  switch (position) {
+    case "top":
+      return {
+        left: "50%",
+        top: -6,
+        transform: "translate3d(-50%, -100%, 0)",
+      }
+    case "bottom":
+      return {
+        left: "50%",
+        top: "100%",
+        transform: "translate3d(-50%, 6px, 0)",
+      }
+    case "left":
+      return {
+        top: "50%",
+        left: -6,
+        transform: "translate3d(-100%, -50%, 0)",
+      }
+    case "right":
+      return {
+        top: "50%",
+        right: -6,
+        transform: "translate3d(100%, -50%, 0)",
+      }
+  }
+}
+
+const makeCaretPositionStyles = (position: Position, backgroundColor: string): {} => {
+  switch (position) {
+    case "top":
+      return {
+        bottom: -4,
+        left: `calc(50% - 6px)`,
+        borderLeft: "6px solid transparent",
+        borderRight: "6px solid transparent",
+        borderTop: `6px solid ${backgroundColor}`,
+      }
+    case "bottom":
+      return {
+        top: -4,
+        left: `calc(50% - 6px)`,
+        borderLeft: "6px solid transparent",
+        borderRight: "6px solid transparent",
+        borderBottom: `6px solid ${backgroundColor}`,
+      }
+    case "left":
+      return {
+        right: -4,
+        top: `calc(50% - 6px)`,
+        borderTop: "6px solid transparent",
+        borderBottom: "6px solid transparent",
+        borderLeft: `6px solid ${backgroundColor}`,
+      }
+    case "right":
+      return {
+        left: -4,
+        top: `calc(50% - 6px)`,
+        borderTop: "6px solid transparent",
+        borderBottom: "6px solid transparent",
+        borderRight: `6px solid ${backgroundColor}`,
+      }
+  }
+}
+
+export const Container = styled("div")(
+  ({
+    position,
+    offScreenWidthTest,
+    singleLineTextWidth,
+    theme,
+  }: {
+    position: Position
+    offScreenWidthTest?: boolean
+    singleLineTextWidth: number
+    theme?: OperationalStyleConstants
+  }) => {
+    const backgroundColor = colorCalculator(theme.color.black)
+      .setAlpha(0.9)
+      .toString()
+    return {
+      backgroundColor,
+      label: "tooltip",
+      color: theme.color.white,
+      position: "absolute",
+      zIndex: theme.zIndex.tooltip,
+      borderRadius: 2,
+      boxShadow: "0 2px 6px rgba(0, 0, 0, .15)",
+      "& > p": {
+        fontSize: 11,
+        lineHeight: 1.3,
+        margin: 0,
+        padding: "2px 6px",
+        textAlign: "center",
+      },
+      ...(offScreenWidthTest
+        ? {
+            width: "fit-content",
+            whiteSpace: "nowrap",
+            position: "fixed",
+            opacity: 0.01,
+            top: -200,
+            left: -200,
+          }
+        : {
+            // If there was an issue determining singleLineTextWidth, default to the 150px width
+            // Otherwise, honor the single line text width unless greater than 150px.
+            width: singleLineTextWidth === 0 ? 150 : Math.min(singleLineTextWidth + 4, 150),
+          }),
+      ...makeContainerPositionStyles(position),
+      // This pseudo-element extends the clickable area of a tooltip extending enough to disappear as the mouse moves over to the caret.
+      "&::after": {
+        content: "''",
+        position: "absolute",
+        top: 0,
+        left: -32,
+        display: "block",
+        width: -32,
+        height: "100%",
+      },
+      // They say behind every great tooltip is a great caret.
+      "&::before": {
+        content: "''",
+        position: "absolute",
+        zIndex: theme.zIndex.tooltip,
+        width: 0,
+        height: 0,
+        ...makeCaretPositionStyles(position, backgroundColor),
+      },
+    }
+  },
+)
+
+export default Container

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -161,7 +161,7 @@ const Container = styled("div")(
       "&::before": {
         content: "''",
         position: "absolute",
-        zIndex: theme.deprecated.baseZIndex - 1,
+        zIndex: theme.zIndex.tooltip,
         width: 0,
         height: 0,
         ...pointerTrianglePositionStyles(position, backgroundColor),

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -122,9 +122,9 @@ const Container = styled("div")(
       label: "tooltip",
       color: theme.color.white,
       position: "absolute",
-      zIndex: theme.deprecated.baseZIndex + 101,
+      zIndex: theme.zIndex.tooltip,
       borderRadius: 2,
-      boxShadow: theme.deprecated.shadows.popup,
+      boxShadow: "0 2px 6px rgba(0, 0, 0, .15)",
       "& > p": {
         fontSize: 11,
         lineHeight: 1.3,
@@ -147,14 +147,14 @@ const Container = styled("div")(
             width: singleLineTextWidth === 0 ? 150 : Math.min(singleLineTextWidth + 4, 150),
           }),
       ...containerPositionStyles(position),
-      // This pseudo-element extends the clickable area of the far-away tooltip.
+      // This pseudo-element extends the clickable area of a tooltip extending enough to disappear as the mouse moves over to the caret.
       "&::after": {
         content: "''",
         position: "absolute",
         top: 0,
-        left: theme.deprecated.spacing * -2,
+        left: -32,
         display: "block",
-        width: theme.deprecated.spacing * 2,
+        width: -32,
         height: "100%",
       },
       // They say behind every great tooltip is a great caret.

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -1,158 +1,184 @@
 import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants } from "../utils/constants"
-import { readableTextColor } from "@operational/utils"
+import colorCalculator from "tinycolor2"
 import { Css } from "../types"
 
 /**
- * Accepting top/left/right/bottom props is a bit redundant, but it makes for a nice casual API:
- * <Tooltip top/>, as opposed to <Tooltip position="top"/>
- * It gets translated into the Position type inside the component, so it allows for a more
- * straightforward implementation.
+ * In order to allow for tooltips that have a sensible max-width that adjusts its width for shorter text,
+ * and in order to have that working reliably across browsers, this implementation renders the tooltip offscreen
+ * in order to determine how wide it would be were it to not do line breaks at any width.
+ * The actual tooltip is rendered with this information extracted from the DOM node.
  */
+
 export interface Props {
   className?: string
   children?: React.ReactNode
   /** Smart-positioned tooltip, with positioning reversed so it doesn't flow out of the window's bounding box. Currently works for left and top-positioned tooltips. */
-
   smart?: boolean
   /** Top-positioned tooltip */
-
   top?: boolean
   /** Left-positioned tooltip */
-
   left?: boolean
   /** Right-positioned tooltip */
-
   right?: boolean
   /** Bottom-positioned tooltip */
-
   bottom?: boolean
-} // bbTop is an abbreviation of boundingBoxTop
+}
 
 export interface State {
+  // bbTop is an abbreviation of boundingBoxTop
   bbTop: number
   bbBottom: number
   bbLeft: number
   bbRight: number
+  singleLineTextWidth: number
 }
 
 type Position = "top" | "left" | "right" | "bottom"
 
-const Container = styled("div")(({ position, theme }: { position: Position; theme?: OperationalStyleConstants }) => {
-  const backgroundColor = theme.deprecated.colors.black
-  return {
-    backgroundColor,
-    label: "tooltip",
-    ...theme.deprecated.typography.small,
-    lineHeight: 1.3,
-    position: "absolute",
-    zIndex: theme.deprecated.baseZIndex + 101,
-    width: "fit-content",
-    minWidth: 80,
-    maxWidth: 360,
-    whiteSpace: "nowrap",
-    padding: `${theme.deprecated.spacing / 3}px ${(theme.deprecated.spacing * 2) / 3}px`,
-    borderRadius: 2,
-    boxShadow: theme.deprecated.shadows.popup,
-    ...(() => {
-      if (position === "top") {
-        return {
-          left: "50%",
-          transform: "translate3d(-50%, calc(-100% - 6px), 0)",
-        }
-      }
-
-      if (position === "bottom") {
-        return {
-          left: "50%",
-          top: "100%",
-          transform: "translate3d(-50%, 6px, 0)",
-        }
-      }
-
-      if (position === "left") {
-        return {
-          top: "50%",
-          left: -6,
-          transform: "translate3d(-100%, -50%, 0)",
-        }
-      }
-
-      if (position === "right") {
-        return {
-          top: "50%",
-          right: -6,
-          transform: "translate3d(100%, -50%, 0)",
-        }
-      }
-
-      return {}
-    })(),
-    color: readableTextColor(backgroundColor, ["black", "white"]),
-    // This pseudo-element extends the clickable area of the far-away tooltip.
-    "&::after": {
-      content: "''",
+const Container = styled("div")(
+  ({
+    position,
+    offScreenWidthTest,
+    singleLineTextWidth,
+    theme,
+  }: {
+    position: Position
+    offScreenWidthTest?: boolean
+    singleLineTextWidth: number
+    theme?: OperationalStyleConstants
+  }) => {
+    const backgroundColor = colorCalculator(theme.color.black)
+      .setAlpha(0.9)
+      .toString()
+    return {
+      backgroundColor,
+      label: "tooltip",
+      color: theme.color.white,
       position: "absolute",
-      top: 0,
-      left: theme.deprecated.spacing * -2,
-      display: "block",
-      width: theme.deprecated.spacing * 2,
-      height: "100%",
-    },
-    // They say behind every great tooltip is a great caret.
-    "&::before": {
-      content: "''",
-      position: "absolute",
-      zIndex: theme.deprecated.baseZIndex - 1,
-      width: 0,
-      height: 0,
+      zIndex: theme.deprecated.baseZIndex + 101,
+      borderRadius: 2,
+      boxShadow: theme.deprecated.shadows.popup,
+      "& > p": {
+        fontSize: 11,
+        lineHeight: 1.3,
+        margin: 0,
+        padding: "2px 6px",
+        textAlign: "center",
+      },
+      ...(offScreenWidthTest
+        ? {
+            width: "fit-content",
+            whiteSpace: "nowrap",
+            position: "fixed",
+            opacity: 0.01,
+            top: -200,
+            left: -200,
+          }
+        : {
+            // If there was an issue determining singleLineTextWidth, default to the 150px width
+            // Otherwise, honor the single line text width unless greater than 150px.
+            width: singleLineTextWidth === 0 ? 150 : Math.min(singleLineTextWidth + 4, 150),
+          }),
       ...(() => {
         if (position === "top") {
           return {
-            bottom: -4,
-            left: `calc(50% - 6px)`,
-            borderLeft: "6px solid transparent",
-            borderRight: "6px solid transparent",
-            borderTop: `6px solid ${backgroundColor}`,
+            left: "50%",
+            transform: "translate3d(-50%, calc(-100% - 6px), 0)",
           }
         }
 
         if (position === "bottom") {
           return {
-            top: -4,
-            left: `calc(50% - 6px)`,
-            borderLeft: "6px solid transparent",
-            borderRight: "6px solid transparent",
-            borderBottom: `6px solid ${backgroundColor}`,
+            left: "50%",
+            top: "100%",
+            transform: "translate3d(-50%, 6px, 0)",
           }
         }
 
         if (position === "left") {
           return {
-            right: -4,
-            top: `calc(50% - 6px)`,
-            borderTop: "6px solid transparent",
-            borderBottom: "6px solid transparent",
-            borderLeft: `6px solid ${backgroundColor}`,
+            top: "50%",
+            left: -6,
+            transform: "translate3d(-100%, -50%, 0)",
           }
         }
 
         if (position === "right") {
           return {
-            left: -4,
-            top: `calc(50% - 6px)`,
-            borderTop: "6px solid transparent",
-            borderBottom: "6px solid transparent",
-            borderRight: `6px solid ${backgroundColor}`,
+            top: "50%",
+            right: -6,
+            transform: "translate3d(100%, -50%, 0)",
           }
         }
 
         return {}
       })(),
-    },
-  }
-})
+      // This pseudo-element extends the clickable area of the far-away tooltip.
+      "&::after": {
+        content: "''",
+        position: "absolute",
+        top: 0,
+        left: theme.deprecated.spacing * -2,
+        display: "block",
+        width: theme.deprecated.spacing * 2,
+        height: "100%",
+      },
+      // They say behind every great tooltip is a great caret.
+      "&::before": {
+        content: "''",
+        position: "absolute",
+        zIndex: theme.deprecated.baseZIndex - 1,
+        width: 0,
+        height: 0,
+        ...(() => {
+          if (position === "top") {
+            return {
+              bottom: -4,
+              left: `calc(50% - 6px)`,
+              borderLeft: "6px solid transparent",
+              borderRight: "6px solid transparent",
+              borderTop: `6px solid ${backgroundColor}`,
+            }
+          }
+
+          if (position === "bottom") {
+            return {
+              top: -4,
+              left: `calc(50% - 6px)`,
+              borderLeft: "6px solid transparent",
+              borderRight: "6px solid transparent",
+              borderBottom: `6px solid ${backgroundColor}`,
+            }
+          }
+
+          if (position === "left") {
+            return {
+              right: -4,
+              top: `calc(50% - 6px)`,
+              borderTop: "6px solid transparent",
+              borderBottom: "6px solid transparent",
+              borderLeft: `6px solid ${backgroundColor}`,
+            }
+          }
+
+          if (position === "right") {
+            return {
+              left: -4,
+              top: `calc(50% - 6px)`,
+              borderTop: "6px solid transparent",
+              borderBottom: "6px solid transparent",
+              borderRight: `6px solid ${backgroundColor}`,
+            }
+          }
+
+          return {}
+        })(),
+      },
+    }
+  },
+)
 
 class Tooltip extends React.Component<Props, State> {
   state = {
@@ -160,18 +186,29 @@ class Tooltip extends React.Component<Props, State> {
     bbLeft: 0,
     bbRight: 0,
     bbBottom: 0,
+    singleLineTextWidth: 0,
   }
 
   containerNode: HTMLElement
+  offScreenWidthTestNode: HTMLElement
 
-  componentDidMount() {
+  setDomProperties() {
+    if (!this.offScreenWidthTestNode || !this.containerNode) {
+      return
+    }
+    const bbOffScreen = this.offScreenWidthTestNode.getBoundingClientRect()
     const bbRect = this.containerNode.getBoundingClientRect()
     this.setState(prevState => ({
       bbTop: bbRect.top,
       bbBottom: bbRect.bottom,
       bbLeft: bbRect.left,
       bbRight: bbRect.right,
+      singleLineTextWidth: bbOffScreen.width,
     }))
+  }
+
+  componentDidMount() {
+    this.setDomProperties()
   }
 
   render() {
@@ -203,14 +240,30 @@ class Tooltip extends React.Component<Props, State> {
     }
 
     return (
-      <Container
-        position={position}
-        innerRef={node => {
-          this.containerNode = node
-        }}
-      >
-        {this.props.children}
-      </Container>
+      <>
+        {/* Test node rendered to determine how wide the text is if it were written in a single line. */}
+        <Container
+          position="bottom"
+          offScreenWidthTest
+          singleLineTextWidth={this.state.singleLineTextWidth}
+          innerRef={node => {
+            this.offScreenWidthTestNode = node
+          }}
+        >
+          {/* Wrapping in a paragraph tag is necessary in order to have Safari read the correct single line width. */}
+          <p>{this.props.children}</p>
+        </Container>
+        <Container
+          singleLineTextWidth={this.state.singleLineTextWidth}
+          position={position}
+          innerRef={node => {
+            this.containerNode = node
+          }}
+        >
+          {/* Wrapping in a paragraph tag is necessary in order to have Safari read the correct single line width. */}
+          <p>{this.props.children}</p>
+        </Container>
+      </>
     )
   }
 }

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -37,6 +37,71 @@ export interface State {
 
 type Position = "top" | "left" | "right" | "bottom"
 
+const containerPositionStyles = (position: Position): {} => {
+  switch (position) {
+    case "top":
+      return {
+        left: "50%",
+        transform: "translate3d(-50%, calc(-100% - 6px), 0)",
+      }
+    case "bottom":
+      return {
+        left: "50%",
+        top: "100%",
+        transform: "translate3d(-50%, 6px, 0)",
+      }
+    case "left":
+      return {
+        top: "50%",
+        left: -6,
+        transform: "translate3d(-100%, -50%, 0)",
+      }
+    case "right":
+      return {
+        top: "50%",
+        right: -6,
+        transform: "translate3d(100%, -50%, 0)",
+      }
+  }
+}
+
+const pointerTrianglePositionStyles = (position: Position, backgroundColor: string): {} => {
+  switch (position) {
+    case "top":
+      return {
+        bottom: -4,
+        left: `calc(50% - 6px)`,
+        borderLeft: "6px solid transparent",
+        borderRight: "6px solid transparent",
+        borderTop: `6px solid ${backgroundColor}`,
+      }
+    case "bottom":
+      return {
+        top: -4,
+        left: `calc(50% - 6px)`,
+        borderLeft: "6px solid transparent",
+        borderRight: "6px solid transparent",
+        borderBottom: `6px solid ${backgroundColor}`,
+      }
+    case "left":
+      return {
+        right: -4,
+        top: `calc(50% - 6px)`,
+        borderTop: "6px solid transparent",
+        borderBottom: "6px solid transparent",
+        borderLeft: `6px solid ${backgroundColor}`,
+      }
+    case "right":
+      return {
+        left: -4,
+        top: `calc(50% - 6px)`,
+        borderTop: "6px solid transparent",
+        borderBottom: "6px solid transparent",
+        borderRight: `6px solid ${backgroundColor}`,
+      }
+  }
+}
+
 const Container = styled("div")(
   ({
     position,
@@ -81,40 +146,7 @@ const Container = styled("div")(
             // Otherwise, honor the single line text width unless greater than 150px.
             width: singleLineTextWidth === 0 ? 150 : Math.min(singleLineTextWidth + 4, 150),
           }),
-      ...(() => {
-        if (position === "top") {
-          return {
-            left: "50%",
-            transform: "translate3d(-50%, calc(-100% - 6px), 0)",
-          }
-        }
-
-        if (position === "bottom") {
-          return {
-            left: "50%",
-            top: "100%",
-            transform: "translate3d(-50%, 6px, 0)",
-          }
-        }
-
-        if (position === "left") {
-          return {
-            top: "50%",
-            left: -6,
-            transform: "translate3d(-100%, -50%, 0)",
-          }
-        }
-
-        if (position === "right") {
-          return {
-            top: "50%",
-            right: -6,
-            transform: "translate3d(100%, -50%, 0)",
-          }
-        }
-
-        return {}
-      })(),
+      ...containerPositionStyles(position),
       // This pseudo-element extends the clickable area of the far-away tooltip.
       "&::after": {
         content: "''",
@@ -132,49 +164,7 @@ const Container = styled("div")(
         zIndex: theme.deprecated.baseZIndex - 1,
         width: 0,
         height: 0,
-        ...(() => {
-          if (position === "top") {
-            return {
-              bottom: -4,
-              left: `calc(50% - 6px)`,
-              borderLeft: "6px solid transparent",
-              borderRight: "6px solid transparent",
-              borderTop: `6px solid ${backgroundColor}`,
-            }
-          }
-
-          if (position === "bottom") {
-            return {
-              top: -4,
-              left: `calc(50% - 6px)`,
-              borderLeft: "6px solid transparent",
-              borderRight: "6px solid transparent",
-              borderBottom: `6px solid ${backgroundColor}`,
-            }
-          }
-
-          if (position === "left") {
-            return {
-              right: -4,
-              top: `calc(50% - 6px)`,
-              borderTop: "6px solid transparent",
-              borderBottom: "6px solid transparent",
-              borderLeft: `6px solid ${backgroundColor}`,
-            }
-          }
-
-          if (position === "right") {
-            return {
-              left: -4,
-              top: `calc(50% - 6px)`,
-              borderTop: "6px solid transparent",
-              borderBottom: "6px solid transparent",
-              borderRight: `6px solid ${backgroundColor}`,
-            }
-          }
-
-          return {}
-        })(),
+        ...pointerTrianglePositionStyles(position, backgroundColor),
       },
     }
   },

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -42,7 +42,8 @@ const containerPositionStyles = (position: Position): {} => {
     case "top":
       return {
         left: "50%",
-        transform: "translate3d(-50%, calc(-100% - 6px), 0)",
+        top: -6,
+        transform: "translate3d(-50%, -100%, 0)",
       }
     case "bottom":
       return {
@@ -202,7 +203,7 @@ class Tooltip extends React.Component<Props, State> {
   }
 
   render() {
-    let position: Position = "top"
+    let position: Position = "right"
 
     if (this.props.left) {
       position = "left"
@@ -214,6 +215,10 @@ class Tooltip extends React.Component<Props, State> {
 
     if (this.props.bottom) {
       position = "bottom"
+    }
+
+    if (this.props.top) {
+      position = "top"
     }
 
     if (this.props.smart) {

--- a/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltip Component Should intialize without problems 1`] = `
 <div
-  class="css-17ozxo2-tooltip"
+  class="css-1fsb7at-tooltip"
 >
   <p>
     Hello

--- a/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltip Component Should intialize without problems 1`] = `
 <div
-  class="css-1fsb7at-tooltip"
+  class="css-mt2a1r-tooltip"
 >
   <p>
     Hello

--- a/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -2,8 +2,10 @@
 
 exports[`Tooltip Component Should intialize without problems 1`] = `
 <div
-  class="css-19croas-tooltip"
+  class="css-17ozxo2-tooltip"
 >
-  Hello
+  <p>
+    Hello
+  </p>
 </div>
 `;

--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -150,6 +150,7 @@ const zIndex = {
   default: 0,
   selectOptions: 300,
   formFieldError: 299,
+  tooltip: 400,
 }
 
 const constants = {

--- a/packages/components/src/utils/mixins.ts
+++ b/packages/components/src/utils/mixins.ts
@@ -32,6 +32,8 @@ export const FormFieldControls = styled("div")({
   right: 0,
 })
 
+const formFieldControlTooltipSelector = "& > :nth-child(2), & > :nth-child(3)"
+
 export const FormFieldControl = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
   position: "relative",
   verticalAlign: "middle",
@@ -41,18 +43,16 @@ export const FormFieldControl = styled("div")(({ theme }: { theme?: OperationalS
   "& svg": {
     opacity: 0.4,
     position: "relative",
-    top: -1,
   },
-  // :nth-child(2) refers to the tooltip
-  "& > :nth-child(2)": {
-    display: "none",
+  [formFieldControlTooltipSelector]: {
+    opacity: 0.01,
   },
   ":hover": {
     "& svg": {
       opacity: 1,
     },
-    "& > :nth-child(2)": {
-      display: "block",
+    [formFieldControlTooltipSelector]: {
+      opacity: 1,
     },
   },
 }))

--- a/packages/components/src/utils/mixins.ts
+++ b/packages/components/src/utils/mixins.ts
@@ -1,7 +1,8 @@
 import React from "react"
 import styled from "react-emotion"
-import { OperationalStyleConstants } from "../utils/constants"
 import { lighten } from "@operational/utils"
+import { OperationalStyleConstants } from "./constants"
+import TooltipContainer from "../Tooltip/Tooltip.Container"
 
 export const inputFocus = ({ theme, isError }: { theme?: OperationalStyleConstants; isError?: boolean }) => ({
   outline: 0,
@@ -32,8 +33,6 @@ export const FormFieldControls = styled("div")({
   right: 0,
 })
 
-const formFieldControlTooltipSelector = "& > :nth-child(2), & > :nth-child(3)"
-
 export const FormFieldControl = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
   position: "relative",
   verticalAlign: "middle",
@@ -44,14 +43,14 @@ export const FormFieldControl = styled("div")(({ theme }: { theme?: OperationalS
     opacity: 0.4,
     position: "relative",
   },
-  [formFieldControlTooltipSelector]: {
+  [TooltipContainer as any]: {
     opacity: 0.01,
   },
   ":hover": {
     "& svg": {
       opacity: 1,
     },
-    [formFieldControlTooltipSelector]: {
+    [TooltipContainer as any]: {
       opacity: 1,
     },
   },


### PR DESCRIPTION
Fine-tunes tooltip component as per https://trello.com/c/6t2zTG0M/221-fine-tune-tooltip-component. Also fixes a safari bug where the tooltip can't shrink to very short texts, using off-screen rendering.

<img width="386" alt="screen shot 2018-07-03 at 3 19 40 pm" src="https://user-images.githubusercontent.com/6738398/42222144-8bb2e36e-7ed4-11e8-8d68-17ed9f84bc5d.png">