### PR TITLE
Fix visualization color assigner.

### DIFF
--- a/packages/visualizations/src/Chart/facade.ts
+++ b/packages/visualizations/src/Chart/facade.ts
@@ -54,9 +54,8 @@ const defaultColorAssigner = (palette: string[]): ((key: string) => string) => {
   return colorAssigner(palette)
 }
 
-const initialColorAssigner: (key: string) => string = defaultColorAssigner(defaultConfig().palette)
-
 const defaultAccessors = () => {
+  const initialColorAssigner = defaultColorAssigner(defaultConfig().palette)
   return {
     data: {
       series: (d: Data): SeriesData => d.series,


### PR DESCRIPTION
<blockquote class="trello-card"><a href="https://trello.com/c/h6sBO7P2/252-fix-automatic-colour-assignment">Fix automatic colour assignment.</a></blockquote>

Problem: In visual tests, sometimes a test would assign colours as if the colours assigned to series in a previously-viewed test were still in use. 

Now: when a new chart is created / a new visual test viewed, a fresh colour assigner is created and so series colours always start from the beginning of the provided palette.