### PR TITLE
Add warning style button.

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -32,21 +32,21 @@ export interface Props {
 type PropsWithTheme = Props & { theme?: OperationalStyleConstants }
 
 const makeColors = (theme: OperationalStyleConstants, color: string) => {
-  const defaultColor: string = theme.color.white
+  const defaultColor = theme.color.white
 
-  const BackgroundColors: { [key: string]: string } = {
+  const backgroundColors: { [key: string]: string } = {
     grey: theme.color.background.light,
     warning: defaultColor,
   }
 
-  const TextColors: { [key: string]: string } = {
+  const textColors: { [key: string]: string } = {
     grey: theme.color.text.action,
     warning: theme.color.error,
   }
 
-  const backgroundColor: string = BackgroundColors[color] || expandColor(theme, color) || defaultColor
-  const textColor: string =
-    TextColors[color] || readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
+  const backgroundColor = backgroundColors[color] || expandColor(theme, color) || defaultColor
+  const textColor =
+    textColors[color] || readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
   return {
     background: backgroundColor,
     foreground: textColor,

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -14,7 +14,7 @@ export interface Props {
   type?: string
   /** Navigation property à la react-router <Link/> */
   to?: string
-  /** Color assigned to the avatar circle (hex or named color from `theme.color`) */
+  /** Button color theme (hex or named color from `theme.color`) */
   color?: string
   /** Icon to display on right of button (optional) */
   icon?: IconName
@@ -33,11 +33,20 @@ type PropsWithTheme = Props & { theme?: OperationalStyleConstants }
 
 const makeColors = (theme: OperationalStyleConstants, color: string) => {
   const defaultColor: string = theme.color.white
-  const grey: string = theme.color.background.light
-  const greyText: string = theme.color.text.action
-  const backgroundColor: string = color === "grey" ? grey : expandColor(theme, color) || defaultColor
+
+  const BackgroundColors: { [key: string]: string } = {
+    grey: theme.color.background.light,
+    warning: defaultColor,
+  }
+
+  const TextColors: { [key: string]: string } = {
+    grey: theme.color.text.action,
+    warning: theme.color.error,
+  }
+
+  const backgroundColor: string = BackgroundColors[color] || expandColor(theme, color) || defaultColor
   const textColor: string =
-    color === "grey" ? greyText : readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
+    TextColors[color] || readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
   return {
     background: backgroundColor,
     foreground: textColor,

--- a/packages/components/src/Button/README.md
+++ b/packages/components/src/Button/README.md
@@ -7,27 +7,47 @@ Using buttons is as simple as including the component with a text node as a chil
 ```jsx
 <div style={{ marginBottom: 10 }}>
   <Button>Default</Button>
-  <Button color="primary">Set color</Button>
-  <Button color="#393939">Custom color</Button>
-  <Button color="success" disabled>Disabled</Button>
-  <Button disabled>Disabled</Button>
+  <Button color="grey">Grey</Button>
+  <Button color="basic">Basic</Button>
+  <Button color="primary">Primary</Button>
+  <Button color="success">Success</Button>
+  <Button color="error">Error</Button>
+  <Button color="warning">Warning</Button>
+  <Button color="#ff0000">Custom color</Button>
   <Button condensed>Condensed</Button>
 </div>
 <div style={{ marginBottom: 10 }}>
-  <Button color="success" icon="Open">Icon</Button>
+  <Button disabled>Default</Button>
+  <Button disabled color="grey">Grey</Button>
+  <Button disabled color="basic">Basic</Button>
+  <Button disabled color="primary">Primary</Button>
+  <Button disabled color="success">Success</Button>
+  <Button disabled color="error">Error</Button>
+  <Button disabled color="warning">Warning</Button>
+  <Button disabled color="#ff0000">Custom color</Button>
+  <Button disabled condensed>Condensed</Button>
+</div>
+<div style={{ marginBottom: 10 }}>
+  <Button color="grey" icon="Open">Icon</Button>
   <Button color="success" icon="Labs">Icon</Button>
   <Button condensed icon="Open">Icon</Button>
   <Button loading>Loading</Button>
 </div>
 <div style={{ marginBottom: 10 }}>
-  <Button color="grey" disabled>Update</Button>
-  <Button color="grey">Test</Button>
-  <Button color="error">Delete this bundle</Button>
+  <Button disabled color="grey" icon="Open">Icon</Button>
+  <Button disabled color="success" icon="Labs">Icon</Button>
+  <Button disabled condensed icon="Open">Icon</Button>
+  <Button disabled loading>Loading</Button>
 </div>
 <div style={{ backgroundColor: "#1499ce", padding: 5 }}>
   <Button color="ghost">Ghost</Button>
   <Button color="ghost" icon="Open">Ghost with icon</Button>
   <Button color="ghost" icon="Open" condensed>Ghost condensed</Button>
+</div>
+<div style={{ backgroundColor: "#1499ce", padding: 5 }}>
+  <Button disabled color="ghost">Ghost</Button>
+  <Button disabled color="ghost" icon="Open">Ghost with icon</Button>
+  <Button disabled color="ghost" icon="Open" condensed>Ghost condensed</Button>
 </div>
 ```
 

--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -61,7 +61,7 @@ const textColors = {
  */
 const borderColors = {
   default: "#c0c0c0",
-  disabled: "#e8e8e8",
+  disabled: "#d8d8d8",
 }
 
 /**


### PR DESCRIPTION
### Summary

<blockquote class="trello-card"><a href="https://trello.com/c/4Txpaa7R/263-add-one-more-button-style-for-dangerous-actions-that-are-not-deleting-anything-and-tweak-button-border">Add one more button style for dangerous actions that are not deleting anything and tweak button border</a></blockquote>

![image](https://user-images.githubusercontent.com/14272822/42750371-5879ff4c-88e7-11e8-8efd-24376a224c5d.png)

In this PR:

- New color option for buttons - "warning" - which results in red text on a white background.
- Slightly darker border color for all buttons
- Rearranged button examples in docs.

### To be tested

Tejas
- [x] No error/warning in the console
- [x] The netlify build is working
- [x] Button styles match those in Trello screenshot / Zeplin
- [x] No button styles missing from docs

Fabien

- [x] No error/warning in the console
- [x] The netlify build is working
- [x] Button styles match those in Trello screenshot / Zeplin
- [x] No button styles missing from docs
- [ ] The component is strongly typed