### PR TITLE
Date picker min-max ranges and visual updates

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.Month.tsx
+++ b/packages/components/src/DatePicker/DatePicker.Month.tsx
@@ -35,7 +35,6 @@ const isSelected = (date: string, current: IDatePair): boolean => {
 }
 
 const Month = ({ year, month, start, end, onChange, min, max }: Props) => {
-  console.log(min, max)
   const prevPlaceholderDays = monthStartDay(year, month)
   const nextMonth = month === 11 ? 0 : month + 1
   const nextYear = month === 11 ? year + 1 : year

--- a/packages/components/src/DatePicker/DatePicker.Month.tsx
+++ b/packages/components/src/DatePicker/DatePicker.Month.tsx
@@ -13,6 +13,8 @@ export interface Props {
   month: number
   start?: string
   end?: string
+  min?: string
+  max?: string
   onChange?: (date: IDatePair) => void
 }
 
@@ -32,7 +34,8 @@ const isSelected = (date: string, current: IDatePair): boolean => {
   return date === start || date === end || (!!start && !!end && date >= start && date <= end)
 }
 
-const Month = ({ year, month, start, end, onChange }: Props) => {
+const Month = ({ year, month, start, end, onChange, min, max }: Props) => {
+  console.log(min, max)
   const prevPlaceholderDays = monthStartDay(year, month)
   const nextMonth = month === 11 ? 0 : month + 1
   const nextYear = month === 11 ? year + 1 : year
@@ -47,6 +50,7 @@ const Month = ({ year, month, start, end, onChange }: Props) => {
       {range(prevPlaceholderDays).map((number, index) => {
         const day = daysInPreviousMonth + index - prevPlaceholderDays
         const date = toDate(prevYear, prevMonth, day)
+        const isDisabled = (min && date < min) || (max && date > max)
         return (
           <Day
             selected={isSelected(date, {
@@ -55,8 +59,12 @@ const Month = ({ year, month, start, end, onChange }: Props) => {
             })}
             key={index}
             isPlaceholder
+            isDisabled={isDisabled}
             onClick={(ev: any) => {
               ev.preventDefault()
+              if (isDisabled) {
+                return
+              }
               onChange &&
                 onChange(
                   setNewDate(date, {
@@ -72,6 +80,7 @@ const Month = ({ year, month, start, end, onChange }: Props) => {
       })}
       {range(daysInCurrentMonth).map((number, index) => {
         const date = toDate(year, month, index)
+        const isDisabled = (min && date < min) || (max && date > max)
         return (
           <Day
             selected={isSelected(date, {
@@ -79,8 +88,12 @@ const Month = ({ year, month, start, end, onChange }: Props) => {
               end,
             })}
             key={index}
+            isDisabled={isDisabled}
             onClick={(ev: any) => {
               ev.preventDefault()
+              if (isDisabled) {
+                return
+              }
               onChange &&
                 onChange(
                   setNewDate(date, {
@@ -96,6 +109,7 @@ const Month = ({ year, month, start, end, onChange }: Props) => {
       })}
       {range(nextPlaceholderDays).map((number, index) => {
         const date = toDate(nextYear, nextMonth, number)
+        const isDisabled = (min && date < min) || (max && date > max)
         return (
           <Day
             key={index}
@@ -103,9 +117,13 @@ const Month = ({ year, month, start, end, onChange }: Props) => {
               start,
               end,
             })}
+            isDisabled={isDisabled}
             isPlaceholder
             onClick={(ev: any) => {
               ev.preventDefault()
+              if (isDisabled) {
+                return
+              }
               onChange &&
                 onChange(
                   setNewDate(date, {

--- a/packages/components/src/DatePicker/DatePicker.styles.ts
+++ b/packages/components/src/DatePicker/DatePicker.styles.ts
@@ -91,7 +91,7 @@ export const IconContainer = styled("div")(
     justifyContent: "center",
     borderRadius: "50%",
     cursor: disabled ? "not-allowed" : "pointer",
-    opacity: disabled ? "0.6" : "1",
+    opacity: disabled ? "0.4" : "1",
     ":hover": {
       backgroundColor: disabled ? undefined : theme.color.background.lighter,
     },

--- a/packages/components/src/DatePicker/DatePicker.styles.ts
+++ b/packages/components/src/DatePicker/DatePicker.styles.ts
@@ -1,5 +1,7 @@
 import * as React from "react"
 import styled from "react-emotion"
+import colorCalculator from "tinycolor2"
+
 import { OperationalStyleConstants } from "../utils/constants"
 import { Card } from "../"
 import * as mixins from "../utils/mixins"
@@ -65,10 +67,10 @@ export const Toggle = styled("div")(({ theme }: { theme?: OperationalStyleConsta
 }))
 
 export const MonthNav = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
-  marginBottom: theme.deprecated.spacing / 2,
+  marginBottom: theme.space.element,
   textAlign: "center",
   "& > *": {
-    margin: `0 6px`,
+    margin: `0 2px`,
     verticalAlign: "middle",
     display: "inline-block",
   },
@@ -80,13 +82,18 @@ export const MonthNav = styled("div")(({ theme }: { theme?: OperationalStyleCons
   },
 }))
 
-export const IconContainer = styled("div")({
-  backgroundColor: "#FFFFFF",
-  padding: 4,
-  height: "auto",
-  width: "fit-content",
+export const IconContainer = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
+  width: 20,
+  height: 20,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: "50%",
   cursor: "pointer",
-})
+  ":hover": {
+    backgroundColor: theme.color.background.lighter,
+  },
+}))
 
 export const Days = styled("div")({
   textAlign: "center",
@@ -105,24 +112,38 @@ export const Day = styled("div")(
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
-    border: "1px solid #efefef",
+    padding: 3,
+    borderRadius: "50%",
+    backgroundClip: "content-box",
   },
   ({
     theme,
     selected,
     isPlaceholder,
+    isDisabled,
   }: {
     theme?: OperationalStyleConstants
     selected?: boolean
     isPlaceholder?: boolean
+    isDisabled?: boolean
   }) => ({
     ...theme.deprecated.typography.body,
     backgroundColor: selected ? theme.deprecated.colors.info : "transparent",
     color: selected
       ? theme.deprecated.colors.white
-      : isPlaceholder
+      : isPlaceholder || isDisabled
         ? theme.deprecated.colors.gray
         : theme.deprecated.colors.black,
+    cursor: isDisabled ? "not-allowed" : "pointer",
+    ":hover": {
+      backgroundColor: selected
+        ? colorCalculator(theme.color.primary)
+            .darken(5)
+            .toString()
+        : isDisabled
+          ? "transparent"
+          : theme.color.background.lighter,
+    },
   }),
 )
 

--- a/packages/components/src/DatePicker/DatePicker.styles.ts
+++ b/packages/components/src/DatePicker/DatePicker.styles.ts
@@ -6,7 +6,7 @@ import { OperationalStyleConstants } from "../utils/constants"
 import { Card } from "../"
 import * as mixins from "../utils/mixins"
 
-const inputHeight: number = 33
+const inputHeight: number = 36
 
 export interface ContainerProps {
   isExpanded: boolean

--- a/packages/components/src/DatePicker/DatePicker.styles.ts
+++ b/packages/components/src/DatePicker/DatePicker.styles.ts
@@ -70,7 +70,7 @@ export const MonthNav = styled("div")(({ theme }: { theme?: OperationalStyleCons
   marginBottom: theme.space.element,
   textAlign: "center",
   "& > *": {
-    margin: `0 2px`,
+    margin: "0 2px",
     verticalAlign: "middle",
     display: "inline-block",
   },

--- a/packages/components/src/DatePicker/DatePicker.styles.ts
+++ b/packages/components/src/DatePicker/DatePicker.styles.ts
@@ -82,24 +82,50 @@ export const MonthNav = styled("div")(({ theme }: { theme?: OperationalStyleCons
   },
 }))
 
-export const IconContainer = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
-  width: 20,
-  height: 20,
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  borderRadius: "50%",
-  cursor: "pointer",
-  ":hover": {
-    backgroundColor: theme.color.background.lighter,
-  },
-}))
+export const IconContainer = styled("div")(
+  ({ theme, disabled }: { theme?: OperationalStyleConstants; disabled?: boolean }): {} => ({
+    width: 20,
+    height: 20,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "50%",
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? "0.6" : "1",
+    ":hover": {
+      backgroundColor: disabled ? undefined : theme.color.background.lighter,
+    },
+  }),
+)
 
 export const Days = styled("div")({
   textAlign: "center",
   width: 210,
   margin: "auto -1px",
 })
+
+const makeDayTextColor = ({
+  isPlaceholder,
+  isDisabled,
+  selected,
+  theme,
+}: {
+  isPlaceholder?: boolean
+  isDisabled?: boolean
+  selected?: boolean
+  theme?: OperationalStyleConstants
+}) => {
+  if (selected) {
+    return theme.color.white
+  }
+  if (isDisabled) {
+    return theme.color.text.lightest
+  }
+  if (isPlaceholder) {
+    return theme.color.text.lighter
+  }
+  return theme.color.text.dark
+}
 
 export const Day = styled("div")(
   {
@@ -129,11 +155,7 @@ export const Day = styled("div")(
   }) => ({
     ...theme.deprecated.typography.body,
     backgroundColor: selected ? theme.deprecated.colors.info : "transparent",
-    color: selected
-      ? theme.deprecated.colors.white
-      : isPlaceholder || isDisabled
-        ? theme.deprecated.colors.gray
-        : theme.deprecated.colors.black,
+    color: makeDayTextColor({ isPlaceholder, isDisabled, selected, theme }),
     cursor: isDisabled ? "not-allowed" : "pointer",
     ":hover": {
       backgroundColor: selected

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -141,7 +141,7 @@ class DatePicker extends React.Component<Props, State> {
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
 
     const canGoToPreviousMonth = !min || min < toDate(this.state.year, this.state.month, 0)
-    const canGoToNextMonth = !max || max > toDate(this.state.year, this.state.month, 0)
+    const canGoToNextMonth = !max || max > toDate(this.state.year, this.state.month, 30)
 
     const datePickerWithoutLabel = (
       <Container

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -5,7 +5,7 @@ import { Label, LabelText } from "../utils/mixins"
 import { Card, Icon } from "../"
 
 import { Container, Toggle, MonthNav, IconContainer, Input, DatePickerCard } from "./DatePicker.styles"
-import { months, toYearMonthDay, validateDateString, toDate } from "./DatePicker.utils"
+import { months, toYearMonthDay, validateDateString, toDate, changeMonth } from "./DatePicker.utils"
 import Month from "./DatePicker.Month"
 
 export interface Props {
@@ -36,16 +36,6 @@ export interface State {
   year: number
   /** Current month. Starting at 0, corresponding to January */
   month: number
-}
-
-const changeMonth = (
-  diff: number,
-  { year, month }: { year: number; month: number },
-): { year: number; month: number } => {
-  return {
-    month: month + diff < 0 ? month + diff + 12 : (month + diff) % 12,
-    year: month + diff < 0 ? year - 1 : month + diff > 11 ? year + 1 : year,
-  }
 }
 
 class DatePicker extends React.Component<Props, State> {

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -38,6 +38,16 @@ export interface State {
   month: number
 }
 
+const changeMonth = (
+  diff: number,
+  { year, month }: { year: number; month: number },
+): { year: number; month: number } => {
+  return {
+    month: month + diff < 0 ? month + diff + 12 : (month + diff) % 12,
+    year: month + diff < 0 ? year - 1 : month + diff > 11 ? year + 1 : year,
+  }
+}
+
 class DatePicker extends React.Component<Props, State> {
   static defaultProps = {
     placeholder: "Enter date",
@@ -84,15 +94,7 @@ class DatePicker extends React.Component<Props, State> {
   }
 
   changeMonth(diff: number) {
-    this.setState(prevState => ({
-      month: prevState.month + diff < 0 ? prevState.month + diff + 12 : (prevState.month + diff) % 12,
-      year:
-        prevState.month + diff < 0
-          ? prevState.year - 1
-          : prevState.month + diff > 11
-            ? prevState.year + 1
-            : prevState.year,
-    }))
+    this.setState(prevState => changeMonth(diff, { month: prevState.month, year: prevState.year }))
   }
 
   componentDidMount() {
@@ -140,8 +142,10 @@ class DatePicker extends React.Component<Props, State> {
     const { isExpanded, month, year } = this.state
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
 
+    const nextMonth = changeMonth(1, { month: this.state.month, year: this.state.year })
+
     const canGoToPreviousMonth = !min || min < toDate(this.state.year, this.state.month, 0)
-    const canGoToNextMonth = !max || max > toDate(this.state.year, this.state.month, 30)
+    const canGoToNextMonth = !max || max >= toDate(nextMonth.year, nextMonth.month, 0)
 
     const datePickerWithoutLabel = (
       <Container

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -5,9 +5,7 @@ import { Label, LabelText } from "../utils/mixins"
 import { Card, Icon } from "../"
 
 import { Container, Toggle, MonthNav, IconContainer, Input, DatePickerCard } from "./DatePicker.styles"
-
-import { months, toYearMonthDay, validateDateString } from "./DatePicker.utils"
-
+import { months, toYearMonthDay, validateDateString, toDate } from "./DatePicker.utils"
 import Month from "./DatePicker.Month"
 
 export interface Props {
@@ -36,6 +34,7 @@ export interface Props {
 export interface State {
   isExpanded: boolean
   year: number
+  /** Current month. Starting at 0, corresponding to January */
   month: number
 }
 
@@ -141,6 +140,9 @@ class DatePicker extends React.Component<Props, State> {
     const { isExpanded, month, year } = this.state
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
 
+    const canGoToPreviousMonth = !min || min < toDate(this.state.year, this.state.month, 0)
+    const canGoToNextMonth = !max || max > toDate(this.state.year, this.state.month, 0)
+
     const datePickerWithoutLabel = (
       <Container
         innerRef={(node: React.ReactNode) => {
@@ -188,8 +190,12 @@ class DatePicker extends React.Component<Props, State> {
         <DatePickerCard isExpanded={isExpanded}>
           <MonthNav>
             <IconContainer
+              disabled={!canGoToPreviousMonth}
               onClick={(ev: any) => {
                 ev.preventDefault()
+                if (!canGoToPreviousMonth) {
+                  return
+                }
                 this.changeMonth(-1)
               }}
             >
@@ -197,8 +203,12 @@ class DatePicker extends React.Component<Props, State> {
             </IconContainer>
             <span>{`${months[month]}, ${year}`}</span>
             <IconContainer
+              disabled={!canGoToNextMonth}
               onClick={(ev: any) => {
                 ev.preventDefault()
+                if (!canGoToNextMonth) {
+                  return
+                }
                 this.changeMonth(+1)
               }}
             >

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -13,14 +13,15 @@ import Month from "./DatePicker.Month"
 export interface Props {
   id?: string
   label?: string
+  /** Min date in the format YYYY-MM-DD. Dates lower than this cannot be selected. */
+  min?: string
+  /** Max date in the format YYYY-MM-DD. Dates higher than this cannot be selected. */
+  max?: string
   /** Start date in the format YYYY-MM-DD. */
-
   start?: string
   /** End date in the format YYYY-MM-DD. */
-
   end?: string
   /** Triggered every time the start or end dates change. `undefined` values clear start or end values. */
-
   onChange?: (
     date: {
       start?: string
@@ -29,7 +30,6 @@ export interface Props {
   ) => void
   className?: string
   /** Placeholder text when no dates selected */
-
   placeholder?: string
 }
 
@@ -137,7 +137,7 @@ class DatePicker extends React.Component<Props, State> {
   }
 
   render() {
-    const { onChange, placeholder, start, end, label, id, className } = this.props
+    const { onChange, placeholder, start, end, label, min, max, id, className } = this.props
     const { isExpanded, month, year } = this.state
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
 
@@ -193,7 +193,7 @@ class DatePicker extends React.Component<Props, State> {
                 this.changeMonth(-1)
               }}
             >
-              <Icon name="ChevronLeft" size={14} />
+              <Icon name="ChevronLeft" size={12} />
             </IconContainer>
             <span>{`${months[month]}, ${year}`}</span>
             <IconContainer
@@ -202,10 +202,10 @@ class DatePicker extends React.Component<Props, State> {
                 this.changeMonth(+1)
               }}
             >
-              <Icon name="ChevronRight" size={14} />
+              <Icon name="ChevronRight" size={12} />
             </IconContainer>
           </MonthNav>
-          <Month start={start} end={end} year={year} month={month} onChange={onChange} />
+          <Month start={start} end={end} min={min} max={max} year={year} month={month} onChange={onChange} />
         </DatePickerCard>
       </Container>
     )

--- a/packages/components/src/DatePicker/DatePicker.utils.ts
+++ b/packages/components/src/DatePicker/DatePicker.utils.ts
@@ -26,6 +26,16 @@ export const range = (n: number): number[] =>
     length: n,
   }).map((_: number, i: number): number => i)
 
+export const changeMonth = (
+  diff: number,
+  { year, month }: { year: number; month: number },
+): { year: number; month: number } => {
+  return {
+    month: month + diff < 0 ? month + diff + 12 : (month + diff) % 12,
+    year: month + diff < 0 ? year - 1 : month + diff > 11 ? year + 1 : year,
+  }
+}
+
 export const toDate = (year: number, month: number, day: number): string =>
   `${year}-${month < 9 ? "0" : ""}${month + 1}-${day < 9 ? "0" : ""}${day + 1}`
 

--- a/packages/components/src/DatePicker/README.md
+++ b/packages/components/src/DatePicker/README.md
@@ -5,10 +5,10 @@ DatePickers can currently be used to pick an period bound by two day selections.
 ```jsx
 class ComponentWithDatePicker extends React.Component {
   constructor(props) {
-    super(props);
+    super(props)
     this.state = {
       start: "2017-10-03",
-      end: "2017-10-18"
+      end: "2017-10-18",
     }
   }
 
@@ -17,6 +17,8 @@ class ComponentWithDatePicker extends React.Component {
       <DatePicker
         start={this.state.start}
         end={this.state.end}
+        min="2017-10-01"
+        max="2018-01-01"
         placeholder="Pick a date"
         onChange={newState => {
           this.setState(prevState => newState)
@@ -26,5 +28,5 @@ class ComponentWithDatePicker extends React.Component {
   }
 }
 
-<ComponentWithDatePicker />
+;<ComponentWithDatePicker />
 ```

--- a/packages/components/src/DatePicker/README.md
+++ b/packages/components/src/DatePicker/README.md
@@ -18,7 +18,7 @@ class ComponentWithDatePicker extends React.Component {
         start={this.state.start}
         end={this.state.end}
         min="2017-10-01"
-        max="2018-01-01"
+        max="2017-11-30"
         placeholder="Pick a date"
         onChange={newState => {
           this.setState(prevState => newState)

--- a/packages/components/src/DatePicker/__tests__/DatePicker.test.tsx
+++ b/packages/components/src/DatePicker/__tests__/DatePicker.test.tsx
@@ -2,14 +2,12 @@ import * as React from "react"
 import { render } from "enzyme"
 import { DatePicker as ThemelessDatePicker } from "../../index"
 import wrapDefaultTheme from "../../utils/wrap-default-theme"
-import { toYearMonthDay } from "../../DatePicker/DatePicker.utils"
+import { toYearMonthDay, changeMonth } from "../../DatePicker/DatePicker.utils"
 
 const DatePicker = wrapDefaultTheme(ThemelessDatePicker)
 
 describe("DatePicker Component", () => {
-  // @todo: this fails because of the way TypeScript imports are handled between Jest and the compiler.
-  // Add this back once a stable solution is found.
-  xit("Should render", () => {
+  it("Should render", () => {
     const renderedComponent = render(<DatePicker start="2018-01-02" end="2018-01-23" placeholder="Pick a date" />)
     expect(renderedComponent).toMatchSnapshot()
   })
@@ -17,5 +15,14 @@ describe("DatePicker Component", () => {
     expect(toYearMonthDay("2018-01-01").year).toEqual(2018)
     expect(toYearMonthDay("2018-01-01").month).toEqual(0)
     expect(toYearMonthDay("2018-01-01").day).toEqual(0)
+  })
+  it("Changes the current month", () => {
+    expect(changeMonth(2, { year: 2018, month: 2 })).toEqual({ year: 2018, month: 4 })
+  })
+  it("Changes the current month, going into the next year", () => {
+    expect(changeMonth(2, { year: 2018, month: 10 })).toEqual({ year: 2019, month: 0 })
+  })
+  it("Changes the current month, going into the previous year", () => {
+    expect(changeMonth(-1, { year: 2018, month: 0 })).toEqual({ year: 2017, month: 11 })
   })
 })

--- a/packages/components/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/components/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatePicker Component Should render 1`] = `
+<div
+  class="css-ar73w8-Messages"
+/>
+`;


### PR DESCRIPTION
### Summary

This PR adds min/max props that allow upper and lower date-bounds be set on this component - in `<DatePicker min="2018-01-01" ... />`, dates before the beginning of this year may not be selected. The restriction only applies to dates that may come out of the `onChange` method - any initial date range can be passed in, only ones within the allowed range can come out.

I took this opportunity to also improve the styling and add some hover background- and cursor feedback. 

<img width="259" alt="screen shot 2018-07-17 at 9 20 33 am" src="https://user-images.githubusercontent.com/6738398/42802276-b8b8cd3c-89a2-11e8-9ad5-819c4aa23deb.png">

### Related issue

https://github.com/contiamo/operational-ui/issues/388

### To be tested

Tester 1 (Tejas)

- [x] No error/warning in the console
- [x] Date picker layout works on Chrome
- [x] Date picker layout works on Firefox
- [x] Date picker layout works on Safari (if mac user)
- [ ] Date picker layout works on IE11 and Edge (if windows user)
- [x] `min` / `max` props are working


Tester 2 (Imo)

- [x] No error/warning in the console
- [x] Date picker layout works on Chrome
- [x] Date picker layout works on Firefox
- [ ] Date picker layout works on Safari (if mac user)
- [ ] Date picker layout works on IE11 and Edge (if windows user)
- [x] `min` / `max` props are working