### PR TITLE
Fix transform origin. Add left/right props

### DIFF
--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -71,8 +71,8 @@ const Container = styled("div")(
     width: size || defaultSize,
     height: size || defaultSize,
     color: expandColor(theme, color) || "currentColor",
-    ...(left ? { marginRight: theme.space.small } : {}),
-    ...(right ? { marginLeft: theme.space.small } : {}),
+    marginRight: left ? theme.space.small : 0,
+    marginLeft: right ? theme.space.small : 0,
     "& svg": {
       fill: "currentColor",
     },
@@ -111,8 +111,10 @@ const BouncingSpinnerContainer = styled("div")({
 })
 
 /**
- * The bouncing spinner is constructed out of 3 80x80 boxes spaced out horizontally on a 360x360 grid (these units don't refer to pixels, they simply mimic the grid of the icons.
- * The math used in here lays these boxes out so they're vertically centered and spaced equally on the horizontal axis without any gutter.
+ * The bouncing spinner is constructed out of 3 80x80 boxes spaced out horizontally on a 360x360 grid
+ * (these units don't refer to pixels, they simply mimic the grid of the icons.
+ * The math used in here lays these boxes out so they're vertically centered and spaced
+ * equally on the horizontal axis without any gutter.
  */
 const BouncingSpinnerBox = styled("div")(({ no }: { no: number }) => ({
   width: `${(80 / 360) * 100}%`,

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -80,7 +80,8 @@ const Container = styled("div")(
 )
 
 /**
- * This additional container is introduced to make transforms set on the main container from the outside (e.g. `styled` helper) do not mess up the rotation origin.
+ * This additional container is introduced to make transforms set on the main container from the outside
+ * (e.g. `styled` helper) do not mess up the rotation origin.
  */
 const AnimationContainer = styled("div")(({ bounce, size }: { bounce?: boolean; size?: number }) => ({
   margin: 0,
@@ -88,7 +89,11 @@ const AnimationContainer = styled("div")(({ bounce, size }: { bounce?: boolean; 
   width: size || defaultSize,
   height: size || defaultSize,
   transformOrigin: "center center",
-  ...(bounce ? {} : { animation: `${spinKeyframes} 1.5s infinite linear` }),
+  /*
+   * When the bounce animation is used, animation properties are set on the individual bouncing squares,
+   * therefore no animation is set on the container.
+   */
+  animation: bounce ? "none" : `${spinKeyframes} 1.5s infinite linear`,
 }))
 
 const RegularSpinner = () => (

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -15,14 +15,24 @@ export interface Props {
   size?: number
   /** Renders a bouncing animation as opposed to a regular spinning one. */
   bounce?: boolean
+  /**
+   * Indicates that this component is left of other content, and adds an appropriate right margin.
+   */
+  left?: boolean
+  /**
+   * Indicates that this component is right of other content, and adds an appropriate left margin.
+   */
+  right?: boolean
 }
 
 const spinKeyframes = keyframes({
   "0%": {
     transform: "rotate(0deg)",
+    transformOrigin: "center center",
   },
   "100%": {
     transform: "rotate(360deg)",
+    transformOrigin: "center center",
   },
 })
 
@@ -49,23 +59,39 @@ const Container = styled("div")(
     color,
     bounce,
     theme,
+    left,
+    right,
   }: {
     size?: number
     color?: string
     bounce?: boolean
     theme?: OperationalStyleConstants
+    left?: boolean
+    right?: boolean
   }) => ({
     label: "spinner",
     display: "inline-block",
     width: size || defaultSize,
     height: size || defaultSize,
-    ...(bounce ? {} : { animation: `${spinKeyframes} 1.5s infinite linear` }),
     color: expandColor(theme, color) || "currentColor",
+    ...(left ? { marginRight: theme.space.small } : {}),
+    ...(right ? { marginLeft: theme.space.small } : {}),
     "& svg": {
       fill: "currentColor",
     },
   }),
 )
+
+/**
+ * This additional container is introduced to make transforms set on the main container from the outside (e.g. `styled` helper) do not mess up the rotation origin.
+ */
+const AnimationContainer = styled("div")(({ bounce, size }: { bounce?: boolean; size?: number }) => ({
+  margin: 0,
+  lineHeight: 0,
+  width: size || defaultSize,
+  height: size || defaultSize,
+  ...(bounce ? {} : { animation: `${spinKeyframes} 1.5s infinite linear` }),
+}))
 
 const RegularSpinner = () => (
   <svg viewBox="0 0 360 360">
@@ -113,7 +139,11 @@ const BouncingSpinner = () => (
 )
 
 const Spinner = (props: Props) => (
-  <Container {...props}>{props.bounce ? <BouncingSpinner /> : <RegularSpinner />}</Container>
+  <Container {...props}>
+    <AnimationContainer bounce={props.bounce} size={props.size}>
+      {props.bounce ? <BouncingSpinner /> : <RegularSpinner />}
+    </AnimationContainer>
+  </Container>
 )
 
 export default Spinner

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -67,7 +67,6 @@ const Container = styled("div")(
     left?: boolean
     right?: boolean
   }) => ({
-    label: "spinner",
     display: "inline-block",
     width: size || defaultSize,
     height: size || defaultSize,

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -28,11 +28,9 @@ export interface Props {
 const spinKeyframes = keyframes({
   "0%": {
     transform: "rotate(0deg)",
-    transformOrigin: "center center",
   },
   "100%": {
     transform: "rotate(360deg)",
-    transformOrigin: "center center",
   },
 })
 
@@ -90,6 +88,7 @@ const AnimationContainer = styled("div")(({ bounce, size }: { bounce?: boolean; 
   lineHeight: 0,
   width: size || defaultSize,
   height: size || defaultSize,
+  transformOrigin: "center center",
   ...(bounce ? {} : { animation: `${spinKeyframes} 1.5s infinite linear` }),
 }))
 


### PR DESCRIPTION
* fixes a bug where the spinner's transform origin is messed up when used within the button.
* adds the missing left/right prop support for spinners.

![spinnerfix](https://user-images.githubusercontent.com/6738398/42435737-c009919e-8357-11e8-8fb7-8e5b5b9b7f80.gif)
