### PR TITLE
Fix page routing sync

### DIFF
--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -103,6 +103,15 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
     }
   }
 
+  componentDidUpdate(props: Props) {
+    if (this.props.activeTabName && props.activeTabName !== this.props.activeTabName) {
+      const index = this.props.tabs.findIndex(
+        ({ name }) => name.toLowerCase() === this.props.activeTabName.toLowerCase(),
+      )
+      this.setState({ activeTab: index === -1 ? 0 : index })
+    }
+  }
+
   onTabClick(index: number) {
     this.setState({ activeTab: index })
     this.props.onTabChange && this.props.onTabChange(this.props.tabs[index].name.toLowerCase())

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -24,7 +24,7 @@ export interface Props {
   /**
    * Active tab name
    *
-   * Useful for easy router mapping
+   * If not specified, active tab is controlled by internal state.
    */
   activeTabName?: string
   /**
@@ -90,36 +90,30 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
     fill: false,
   }
 
-  constructor(props: Props) {
-    super(props)
-    if (props.activeTabName && props.tabs) {
-      const index = props.tabs.findIndex(({ name }) => name.toLowerCase() === props.activeTabName.toLowerCase())
-      this.state = {
-        ...initialState,
-        activeTab: index === -1 ? 0 : index,
-      }
-    } else {
-      this.state = initialState
-    }
-  }
-
-  componentDidUpdate(props: Props) {
-    if (this.props.activeTabName && props.activeTabName !== this.props.activeTabName) {
-      const index = this.props.tabs.findIndex(
-        ({ name }) => name.toLowerCase() === this.props.activeTabName.toLowerCase(),
-      )
-      this.setState({ activeTab: index === -1 ? 0 : index })
-    }
-  }
+  state = initialState
 
   onTabClick(index: number) {
     this.setState({ activeTab: index })
     this.props.onTabChange && this.props.onTabChange(this.props.tabs[index].name.toLowerCase())
   }
 
+  getActiveTab(): number {
+    let activeTab: number
+    if (this.props.activeTabName) {
+      const index = this.props.tabs.findIndex(
+        ({ name }) => name.toLowerCase() === this.props.activeTabName.toLowerCase(),
+      )
+      activeTab = index === -1 ? 0 : index
+    } else {
+      activeTab = this.state.activeTab
+    }
+
+    return activeTab
+  }
+
   render() {
     const { children, title, actions, tabs, areas, fill } = this.props
-    const { activeTab } = this.state
+    const activeTab = this.getActiveTab()
     const grid = React.Children.count(children) > 1 ? "main side" : "main"
     const CurrentTab = tabs && tabs[activeTab].component
 

--- a/packages/components/src/Page/README.md
+++ b/packages/components/src/Page/README.md
@@ -119,6 +119,55 @@ const Tab = n => () => (
 />
 ```
 
+### With activeTabName trigger from outside (router)
+
+```jsx
+const Tab = n => () => (
+  <PageContent>
+    <Card title={`${n} Tab`} />
+  </PageContent>
+)
+
+class Router extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      tabName: "jobs",
+    }
+  }
+
+  goTo(tabName) {
+    this.setState({ tabName })
+  }
+
+  render() {
+    return (
+      <>
+        <div style={{ paddingBottom: 10, marginBottom: 10, borderBottom: "1px black solid" }}>
+          <h1>Router actions</h1>
+          <p>Current route: {this.state.tabName}</p>
+          <Button onClick={() => this.goTo("overview")}>go to overview</Button>
+          <Button onClick={() => this.goTo("jobs")}>go to jobs</Button>
+          <Button onClick={() => this.goTo("functions")}>go to functions</Button>
+        </div>
+        <Page
+          title="Bundle detail"
+          activeTabName={this.state.tabName}
+          onTabChange={this.goTo.bind(this)}
+          tabs={[
+            { name: "overview", component: Tab("overview") },
+            { name: "jobs", component: Tab("jobs") },
+            { name: "functions", component: Tab("functions") },
+          ]}
+        />
+      </>
+    )
+  }
+}
+
+;<Router />
+```
+
 ### With different layout
 
 ```jsx

--- a/packages/components/src/Page/README.md
+++ b/packages/components/src/Page/README.md
@@ -104,7 +104,7 @@ const Tab = n => () => (
 ```jsx
 const Tab = n => () => (
   <PageContent>
-    <Card title={`${n} Tab`} />
+    <Card title={`${n} Tab`}>The tabs are not working because nothing update `activeTabName`!</Card>
   </PageContent>
 )
 ;<Page
@@ -119,7 +119,7 @@ const Tab = n => () => (
 />
 ```
 
-### With activeTabName trigger from outside (router)
+### With activeTabName controlled (classically with a router)
 
 ```jsx
 const Tab = n => () => (


### PR DESCRIPTION
### Summary
The page routing can be out of sync if the router state change and the component is already mount.

Before:
![ef415011-6e60-4cc4-93e6-0c1c1257e0a0](https://user-images.githubusercontent.com/1761469/42940011-323eff94-8b58-11e8-8ff9-245016750876.gif)

After:
![a75bb28e-c789-4802-a552-9db0a7a5ee37](https://user-images.githubusercontent.com/1761469/42939941-e93e25e0-8b57-11e8-870e-5c486d6d4b17.gif)

### To be tested
Fabien 
- [x] No error/warning in the console

Tejas
- [x] The netlify build is working
- [x] The Page tab is sync with the router state (cf Page/With activeTabName trigger from outside (router) example)

Tester 2

- [ ] The netlify build is working
- [ ] The Page tab is sync with the router state (cf Page/With activeTabName trigger from outside (router) example)
