### PR TITLE
Remove deprecated theme from visualizations.

### DIFF
--- a/packages/visualizations/src/Chart/axes/styles.ts
+++ b/packages/visualizations/src/Chart/axes/styles.ts
@@ -1,9 +1,9 @@
 import { css } from "glamor"
-import { deprecatedTheme } from "../../utils/theme"
+import theme from "../../utils/constants"
 
 const labelStyle = {
-  fill: deprecatedTheme.colors.gray,
-  fontFamily: deprecatedTheme.fontFamily,
+  fill: theme.colors.axis.label,
+  fontFamily: theme.font.family,
   "&.weekend": {
     fill: "#9d261d",
   },
@@ -13,7 +13,7 @@ const labelStyle = {
 }
 
 const borderStyle = {
-  stroke: deprecatedTheme.colors.border,
+  stroke: theme.colors.axis.border,
   shapeRendering: "crispedges",
 }
 
@@ -22,7 +22,7 @@ const componentRectStyle = {
 }
 
 const rulesStyle = {
-  stroke: deprecatedTheme.colors.lightGray,
+  stroke: theme.colors.axis.rules,
   strokeWidth: "1",
   shapeRendering: "crispedges",
   "&.zero": {
@@ -31,7 +31,7 @@ const rulesStyle = {
 }
 
 const tickStyle = {
-  stroke: deprecatedTheme.colors.border,
+  stroke: theme.colors.axis.border,
   strokeWidth: "1",
   shapeRendering: "crispedges",
   "&.zero": {

--- a/packages/visualizations/src/Chart/facade.ts
+++ b/packages/visualizations/src/Chart/facade.ts
@@ -7,7 +7,7 @@ import Events from "../shared/event_catalog"
 import StateHandler from "../shared/state_handler"
 import EventEmitter from "../shared/event_bus"
 import { colorAssigner } from "../utils/colorAssigner"
-import { deprecatedTheme } from "../utils/theme"
+import theme from "../utils/constants"
 import { has, isEmpty, uniqueId } from "lodash/fp"
 import defaultNumberFormatter from "../utils/number_formatter"
 
@@ -41,7 +41,7 @@ const defaultConfig = (): ChartConfig => {
     minBarWidth: 3,
     numberFormatter: defaultNumberFormatter,
     outerBarSpacing: 10,
-    palette: deprecatedTheme.palettes.qualitative.generic,
+    palette: theme.palettes.qualitative.generic,
     showComponentFocus: false,
     timeAxisPriority: ["x1", "x2", "y1", "y2"],
     uid: uniqueId("chart"),

--- a/packages/visualizations/src/Chart/focus/styles.ts
+++ b/packages/visualizations/src/Chart/focus/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "glamor"
-import { deprecatedTheme } from "../../utils/theme"
+import theme from "../../utils/constants"
 
 const dateFocusStyle = {
   "& li": {
@@ -42,8 +42,8 @@ const elementFocusStyle = {
 }
 
 const flagFocusStyle = {
-  fontFamily: deprecatedTheme.fontFamily,
-  color: deprecatedTheme.colors.text,
+  fontFamily: theme.font.family,
+  color: theme.colors.focus.label,
   "& li.name": {
     fontWeight: "bold",
   },

--- a/packages/visualizations/src/Chart/series/renderers/styles.ts
+++ b/packages/visualizations/src/Chart/series/renderers/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "glamor"
-import { deprecatedTheme } from "../../../utils/theme"
+import theme from "../../../utils/constants"
 
 const areaStyle = {
   "& path:hover": {
@@ -61,7 +61,7 @@ const symbolStyle = {
 const textStyle = {
   "& text": {
     fill: "#333",
-    fontFamily: deprecatedTheme.fontFamily,
+    fontFamily: theme.font.family,
     dominantBaseline: "middle",
   },
   "& text:hover": {

--- a/packages/visualizations/src/Chart/styles.ts
+++ b/packages/visualizations/src/Chart/styles.ts
@@ -1,14 +1,14 @@
 import { css } from "glamor"
-import { deprecatedTheme } from "../utils/theme"
+import theme from "../utils/constants"
 
 const focusGroupStyle = {
   strokeWidth: "1.5px",
   "& line": {
-    stroke: deprecatedTheme.colors.gray,
+    stroke: theme.colors.focus.stroke,
     shapeRenderering: "crispEdges",
   },
   "& circle": {
-    stroke: "#fff",
+    stroke: theme.colors.white,
   },
 }
 

--- a/packages/visualizations/src/PieChart/facade.ts
+++ b/packages/visualizations/src/PieChart/facade.ts
@@ -6,7 +6,7 @@ import Events from "../shared/event_catalog"
 import StateHandler from "../shared/state_handler"
 import EventEmitter from "../shared/event_bus"
 import { isEmpty, uniqueId } from "lodash/fp"
-import { deprecatedTheme } from "../utils/theme"
+import theme from "../utils/constants"
 
 import {
   Accessors,
@@ -38,7 +38,7 @@ const defaultConfig = (): PieChartConfig => {
     minLegendWidth: 50,
     minTotalFontSize: 11,
     outerBorderMargin: 1,
-    palette: deprecatedTheme.palettes.qualitative.generic,
+    palette: theme.palettes.qualitative.generic,
     showComponentFocus: false,
     uid: uniqueId("piechart"),
     visualizationName: "piechart",

--- a/packages/visualizations/src/PieChart/renderers/styles.ts
+++ b/packages/visualizations/src/PieChart/renderers/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "glamor"
-import { deprecatedTheme } from "../../utils/theme"
+import theme from "../../utils/constants"
 
 const arcStyle = {
   stroke: "#fff",
@@ -11,19 +11,19 @@ const labelStyle = {
   fill: "#333",
   stroke: "none",
   pointerEvents: "none",
-  ...deprecatedTheme.typography.small,
+  ...theme.font.small,
 }
 
 const labelBackgroundStyle = {
   fill: "rgba(255, 255, 255, 0.2)",
   pointerEvents: "none",
   stroke: "none",
-  borderRadius: deprecatedTheme.borderRadius,
+  borderRadius: theme.borderRadius,
 }
 
 const totalStyle = {
   fill: "#4c4c4c",
-  ...deprecatedTheme.typography.small,
+  ...theme.font.small,
 }
 
 const comparisonStyle = {

--- a/packages/visualizations/src/ProcessFlow/styles.ts
+++ b/packages/visualizations/src/ProcessFlow/styles.ts
@@ -1,7 +1,7 @@
 import { css } from "glamor"
 
 import { setBrightness } from "../utils/color"
-import { deprecatedTheme } from "../utils/theme"
+import theme from "../utils/constants"
 
 const breakdownStyle = {
   maxWidth: "300px",
@@ -17,15 +17,15 @@ const breakdownsContainerStyle = {
 
 const breakdownContainerStyle = {
   padding: `2%`,
-  background: deprecatedTheme.colors.white,
+  background: theme.colors.white,
   width: "46%",
   float: "left",
 }
 
 const breakdownLabelStyle = {
-  ...deprecatedTheme.typography.small,
+  ...theme.font.small,
   display: "block",
-  marginBottom: deprecatedTheme.spacing / 4,
+  marginBottom: theme.space.small,
 }
 
 const breakdownCommentLabelStyle = {
@@ -37,7 +37,7 @@ const breakdownBackgroundBarStyle = {
   width: "100%",
   fontSize: 12,
   overflow: "hidden",
-  backgroundColor: deprecatedTheme.colors.lightGray,
+  backgroundColor: theme.colors.lightGrey,
 }
 
 const breakdownBarStyle = {
@@ -49,17 +49,17 @@ const breakdownBarStyle = {
   display: "block",
   height: "100%",
   pointerEvents: "none",
-  backgroundColor: setBrightness(deprecatedTheme.colors.info, 145),
+  backgroundColor: setBrightness(theme.colors.primary, 145),
 }
 
 const breakdownTextStyle = {
-  ...deprecatedTheme.typography.small,
+  ...theme.font.small,
   lineHeight: 1,
-  color: deprecatedTheme.colors.gray,
+  color: theme.font.color,
   position: "relative",
   top: 1,
   fontWeight: 400,
-  padding: `${deprecatedTheme.spacing / 4}px ${deprecatedTheme.spacing / 2}px`,
+  padding: `${theme.space.small}px ${theme.space.default}px`,
 }
 
 const titleStyle = {

--- a/packages/visualizations/src/Sunburst/facade.ts
+++ b/packages/visualizations/src/Sunburst/facade.ts
@@ -7,7 +7,7 @@ import StateHandler from "../shared/state_handler"
 import EventEmitter from "../shared/event_bus"
 import { has, uniqueId } from "lodash/fp"
 import { colorAssigner } from "../utils/colorAssigner"
-import { deprecatedTheme } from "../utils/theme"
+import theme from "../utils/constants"
 import defaultNumberFormatter from "../utils/number_formatter"
 import { Accessors, AccessorsObject, Components, Facade, RawData, SunburstConfig } from "./typings"
 
@@ -24,10 +24,10 @@ const defaultConfig = (): SunburstConfig => {
     maxBreadcrumbLength: 4,
     maxRings: 10,
     maxTotalFontSize: 54,
-    minTotalFontSize: deprecatedTheme.typography.small.fontSize,
+    minTotalFontSize: theme.font.small.fontSize,
     numberFormatter: defaultNumberFormatter,
     outerBorderMargin: 1,
-    palette: deprecatedTheme.palettes.qualitative.generic,
+    palette: theme.palettes.qualitative.generic,
     propagateColors: true,
     sort: true,
     uid: uniqueId("sunburst"),

--- a/packages/visualizations/src/Sunburst/styles.ts
+++ b/packages/visualizations/src/Sunburst/styles.ts
@@ -1,7 +1,6 @@
 import { css } from "glamor"
 
-import { deprecatedTheme } from "../utils/theme"
-import { seriesLegend } from "../shared/styles"
+import theme from "../utils/constants"
 
 const arcStyle = {
   strokeWidth: "1",
@@ -38,7 +37,7 @@ const breadcrumbItemStyle = {
   lineHeight: "18px",
   cursor: "pointer",
   margin: "5px 0",
-  ...deprecatedTheme.typography.small,
+  ...theme.font.small,
   "&:first-child": {
     paddingLeft: "8px",
   },
@@ -93,7 +92,7 @@ const rootLabelStyle = {
   overflow: "hidden",
   textOverflow: "ellipsis",
   "& .name": {
-    ...deprecatedTheme.typography.small,
+    ...theme.font.small,
   },
 }
 

--- a/packages/visualizations/src/shared/styles.ts
+++ b/packages/visualizations/src/shared/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "glamor"
-import { deprecatedTheme } from "../utils/theme"
+import theme from "../utils/constants"
 
 const legendStyle = {
   fontSize: "11px",
@@ -28,7 +28,7 @@ const seriesLegendStyle = {
   },
   "& div.name": {
     float: "left",
-    ...deprecatedTheme.typography.small,
+    ...theme.font.small,
   },
 }
 
@@ -54,7 +54,7 @@ const componentFocusStyle = {
   position: "absolute",
   pointerEvents: "all",
   backgroundColor: "rgba(0, 74, 117, 0.05)",
-  borderRadius: deprecatedTheme.borderRadius,
+  borderRadius: theme.borderRadius,
   border: 0,
   padding: 0,
   cursor: "pointer",
@@ -80,7 +80,7 @@ const focusLegendStyle = {
   zIndex: 3000,
   maxWidth: "350px",
   backgroundColor: "#fff",
-  borderRadius: deprecatedTheme.borderRadius,
+  borderRadius: theme.borderRadius,
   "& ul": {
     listStyle: "none",
     fontSize: 12,

--- a/packages/visualizations/src/utils/VisualizationWrapper.tsx
+++ b/packages/visualizations/src/utils/VisualizationWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { defaults, forEach } from "lodash/fp"
 
-import { deprecatedTheme } from "./theme"
+import theme from "./constants"
 
 export interface Props {
   style?: {}
@@ -46,7 +46,7 @@ class VisualizationWrapper extends React.Component<Props, {}> {
         this.viz.accessors(key, accessors)
       },
     )(this.props.accessors)
-    this.viz.config(defaults({ palette: deprecatedTheme.palettes.qualitative.generic })(this.props.config || {}))
+    this.viz.config(defaults({ palette: theme.palettes.qualitative.generic })(this.props.config || {}))
   }
 
   componentWillUnmount() {

--- a/packages/visualizations/src/utils/constants.ts
+++ b/packages/visualizations/src/utils/constants.ts
@@ -1,0 +1,87 @@
+/**
+ * # Operational UI's visualization styling constants.
+ *
+ */
+
+// Pre-defined visualization color palettes.
+const palettes = {
+  qualitative: {
+    generic: ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c", "#fb9a99", "#e31a1c", "#fdbf6f", "#ff7f00", "#cab2d6"],
+    pastel: ["#8dd3c7", "#ffffb3", "#bebada", "#fb8072", "#80b1d3", "#fdb462", "#b3de69", "#fccde5", "#d9d9d9"],
+    operational: [
+      "#1499CE",
+      "#7C246F",
+      "#EAD63F",
+      "#343972",
+      "#ED5B17",
+      "#009691",
+      "#1D6199",
+      "#D31F1F",
+      "#AD329C",
+      "#006865",
+    ],
+  },
+  sequential: {
+    cool: ["#fff7fb", "#ece2f0", "#d0d1e6", "#a6bddb", "#67a9cf", "#3690c0", "#02818a", "#016c59", "#014636"],
+    sharp: ["#f7fcfd", "#e0ecf4", "#bfd3e6", "#9ebcda", "#8c96c6", "#8c6bb1", "#88419d", "#810f7c", "#4d004b"],
+    intense: ["#fff7ec", "#fee8c8", "#fdd49e", "#fdbb84", "#fc8d59", "#ef6548", "#d7301f", "#b30000", "#7f0000"],
+  },
+  diverging: {
+    rainbow: ["#d53e4f", "#f46d43", "#fdae61", "#fee08b", "#ffffbf", "#e6f598", "#abdda4", "#66c2a5", "#3288bd"],
+    earthy: ["#8c510a", "#bf812d", "#dfc27d", "#f6e8c3", "#f5f5f5", "#c7eae5", "#80cdc1", "#35978f", "#01665e"],
+  },
+}
+
+const axisColors = {
+  border: "#adadad",
+  rules: "#e8e8e8",
+  label: "#999999",
+}
+
+const focusColors = {
+  label: "#2f3435",
+  stroke: "#999999",
+}
+
+const colors = {
+  axis: axisColors,
+  focus: focusColors,
+  white: "#ffffff",
+  primary: "#1499ce",
+  lightGrey: "#e8e8e8",
+}
+
+const font = {
+  color: "#999999",
+  small: {
+    lineHeight: "1.5",
+    textTransform: "none",
+    letterSpacing: "normal",
+    fontSize: 12,
+    fontWeight: 400,
+  },
+  family:
+    "Helvetica Neue, Helvetica, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
+}
+
+/**
+ * A container of space-related constants to be
+ * used throughout Operational UI.
+ */
+const space = {
+  /** Small space is `4px` */
+  small: 4,
+
+  /** Default space is `8px` */
+  default: 8,
+}
+
+const constants = {
+  palettes,
+  colors,
+  font,
+  space,
+  borderRadius: 4,
+}
+
+export default constants


### PR DESCRIPTION
### Summary

<blockquote class="trello-card"><a href="https://trello.com/c/kXD10Jhd/283-visualisation-deprecatedtheme-constants">Visualisation deprecatedTheme -&gt; constants</a></blockquote>

### To be tested

Tester 1

- [ ] No error/warning in the console
- [ ] The netlify build is working

Tester 2

- [ ] No error/warning in the console
- [ ] The netlify build is working
