### PR TITLE
Fix vertical alignment bug for card header action items

### DIFF
--- a/packages/components/src/CardHeader/CardHeader.tsx
+++ b/packages/components/src/CardHeader/CardHeader.tsx
@@ -49,10 +49,15 @@ const Container = styled("div")(({ theme }: { theme?: OperationalStyleConstants 
   },
 }))
 
+const ActionsContainer = styled("div")`
+  display: flex;
+  align-items: center;
+`
+
 const CardHeader = (props: Props) => (
   <Container id={props.id} className={props.className}>
     <div>{props.title || props.children}</div>
-    <div>{props.action}</div>
+    <ActionsContainer>{props.action}</ActionsContainer>
   </Container>
 )
 

--- a/packages/components/src/CardHeader/README.md
+++ b/packages/components/src/CardHeader/README.md
@@ -16,15 +16,11 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
 <Card>
   <CardHeader
     action={
-      <div>
+      <>
         <Button condensed>Button</Button>
-        <Button condensed color="primary">
-          Button <Icon name="Plus" />
-        </Button>
-        <a href="#">
-          Link <Icon name="ExternalLink" />
-        </a>
-      </div>
+        Persisting changes
+        <Spinner bounce right />
+      </>
     }
   >
     Title for my card
@@ -48,10 +44,10 @@ Passing `title` and `action` props to the `Card` component can be used as a shor
 <Card>
   <CardHeader
     action={
-      <div>
+      <>
         <Button condensed>Button</Button>
         <a href="#">Link</a>
-      </div>
+      </>
     }
     title={
       <>


### PR DESCRIPTION
### Summary

Card header actions need to center vertically, like so:

<img width="915" alt="screen shot 2018-07-19 at 10 33 35 am" src="https://user-images.githubusercontent.com/6738398/42931232-71fab1aa-8b3f-11e8-8bd2-0104cf823098.png">

### Related issue

This PR fixes #606

### To be tested

Tester 1 (Imo)

- [x] No error/warning in the console
- [x] Correct centering

Tester 2 (Fab)

- [x] No error/warning in the console
- [x] Correct centering
