### PR TITLE
Fix spinner margin regression in card header

### DIFF
--- a/packages/components/src/CardHeader/README.md
+++ b/packages/components/src/CardHeader/README.md
@@ -72,3 +72,18 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
   <img alt="Cat" src="https://images.unsplash.com/photo-1491485880348-85d48a9e5312?w=500" />
 </Card>
 ```
+
+### Usage with spinner
+
+```jsx
+<Card>
+  <CardHeader
+    title="My Card"
+    action={
+      <>
+        Updating<Spinner right size={12} />
+      </>
+    }
+  />
+</Card>
+```

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -83,18 +83,29 @@ const Container = styled("div")(
  * This additional container is introduced to make transforms set on the main container from the outside
  * (e.g. `styled` helper) do not mess up the rotation origin.
  */
-const AnimationContainer = styled("div")(({ bounce, size }: { bounce?: boolean; size?: number }) => ({
-  margin: 0,
-  lineHeight: 0,
-  width: size || defaultSize,
-  height: size || defaultSize,
-  transformOrigin: "center center",
-  /*
-   * When the bounce animation is used, animation properties are set on the individual bouncing squares,
-   * therefore no animation is set on the container.
-   */
-  animation: bounce ? "none" : `${spinKeyframes} 1.5s infinite linear`,
-}))
+const AnimationContainer = styled("div")`
+  ${({ bounce, size }: { bounce?: boolean; size?: number }) => `
+    margin: 0px;
+    lineHeight: 0;
+    width: ${size || defaultSize}px;
+    height: ${size || defaultSize}px;
+    transform-origin: center center;
+    /*
+     * When the bounce animation is used, animation properties are set on the individual bouncing squares,
+     * therefore no animation is set on the container.
+     */
+    animation: ${bounce ? "none" : `${spinKeyframes} 1.5s infinite linear`};
+  `};
+  & svg {
+    /*
+     * Prevents margins and width assignments to be inherited from the outside, which would cause the spinner
+     * to spin around a transform origin other than its center, leading to highly undesirable looks.
+     */
+    margin: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+  }
+`
 
 const RegularSpinner = () => (
   <svg viewBox="0 0 360 360">


### PR DESCRIPTION
Fixes the pivoting bug inside CardHeader:

![spinner-in-card](https://user-images.githubusercontent.com/6738398/42633649-748a445c-85e1-11e8-8082-40175b41b1e4.gif)

In the current setup, `!important` styles are necessary to make sure the cardheader's svg descendant selector rule doesn't override the spinner's styles. Ideally, we'll have fewer loose descendant selectors in the future, making these overrides unnecessary.