### PR TITLE
Fixed height on ContiamoLogo

### DIFF
--- a/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
+++ b/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
@@ -20,7 +20,6 @@ const LogoContainer = styled("div")(
   {
     display: "inline-flex",
     alignItems: "center",
-    height: "100%",
   },
   ({ size, stack }: LogoProps & WithTheme) => ({
     width: size,


### PR DESCRIPTION
Pretty self-explanatory. The former height was `100%`, I'm not sure why. I removed this line to make it fit its container.