### PR TITLE
Fix Status component

### DIFF
--- a/packages/components/src/Status/Status.tsx
+++ b/packages/components/src/Status/Status.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants } from "../utils/constants"
-import * as tinycolor from "tinycolor2"
+import tinycolor from "tinycolor2"
 
 export interface Props {
   success?: boolean


### PR DESCRIPTION
For a strange reason, this fix the Status component inside `labs-ui`, styleguidist accept the both import version but webpack not 😕 