### PR TITLE
Added cases to components that we'll need for other UIs

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,10 +1,9 @@
 import * as React from "react"
 import styled, { Interpolation } from "react-emotion"
-import { readableTextColor, darken, lighten } from "@operational/utils"
+import { readableTextColor, darken } from "@operational/utils"
 
 import { OperationalStyleConstants, expandColor } from "../utils/constants"
 import { isWhite, isModifiedEvent } from "../utils"
-import { Css } from "../types"
 import { ContextConsumer, Context, Icon, IconName } from "../"
 import Spinner from "../Spinner/Spinner"
 
@@ -26,6 +25,8 @@ export interface Props {
   disabled?: boolean
   /** Condensed option */
   condensed?: boolean
+  /** Should the button fill its container? */
+  fill?: boolean
   children?: React.ReactNode
 }
 
@@ -50,7 +51,7 @@ const containerStyles: Interpolation<Props> = ({
   disabled,
   condensed,
   loading,
-  icon,
+  fill,
 }: PropsWithTheme) => {
   const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color)
   return {
@@ -71,6 +72,7 @@ const containerStyles: Interpolation<Props> = ({
     opacity: disabled ? 0.6 : 1.0,
     outline: "none",
     position: "relative",
+    width: fill ? "100%" : "initial",
     // Apply styles with increased specificity to override defaults
     "&, a:link&, a:visited&": {
       textDecoration: "none",
@@ -90,10 +92,10 @@ const containerStyles: Interpolation<Props> = ({
 const Container = styled("button")(containerStyles)
 const ContainerLink = styled("a")(containerStyles)
 
-const IconContainer = styled("div")(({ theme }: Css) => ({
+const IconContainer = styled("div")({
   display: "flex",
   alignItems: "center",
-}))
+})
 
 const ButtonSpinner = styled(Spinner)(
   ({ theme, containerColor }: { theme?: OperationalStyleConstants; containerColor: string }) => ({
@@ -111,10 +113,7 @@ const Button = (props: Props) => {
     <ContextConsumer>
       {(ctx: Context) => (
         <ContainerComponent
-          type={props.type}
-          id={props.id}
-          href={props.to}
-          className={props.className}
+          {...props}
           onClick={(ev: React.SyntheticEvent<Node>) => {
             if (props.disabled) {
               ev.preventDefault()
@@ -128,16 +127,11 @@ const Button = (props: Props) => {
               ctx.pushState(props.to)
             }
           }}
-          color={props.color}
-          loading={props.loading}
-          disabled={props.disabled}
-          condensed={props.condensed}
-          icon={props.icon}
           title={props.loading && props.children === String(props.children) ? String(props.children) : undefined}
         >
           {props.children}
           {props.icon && (
-            <IconContainer condensed={props.condensed}>
+            <IconContainer>
               {typeof props.icon === "string" ? <Icon right name={props.icon as IconName} size={18} /> : props.icon}
             </IconContainer>
           )}

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -18,7 +18,7 @@ export interface Props {
   /** Color assigned to the avatar circle (hex or named color from `theme.color`) */
   color?: string
   /** Icon to display on right of button (optional) */
-  icon?: string | React.ReactNode
+  icon?: IconName
   /** Loading flag - if enabled, the text hides and a spinner appears in the center */
   loading?: boolean
   /** Disabled option */
@@ -26,7 +26,7 @@ export interface Props {
   /** Condensed option */
   condensed?: boolean
   /** Should the button fill its container? */
-  fill?: boolean
+  fullWidth?: boolean
   children?: React.ReactNode
 }
 
@@ -51,7 +51,7 @@ const containerStyles: Interpolation<Props> = ({
   disabled,
   condensed,
   loading,
-  fill,
+  fullWidth,
 }: PropsWithTheme) => {
   const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color)
   return {
@@ -72,7 +72,7 @@ const containerStyles: Interpolation<Props> = ({
     opacity: disabled ? 0.6 : 1.0,
     outline: "none",
     position: "relative",
-    width: fill ? "100%" : "initial",
+    width: fullWidth ? "100%" : "initial",
     // Apply styles with increased specificity to override defaults
     "&, a:link&, a:visited&": {
       textDecoration: "none",
@@ -130,11 +130,7 @@ const Button = (props: Props) => {
           title={props.loading && props.children === String(props.children) ? String(props.children) : undefined}
         >
           {props.children}
-          {props.icon && (
-            <IconContainer>
-              {typeof props.icon === "string" ? <Icon right name={props.icon as IconName} size={18} /> : props.icon}
-            </IconContainer>
-          )}
+          {props.icon && <Icon right name={props.icon} size={18} />}
           {props.loading && <ButtonSpinner containerColor={props.color} />}
         </ContainerComponent>
       )}

--- a/packages/components/src/Button/README.md
+++ b/packages/components/src/Button/README.md
@@ -36,7 +36,13 @@ Using buttons is as simple as including the component with a text node as a chil
 Using a `to` prop navigates automatically, and render proper anchor tags with hrefs. See `OperationalUI` docs for a one-time configuration you need to do to have pushstate navigation working out-of-the-box.
 
 ```jsx
-<Button color="info" to="/some-url">
-  Button One
+<Button to="/some-url">Button One</Button>
+```
+
+### Full-width Buttons
+
+```jsx
+<Button fill color="grey">
+  I want to lose weight
 </Button>
 ```

--- a/packages/components/src/Button/README.md
+++ b/packages/components/src/Button/README.md
@@ -42,7 +42,7 @@ Using a `to` prop navigates automatically, and render proper anchor tags with hr
 ### Full-width Buttons
 
 ```jsx
-<Button fill color="grey">
+<Button fullWidth color="grey">
   I want to lose weight
 </Button>
 ```

--- a/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
+++ b/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
@@ -11,27 +11,33 @@ export interface LogoProps {
 
   /** A color from the constants, or an arbitrary hex value */
   color?: keyof OperationalStyleConstants["color"] | string
+
+  /** Do we want it stacked vertically? */
+  stack?: boolean
 }
 
 const LogoContainer = styled("div")(
   {
-    display: "flex",
+    display: "inline-flex",
     alignItems: "center",
     height: "100%",
   },
-  ({ size }: LogoProps & WithTheme) => ({
+  ({ size, stack }: LogoProps & WithTheme) => ({
     width: size,
+    display: "flex",
+    flexDirection: stack ? "column" : "row",
   }),
 )
 
-const LogoType = styled("svg")(({ theme, color }: LogoProps & WithTheme) => ({
+const LogoType = styled("svg")(({ theme, stack, color }: LogoProps & WithTheme) => ({
   fill: expandColor(theme, color) || theme.color.white,
+  marginTop: stack ? theme.space.element : 0,
 }))
 
-const ContiamoLogo: React.SFC<LogoProps> = ({ size, color }) => (
-  <LogoContainer>
+const ContiamoLogo: React.SFC<LogoProps> = ({ size, color, stack }) => (
+  <LogoContainer stack={stack}>
     <Icon left name="Contiamo" size={size} color={color} />
-    <LogoType color={color} width={size * 3.5} viewBox="650 255 1800 215" fill="currentColor">
+    <LogoType stack={stack} color={color} width={size * 3.5} viewBox="650 255 1800 215" fill="currentColor">
       <title>Contiamo</title>
       <g transform="matrix(1.3333333,0,0,-1.3333333,0,737.64133)">
         <g transform="translate(783.6366,282.649)">
@@ -64,6 +70,7 @@ const ContiamoLogo: React.SFC<LogoProps> = ({ size, color }) => (
 ContiamoLogo.defaultProps = {
   size: 26,
   color: "white",
+  stack: false,
 }
 
 export default ContiamoLogo

--- a/packages/components/src/ContiamoLogo/README.md
+++ b/packages/components/src/ContiamoLogo/README.md
@@ -19,3 +19,9 @@ This component provides a Contiamo logo for use out of the box. It is typically 
 ```jsx
 <ContiamoLogo color="black" size={200} />
 ```
+
+#### Stacked
+
+```jsx
+<ContiamoLogo size={35} color="#747474" stack />
+```

--- a/packages/components/src/Input/Input.tsx
+++ b/packages/components/src/Input/Input.tsx
@@ -33,6 +33,8 @@ export interface Props {
   hint?: string
   /** Disabled input */
   disabled?: boolean
+  /** Should the input fill its container? */
+  fullWidth?: boolean
   onToggle?: () => void
 }
 
@@ -55,12 +57,20 @@ const inputHeight = 36
 
 const InputFieldContainer = styled("div")`
   position: relative;
-  min-width: 360px;
   align-items: center;
   justify-content: center;
-  ${({ withLabel, theme }: { withLabel?: boolean; theme?: OperationalStyleConstants }) => `
+  ${({
+    fullWidth,
+    withLabel,
+    theme,
+  }: {
+    fullWidth: Props["fullWidth"]
+    withLabel?: boolean
+    theme?: OperationalStyleConstants
+  }) => `
     margin-right: ${withLabel ? 0 : theme.space.small}px;
     display: ${withLabel ? "flex" : "inline-flex"};
+    min-width: ${fullWidth ? "100%" : 360};
   `};
 `
 
@@ -180,7 +190,7 @@ class Input extends React.Component<PropsWithoutCopy | PropsWithCopy, State> {
 
     if (props.label) {
       return (
-        <Label id={props.id} htmlFor={forAttributeId} className={props.className} left>
+        <Label fullWidth={props.fullWidth} id={props.id} htmlFor={forAttributeId} className={props.className} left>
           <LabelText>{props.label}</LabelText>
           <FormFieldControls>
             {props.hint ? (
@@ -199,7 +209,7 @@ class Input extends React.Component<PropsWithoutCopy | PropsWithCopy, State> {
               </FormFieldControl>
             ) : null}
           </FormFieldControls>
-          <InputFieldContainer withLabel>
+          <InputFieldContainer fullWidth={props.fullWidth} withLabel>
             {inputButtonElement}
             <InputField
               {...commonInputProps}
@@ -214,7 +224,7 @@ class Input extends React.Component<PropsWithoutCopy | PropsWithCopy, State> {
     }
 
     return (
-      <InputFieldContainer>
+      <InputFieldContainer fullWidth={props.fullWidth}>
         {inputButtonElement}
         <InputField
           {...commonInputProps}

--- a/packages/components/src/Input/README.md
+++ b/packages/components/src/Input/README.md
@@ -60,3 +60,17 @@ You can have a field with a "copy to clipboard" button with the `copy` prop.
 ```jsx
 <Input value="go to my clipboard!" label="Something to save" copy />
 ```
+
+### Full Width
+
+#### With Label
+
+```jsx
+<Input fullWidth value="Dave the Sheep" label="Hi, my name is" />
+```
+
+#### Without a Label
+
+```jsx
+<Input fullWidth value="I feel naked" />
+```

--- a/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button Component Should initialize properly 1`] = `
 <button
-  class="css-j26hxv-button"
+  class="css-1p16o1e-button"
 >
   hi
 </button>

--- a/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   class="css-1h5oz0d-buttongroup"
 >
   <button
-    class="css-j26hxv-button"
+    class="css-1p16o1e-button"
   >
     Hello
   </button>

--- a/packages/components/src/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Input.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Input Should initialize 1`] = `
 <div
-  class="css-wgfiur"
+  class="css-1fh0ram"
 >
   <input
     class="hi css-c8tup6-input"

--- a/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/packages/components/src/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Paginator Component Should initialize properly 1`] = `
   class="css-1pxqklq-paginator"
 >
   <button
-    class="css-1pwb8ty-button"
+    class="css-h85arf-button"
   >
     first
   </button>
   <button
-    class="css-1pwb8ty-button"
+    class="css-h85arf-button"
   >
     <svg
       fill="none"
@@ -43,7 +43,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
      of 258
   </div>
   <button
-    class="css-1pwb8ty-button"
+    class="css-h85arf-button"
   >
     <span>
       next
@@ -68,7 +68,7 @@ exports[`Paginator Component Should initialize properly 1`] = `
     </svg>
   </button>
   <button
-    class="css-1pwb8ty-button"
+    class="css-h85arf-button"
   >
     last
   </button>

--- a/packages/components/src/utils/mixins.ts
+++ b/packages/components/src/utils/mixins.ts
@@ -11,12 +11,14 @@ export const inputFocus = ({ theme, isError }: { theme?: OperationalStyleConstan
   boxShadow: `0 0 0 3px ${isError ? lighten(theme.color.error, 60) : lighten(theme.color.primary, 40)}`,
 })
 
-export const Label = styled("label")(({ theme, left }: { theme?: OperationalStyleConstants; left?: boolean }) => ({
-  display: "inline-block",
-  position: "relative",
-  minWidth: 360,
-  marginRight: left ? theme.space.small : 0,
-}))
+export const Label = styled("label")(
+  ({ fullWidth, theme, left }: { fullWidth?: boolean; theme?: OperationalStyleConstants; left?: boolean }) => ({
+    display: "inline-block",
+    position: "relative",
+    minWidth: fullWidth ? "100%" : 360,
+    marginRight: left ? theme.space.small : 0,
+  }),
+)
 
 export const LabelText = styled("span")(({ theme }: { theme?: OperationalStyleConstants }) => ({
   fontSize: theme.font.size.fineprint,


### PR DESCRIPTION
This PR adds the possibility to have a full-width login button, and a stacked Contiamo logo in order to support the following screenshot:

![image](https://user-images.githubusercontent.com/9947422/42232082-ab4d2fd6-7eed-11e8-8827-0b41df4f79c6.png)

Also updated `Input` to support a `fullWidth` prop.
