### PR TITLE
Fix sunburst transitions in hidden tabs.

### DIFF
--- a/packages/visualizations/src/Sunburst/renderer.ts
+++ b/packages/visualizations/src/Sunburst/renderer.ts
@@ -10,7 +10,7 @@ import "d3-transition"
 import { interpolate as d3Interpolate, interpolateObject as d3InterpolateObject } from "d3-interpolate"
 import { arc as d3Arc } from "d3-shape"
 import { scaleLinear as d3ScaleLinear } from "d3-scale"
-import { withD3Element, transitionIfVisible, onTransitionEnd } from "../utils/d3_utils"
+import { withD3Element, onTransitionEnd } from "../utils/d3_utils"
 
 const arrowPath: string = "M-5 0 L0 -5 L5 0 M-4 -5 L0 -9 L4 -5 M-3 -10 L0 -13 L3 -10"
 const spaceForArrow: number = 20
@@ -68,7 +68,8 @@ class Renderer {
           .attrTween("d", this.removeArcTween.bind(this))
           .style("opacity", 1e-6)
           .remove()
-          .call(onTransitionEnd, this.updateZoom.bind(this))
+
+    this.updateZoom()
   }
 
   private updateZoom(): void {
@@ -329,10 +330,15 @@ class Renderer {
     }, 0)(this.dataHandler.topNode.children)
     const isSurrounded = zoomNode === this.dataHandler.topNode && zoomNode.value === totalRootChildValue
 
-    transitionIfVisible(this.el.select(`circle.${styles.centerCircle}`), config.duration).attr(
-      "r",
-      innerRadius * (isSurrounded ? 1 : config.centerCircleRadius),
-    )
+    document.hidden || config.disableAnimations
+      ? this.el
+          .select(`circle.${styles.centerCircle}`)
+          .attr("r", innerRadius * (isSurrounded ? 1 : config.centerCircleRadius))
+      : this.el
+          .select(`circle.${styles.centerCircle}`)
+          .transition()
+          .duration(config.duration)
+          .attr("r", innerRadius * (isSurrounded ? 1 : config.centerCircleRadius))
 
     // If no payload has been sent (resetting zoom) and the chart hasn't already been zoomed
     // (occurs when no zoom config is passed in from the outside)

--- a/packages/visualizations/src/Sunburst/root_label.ts
+++ b/packages/visualizations/src/Sunburst/root_label.ts
@@ -1,4 +1,4 @@
-import { ClickPayload, D3Selection, EventBus, State, StateWriter } from "./typings"
+import { D3Selection, EventBus, State, StateWriter } from "./typings"
 import Events from "../shared/event_catalog"
 import { approxZero, stepFunction } from "../utils/font_sizing_utils"
 
@@ -16,7 +16,7 @@ class RootLabel {
     this.events.on(Events.FOCUS.ELEMENT.CLICK, this.update.bind(this))
   }
 
-  private update(payload: ClickPayload): void {
+  private update(): void {
     const computed = this.state.current.get("computed")
     const config = this.state.current.get("config")
     const renderer = computed.renderer

--- a/packages/visualizations/src/utils/d3_utils.ts
+++ b/packages/visualizations/src/utils/d3_utils.ts
@@ -27,12 +27,6 @@ const transitionIfDuration = (selection: D3SelectionOrTransition, duration?: num
   return duration != null ? selection.transition().duration(duration) : selection
 }
 
-// Only animates transitions if the document can be seen
-// N.B. can only be used if no attribute interpolation required
-export const transitionIfVisible = (selection: D3Selection, duration: number) => {
-  return document.hidden ? selection : selection.transition().duration(duration)
-}
-
 // Helper function to trigger a callback function when all elements of a selection have finished transitioning
 // @TODO Add a simple unit test for this to avoid off-by-one errors
 export const onTransitionEnd = (selection: D3Transition, func?: () => void): any => {


### PR DESCRIPTION
Issue: #410 

The problem was that the transitions of the centre circle of the sunburst charts was not being disabled properly when the tab was hidden/not active.

To check: open the first visual test for sunbursts, switch immediately to a different tab. The chart should now be correctly rendered when you switch back to the visual test tab.