### PR TITLE
Feat/textarea fullwidth

### DIFF
--- a/packages/components/src/CardColumn/CardColumn.tsx
+++ b/packages/components/src/CardColumn/CardColumn.tsx
@@ -7,10 +7,13 @@ export interface Props {
   title?: string
   /** Align the content to the right */
   contentRight?: boolean
+
+  /** Set the component as a flex-box column */
+  flexColumn?: boolean
 }
 
 const Container = styled("div")(
-  ({ theme, contentRight }: { theme?: OperationalStyleConstants; contentRight?: Props["contentRight"] }) => ({
+  ({ theme, contentRight, flexColumn }: { theme?: OperationalStyleConstants } & Props) => ({
     label: "card-column",
     minWidth: 280 / 2,
     padding: theme.space.element / 2,
@@ -19,6 +22,13 @@ const Container = styled("div")(
       maxWidth: "100%",
     },
     textAlign: contentRight ? "right" : null,
+    ...(flexColumn
+      ? {
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: contentRight ? "flex-end" : "flex-start",
+        }
+      : {}),
   }),
 )
 
@@ -32,7 +42,7 @@ const Title = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) =
   marginBottom: theme.space.content,
 }))
 
-const CardColumn: React.SFC<Props & React.HTMLAttributes<HTMLDivElement>> = ({ title, children, ...props }) => (
+const CardColumn: React.SFC<Props> = ({ title, children, ...props }) => (
   <Container {...props}>
     {title && <Title>{title}</Title>}
     {children}

--- a/packages/components/src/CardColumn/CardColumn.tsx
+++ b/packages/components/src/CardColumn/CardColumn.tsx
@@ -32,7 +32,7 @@ const Title = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) =
   marginBottom: theme.space.content,
 }))
 
-const CardColumn: React.SFC<Props> = ({ title, children, ...props }) => (
+const CardColumn: React.SFC<Props & React.HTMLAttributes<HTMLDivElement>> = ({ title, children, ...props }) => (
   <Container {...props}>
     {title && <Title>{title}</Title>}
     {children}

--- a/packages/components/src/CardColumn/CardColumn.tsx
+++ b/packages/components/src/CardColumn/CardColumn.tsx
@@ -7,7 +7,6 @@ export interface Props {
   title?: string
   /** Align the content to the right */
   contentRight?: boolean
-
   /** Set the component as a flex-box column */
   flexColumn?: boolean
 }

--- a/packages/components/src/CardColumns/README.md
+++ b/packages/components/src/CardColumns/README.md
@@ -85,3 +85,28 @@ The `CardColumns` component is used as a wrapper around groups of `CardColumn` c
   </CardColumns>
 </Card>
 ```
+
+### With flexColumn
+
+```jsx
+<Card title="Playground">
+  <CardColumns>
+    <CardColumn title="Input">
+      <Textarea code value="hello-word" fullWidth />
+    </CardColumn>
+    <CardColumn title="Schema" flexColumn>
+      <Code syntax="json">{`schema is not availble for this function`}</Code>
+    </CardColumn>
+  </CardColumns>
+  <CardColumns>
+    <CardColumn>
+      <Button color="primary">Send Request</Button>
+    </CardColumn>
+    <CardColumn contentRight>
+      <Button color="grey" icon="ExternalLink">
+        curl/code
+      </Button>
+    </CardColumn>
+  </CardColumns>
+</Card>
+```

--- a/packages/components/src/Code/Code.tsx
+++ b/packages/components/src/Code/Code.tsx
@@ -12,6 +12,20 @@ export interface Props {
   children?: string | string[]
 }
 
+const Container = styled("div")`
+  display: flex;
+  flex: 1;
+  pre {
+    flex: 1;
+    display: flex;
+    margin: 0;
+  }
+
+  code {
+    flex: 1;
+  }
+`
+
 const Code = styled(Highlight)(({ theme }: { theme?: OperationalStyleConstants }) => {
   return {
     margin: 0,
@@ -22,6 +36,10 @@ const Code = styled(Highlight)(({ theme }: { theme?: OperationalStyleConstants }
   }
 })
 
-const StyledCode = (props: Props) => <Code className={`${css(styles)} ${props.syntax}`}>{props.children}</Code>
+const StyledCode = (props: Props) => (
+  <Container>
+    <Code className={`${css(styles)} ${props.syntax}`}>{props.children}</Code>
+  </Container>
+)
 
 export default StyledCode

--- a/packages/components/src/ContextMenu/ContextMenu.tsx
+++ b/packages/components/src/ContextMenu/ContextMenu.tsx
@@ -70,7 +70,7 @@ class ContextMenu extends React.Component<Props, State> {
     isOpen: false,
   }
 
-  defaultProps = {
+  static defaultProps: Partial<Props> = {
     align: "left",
   }
 

--- a/packages/components/src/Textarea/Textarea.tsx
+++ b/packages/components/src/Textarea/Textarea.tsx
@@ -8,28 +8,20 @@ import Hint from "../Hint/Hint"
 export interface Props {
   id?: string
   className?: string
-
   /** Controlled value of the field */
   value: string
-
   /** Label of the field */
   label?: string
-
   /** OnChange handler */
   onChange?: (val: string) => void
-
   /** Change the font to monospace to better display of code */
   code?: boolean
-
   /** Text for a hint */
   hint?: string
-
   /** Error text */
   error?: string
-
   /** Should the input fill its container? */
   fullWidth?: boolean
-
   /** Is it disabled? */
   disabled?: boolean
 }

--- a/packages/components/src/Textarea/Textarea.tsx
+++ b/packages/components/src/Textarea/Textarea.tsx
@@ -2,10 +2,8 @@ import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants } from "../utils/constants"
 
-import { Label, LabelText, FormFieldControls, FormFieldControl, FormFieldError, inputFocus } from "../utils/mixins"
-import { Icon, Hint } from "../"
-import Tooltip from "../Tooltip/Tooltip" // Styled components appears to have an internal bug that breaks when this is imported from index.ts
-import { Css, CssStatic } from "../types"
+import { Label, LabelText, FormFieldControls, FormFieldError, inputFocus } from "../utils/mixins"
+import Hint from "../Hint/Hint"
 
 export interface Props {
   id?: string
@@ -30,6 +28,9 @@ export interface Props {
   error?: string
   /** Is it disabled? */
 
+  /** Should the input fill its container? */
+  fullWidth?: boolean
+
   disabled?: boolean
 }
 
@@ -44,7 +45,7 @@ const TextareaComp = styled("textarea")(
     isCode: boolean
     isError: boolean
     disabled: boolean
-  }): CssStatic => {
+  }) => {
     return {
       ...theme.deprecated.typography.body,
       display: "block",
@@ -63,14 +64,9 @@ const TextareaComp = styled("textarea")(
   },
 )
 
-const HelpTooltip = styled(Tooltip)({
-  minWidth: 100,
-  width: "fit-content",
-})
-
 const Textarea = (props: Props) => {
   return (
-    <Label className={props.className} id={props.id}>
+    <Label fullWidth={props.fullWidth} className={props.className} id={props.id}>
       {props.label ? <LabelText>{props.label}</LabelText> : null}
       <FormFieldControls>{props.hint && <Hint>{props.hint}</Hint>}</FormFieldControls>
       <TextareaComp

--- a/packages/components/src/Textarea/Textarea.tsx
+++ b/packages/components/src/Textarea/Textarea.tsx
@@ -8,29 +8,29 @@ import Hint from "../Hint/Hint"
 export interface Props {
   id?: string
   className?: string
+
   /** Controlled value of the field */
-
   value: string
+
   /** Label of the field */
-
   label?: string
+
   /** OnChange handler */
-
   onChange?: (val: string) => void
+
   /** Change the font to monospace to better display of code */
-
   code?: boolean
+
   /** Text for a hint */
-
   hint?: string
-  /** Error text */
 
+  /** Error text */
   error?: string
-  /** Is it disabled? */
 
   /** Should the input fill its container? */
   fullWidth?: boolean
 
+  /** Is it disabled? */
   disabled?: boolean
 }
 

--- a/packages/components/src/utils/with-label.tsx
+++ b/packages/components/src/utils/with-label.tsx
@@ -14,9 +14,9 @@ const Label = styled("label")(({ theme }: { theme?: OperationalStyleConstants })
   marginBottom: theme.deprecated.spacing / 4,
 }))
 
-type IComponent = Pick<React.HTMLProps<HTMLDivElement>, "className" | "label" | "id">
-
-function withLabel<T extends IComponent>(Component: React.ComponentType<T>): React.SFC<T> {
+function withLabel<T extends Pick<React.HTMLProps<HTMLDivElement>, "className" | "label" | "id">>(
+  Component: React.ComponentType<T>,
+): React.SFC<T> {
   return (props: T) => {
     const { id, label } = props
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)

--- a/packages/components/src/utils/with-label.tsx
+++ b/packages/components/src/utils/with-label.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import styled from "react-emotion"
 import { OperationalStyleConstants } from "./constants"
-import { Css } from "../types"
 
 const Container = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
   display: "inline-block",
@@ -15,16 +14,14 @@ const Label = styled("label")(({ theme }: { theme?: OperationalStyleConstants })
   marginBottom: theme.deprecated.spacing / 4,
 }))
 
-type IComponent = Pick<React.HTMLProps<HTMLDivElement>, "className" | "label" | "id"> & {
-  css?: Css
-}
+type IComponent = Pick<React.HTMLProps<HTMLDivElement>, "className" | "label" | "id">
 
 function withLabel<T extends IComponent>(Component: React.ComponentType<T>): React.SFC<T> {
-  return (props: T & IComponent) => {
+  return (props: T) => {
     const { id, label } = props
     const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : null)
     return (
-      <Container className={props.className} css={props.css}>
+      <Container className={props.className}>
         {props.label && <Label htmlFor={domId}>{props.label}</Label>}
         {props.label && <br />}
         <Component {...props} id={domId} />


### PR DESCRIPTION
### Summary

![image](https://user-images.githubusercontent.com/1761469/42805060-11c234ba-89ab-11e8-8356-4c9fbb39ee80.png)

To be able to do this screen, I added `fullWidth` property to `TextArea` and `flexColumn` to `CardColumn`

### Other fixes
* Remove the following warning: 
![image](https://user-images.githubusercontent.com/1761469/42805504-422de756-89ac-11e8-87fa-35b7f96d16eb.png)

* Fix some type issue with `withLabel` that I have when I'm linking operational-ui into labs-ui

### Related issue

https://trello.com/c/FW1EFFIu

### To be tested

**Fabien**

- [x] No error/warning in the console
- [x] I can reproduce the screenshot in labs-ui easily 😎 (with npm-link)

**Tejas**

- [ ] The netlify build is working
- [ ] I can set TextArea in fullWidth mode
- [ ] ContextMenu is working as before
- [ ] Checkbox is working as before

**Peter**

- [x] The netlify build is working
- [x] I can set TextArea in fullWidth mode
- [x] ContextMenu is working as before
- [x] Checkbox is working as before
