### PR TITLE
Add colorMapper util

### DIFF
--- a/packages/components/src/Avatar/Avatar.tsx
+++ b/packages/components/src/Avatar/Avatar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants, expandColor } from "../utils/constants"
+import { colorMapper } from "../utils/color"
 import { readableTextColor, getInitials } from "@operational/utils"
 
 export interface Props {
@@ -67,7 +68,7 @@ const Picture = styled("div")(
   }: {
     theme?: OperationalStyleConstants
     color?: Props["color"]
-    colorAssignment?: number
+    colorAssignment?: string
     photo?: Props["photo"]
     showName: Props["showName"]
     addBorder: Props["addBorder"]
@@ -76,7 +77,7 @@ const Picture = styled("div")(
     const defaultColor: string = theme.color.primary
     const fixedBackgroundColor: string = color ? expandColor(theme, color) || defaultColor : defaultColor
     const assignedBackgroundColor: null | string = colorAssignment
-      ? theme.color.palette[colorAssignment % theme.color.palette.length]
+      ? colorMapper(theme.color.palette)(colorAssignment)
       : null
     const backgroundColor = assignedBackgroundColor || fixedBackgroundColor
     const textColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
@@ -119,19 +120,12 @@ const Picture = styled("div")(
 
 const Avatar: React.SFC<Props> = props => {
   const initials = getInitials(props.name)
-  const colorAssignmentNumber =
-    props.assignColor && !props.color
-      ? [initials.charCodeAt(0), initials.charCodeAt(1)].reduce(
-          (accumulator, current) => accumulator + (!current || isNaN(current) ? 0 : current),
-          0,
-        )
-      : undefined
   return (
     <Container {...props}>
       <Picture
         photo={props.photo}
         color={props.color}
-        colorAssignment={colorAssignmentNumber}
+        colorAssignment={!props.color ? props.name : undefined}
         showName={props.showName}
         size={props.size}
         addBorder={props.addBorder}

--- a/packages/components/src/NameTag/NameTag.tsx
+++ b/packages/components/src/NameTag/NameTag.tsx
@@ -3,9 +3,11 @@ import styled from "react-emotion"
 import { readableTextColor } from "@operational/utils"
 
 import { OperationalStyleConstants, expandColor } from "../utils/constants"
+import { colorMapper } from "../utils/color"
 import { CardHeader, CardItem } from "../"
 
 export interface Props {
+  /** Background color */
   color?: string
   /**
    * Indicates that this component is left of other content, and adds an appropriate right margin.
@@ -15,7 +17,10 @@ export interface Props {
    * Indicates that this component is right of other content, and adds an appropriate left margin.
    */
   right?: boolean
-  children?: React.ReactNode
+  /**
+   * Children to this component are expected to be a plain string
+   */
+  children?: string
 }
 
 const Container = styled("div")(
@@ -24,13 +29,19 @@ const Container = styled("div")(
     color,
     left,
     right,
+    children,
+    assignColor,
   }: {
     theme?: OperationalStyleConstants
     color?: Props["color"]
     left?: Props["left"]
     right?: Props["right"]
+    children: string
+    assignColor: boolean
   }) => {
-    const backgroundColor = expandColor(theme, color) || theme.color.primary
+    const backgroundColor = assignColor
+      ? colorMapper(theme.color.palette)(children)
+      : expandColor(theme, color) || theme.color.primary
     const textColor = readableTextColor(backgroundColor, [theme.color.white, theme.color.black])
     return {
       backgroundColor,
@@ -49,6 +60,14 @@ const Container = styled("div")(
   },
 )
 
-const NameTag: React.SFC<Props> = props => <Container {...props}>{props.children}</Container>
+const NameTag: React.SFC<Props> = props => (
+  <Container {...props} assignColor={Boolean(!props.color)}>
+    {props.children}
+  </Container>
+)
+
+NameTag.defaultProps = {
+  children: "",
+}
 
 export default NameTag

--- a/packages/components/src/NameTag/README.md
+++ b/packages/components/src/NameTag/README.md
@@ -1,11 +1,26 @@
 NameTags are small colored boxes containing the initials of an entity. They are simple ways to identify a resource across a product, such as a purple `PG` tag for a PostgreSQL database.
 
-### Usage
+### Usage with assigned colors
+
+By default, name tags are assigned a color from the Operational palette using a deterministic hash derived from the component's string content.
 
 ```jsx
 <>
-  <NameTag color="#5e0074">PG</NameTag>
-  <NameTag right color="primary">
+  <NameTag>PG</NameTag>
+  <NameTag right>CT</NameTag>
+</>
+```
+
+### Usage with custom colors
+
+Automatic color assignment is disabled if a color is provided.
+
+```jsx
+<>
+  <NameTag color="#5e0074" assignColor={false}>
+    PG
+  </NameTag>
+  <NameTag right color="primary" assignColor={false}>
     CT
   </NameTag>
 </>

--- a/packages/components/src/__tests__/utils.color.test.tsx
+++ b/packages/components/src/__tests__/utils.color.test.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+import { colorMapper } from "../utils/color"
+
+describe("ColorMapper", () => {
+  it("should deterministically assign colors to strings", () => {
+    const colors = ["#fff", "#000", "#ccc", "#333", "#666", "#999"]
+    const mapToColor = colorMapper(colors)
+    expect(mapToColor("Tejas")).toEqual("#666")
+    expect(mapToColor("Imogen")).toEqual("#666")
+    expect(mapToColor("Peter")).toEqual("#999")
+    expect(mapToColor("Fabien")).toEqual("#666")
+    expect(mapToColor("Kasi")).toEqual("#333")
+    expect(mapToColor("Michael")).toEqual("#ccc")
+    expect(mapToColor("Tejas")).toEqual("#666")
+    expect(mapToColor("Ian")).toEqual("#000")
+    expect(mapToColor("Chris")).toEqual("#ccc")
+    expect(mapToColor("Lucia")).toEqual("#333")
+    expect(mapToColor("Nick")).toEqual("#ccc")
+    expect(mapToColor("Nic")).toEqual("#333")
+  })
+})

--- a/packages/components/src/utils/__tests__/color.test.tsx
+++ b/packages/components/src/utils/__tests__/color.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { colorMapper } from "../utils/color"
+import { colorMapper } from "../color"
 
 describe("ColorMapper", () => {
   it("should deterministically assign colors to strings", () => {

--- a/packages/components/src/utils/__tests__/color.test.tsx
+++ b/packages/components/src/utils/__tests__/color.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { colorMapper } from "../color"
 
 describe("ColorMapper", () => {

--- a/packages/components/src/utils/color.ts
+++ b/packages/components/src/utils/color.ts
@@ -1,2 +1,58 @@
 export const isWhite = (color: string) =>
   ["white", "#fff", "#ffffff", "hsl(0, 0%, 100%)"].indexOf(color.toLowerCase()) > -1
+
+// Maps strings deterministally to the same color. Avoids similar strings ending up with the same color.
+export const colorMapper = (colors: string[]) => {
+  return (str: string) => colors[(hash32FNV1aUTF(str) % colors.length)]
+}
+
+/*
+* This FNV-1a hash algorithm, often simply called "fnv", disperses hashes throughout
+* the 32-bit hash space with very good dispersion and is very fast.
+*/
+function hash32FNV1aUTF(str: string) {
+  var c,i,l=str.length,t0=0,v0=0x9dc5,t1=0,v1=0x811c;
+
+  for (i = 0; i < l; i++) {
+    c = str.charCodeAt(i)
+    if (c < 128) {
+      v0^=c
+    } else if (c < 2048) {
+      v0^=(c>>6)|192
+      t0=v0*403;t1=v1*403
+      t1+=v0<<8
+      v1=(t1+(t0>>>16))&65535;v0=t0&65535
+      v0^=(c&63)|128
+    } else if (((c&64512)==55296)&&(i+1)<l&&((str.charCodeAt(i+1)&64512)==56320)) {
+      c=65536+((c&1023)<<10)+(str.charCodeAt(++i)&1023)
+      v0^=(c>>18)|240
+      t0=v0*403;t1=v1*403
+      t1+=v0<<8
+      v1=(t1+(t0>>>16))&65535;v0=t0&65535
+      v0^=((c>>12)&63)|128
+      t0=v0*403;t1=v1*403
+      t1+=v0<<8
+      v1=(t1+(t0>>>16))&65535;v0=t0&65535
+      v0^=((c>>6)&63)|128
+      t0=v0*403;t1=v1*403
+      t1+=v0<<8
+      v1=(t1+(t0>>>16))&65535;v0=t0&65535
+      v0^=(c&63)|128
+    } else {
+      v0^=(c>>12)|224
+      t0=v0*403;t1=v1*403
+      t1+=v0<<8
+      v1=(t1+(t0>>>16))&65535;v0=t0&65535
+      v0^=((c>>6)&63)|128
+      t0=v0*403;t1=v1*403
+      t1+=v0<<8
+      v1=(t1+(t0>>>16))&65535;v0=t0&65535
+      v0^=(c&63)|128
+    }
+    t0=v0*403;t1=v1*403
+    t1+=v0<<8
+    v1=(t1+(t0>>>16))&65535;v0=t0&65535
+  }
+
+  return ((v1<<16)>>>0)+v0
+}

--- a/packages/components/src/utils/color.ts
+++ b/packages/components/src/utils/color.ts
@@ -3,7 +3,7 @@ export const isWhite = (color: string) =>
 
 // Maps strings deterministally to the same color. Avoids similar strings ending up with the same color.
 export const colorMapper = (colors: string[]) => {
-  return (str: string) => colors[(hash32FNV1aUTF(str) % colors.length)]
+  return (str: string) => colors[hash32FNV1aUTF(str) % colors.length]
 }
 
 /*
@@ -11,48 +11,69 @@ export const colorMapper = (colors: string[]) => {
 * the 32-bit hash space with very good dispersion and is very fast.
 */
 function hash32FNV1aUTF(str: string) {
-  var c,i,l=str.length,t0=0,v0=0x9dc5,t1=0,v1=0x811c;
+  let c
+  let i
+  const l = str.length
+  let t0 = 0
+  let v0 = 0x9dc5
+  let t1 = 0
+  let v1 = 0x811c
 
-  for (i = 0; i < l; i++) {
+  for (i = 0; i < l; i = i + 1) {
     c = str.charCodeAt(i)
     if (c < 128) {
-      v0^=c
+      v0 ^= c
     } else if (c < 2048) {
-      v0^=(c>>6)|192
-      t0=v0*403;t1=v1*403
-      t1+=v0<<8
-      v1=(t1+(t0>>>16))&65535;v0=t0&65535
-      v0^=(c&63)|128
-    } else if (((c&64512)==55296)&&(i+1)<l&&((str.charCodeAt(i+1)&64512)==56320)) {
-      c=65536+((c&1023)<<10)+(str.charCodeAt(++i)&1023)
-      v0^=(c>>18)|240
-      t0=v0*403;t1=v1*403
-      t1+=v0<<8
-      v1=(t1+(t0>>>16))&65535;v0=t0&65535
-      v0^=((c>>12)&63)|128
-      t0=v0*403;t1=v1*403
-      t1+=v0<<8
-      v1=(t1+(t0>>>16))&65535;v0=t0&65535
-      v0^=((c>>6)&63)|128
-      t0=v0*403;t1=v1*403
-      t1+=v0<<8
-      v1=(t1+(t0>>>16))&65535;v0=t0&65535
-      v0^=(c&63)|128
+      v0 ^= (c >> 6) | 192
+      t0 = v0 * 403
+      t1 = v1 * 403
+      t1 += v0 << 8
+      v1 = (t1 + (t0 >>> 16)) & 65535
+      v0 = t0 & 65535
+      v0 ^= (c & 63) | 128
+    } else if ((c & 64512) === 55296 && i + 1 < l && (str.charCodeAt(i + 1) & 64512) === 56320) {
+      i = i + 1
+      c = 65536 + ((c & 1023) << 10) + (str.charCodeAt(i) & 1023)
+      v0 ^= (c >> 18) | 240
+      t0 = v0 * 403
+      t1 = v1 * 403
+      t1 += v0 << 8
+      v1 = (t1 + (t0 >>> 16)) & 65535
+      v0 = t0 & 65535
+      v0 ^= ((c >> 12) & 63) | 128
+      t0 = v0 * 403
+      t1 = v1 * 403
+      t1 += v0 << 8
+      v1 = (t1 + (t0 >>> 16)) & 65535
+      v0 = t0 & 65535
+      v0 ^= ((c >> 6) & 63) | 128
+      t0 = v0 * 403
+      t1 = v1 * 403
+      t1 += v0 << 8
+      v1 = (t1 + (t0 >>> 16)) & 65535
+      v0 = t0 & 65535
+      v0 ^= (c & 63) | 128
     } else {
-      v0^=(c>>12)|224
-      t0=v0*403;t1=v1*403
-      t1+=v0<<8
-      v1=(t1+(t0>>>16))&65535;v0=t0&65535
-      v0^=((c>>6)&63)|128
-      t0=v0*403;t1=v1*403
-      t1+=v0<<8
-      v1=(t1+(t0>>>16))&65535;v0=t0&65535
-      v0^=(c&63)|128
+      v0 ^= (c >> 12) | 224
+      t0 = v0 * 403
+      t1 = v1 * 403
+      t1 += v0 << 8
+      v1 = (t1 + (t0 >>> 16)) & 65535
+      v0 = t0 & 65535
+      v0 ^= ((c >> 6) & 63) | 128
+      t0 = v0 * 403
+      t1 = v1 * 403
+      t1 += v0 << 8
+      v1 = (t1 + (t0 >>> 16)) & 65535
+      v0 = t0 & 65535
+      v0 ^= (c & 63) | 128
     }
-    t0=v0*403;t1=v1*403
-    t1+=v0<<8
-    v1=(t1+(t0>>>16))&65535;v0=t0&65535
+    t0 = v0 * 403
+    t1 = v1 * 403
+    t1 += v0 << 8
+    v1 = (t1 + (t0 >>> 16)) & 65535
+    v0 = t0 & 65535
   }
 
-  return ((v1<<16)>>>0)+v0
+  return ((v1 << 16) >>> 0) + v0
 }

--- a/packages/components/src/utils/color.ts
+++ b/packages/components/src/utils/color.ts
@@ -7,9 +7,14 @@ export const colorMapper = (colors: string[]) => {
 }
 
 /*
-* This FNV-1a hash algorithm, often simply called "fnv", disperses hashes throughout
-* the 32-bit hash space with very good dispersion and is very fast.
-*/
+ * Hashing algorithm used to pair strings with colors (see `colorMapper` above), chosen
+ * as a compromise between speed and low risk of having identical colors assigned for two
+ * strings that are nearly identical.
+ *
+ * Copied from https://github.com/tjwebb/fnv-plus (MIT licensed), author Travis Webb <me@traviswebb.com>
+ * This FNV-1a hash algorithm, often simply called "fnv", disperses hashes throughout
+ * the 32-bit hash space with very good dispersion and is very fast.
+ */
 function hash32FNV1aUTF(str: string) {
   let c
   let i


### PR DESCRIPTION
A simple way to assign colors to strings deterministically without ending up with the same colors for similar names / names starting with the same initials. To be used with avatars and name tags.