### PR TITLE
Hidden tab

### DIFF
--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -20,7 +20,7 @@ export interface Props {
    * List of tabs
    * This will disable any children to render `tabs[i].component` instead
    */
-  tabs?: { name: string; component: React.ComponentType }[]
+  tabs?: { name: string; component: React.ComponentType; hidden?: boolean }[]
   /**
    * Active tab name
    *
@@ -128,7 +128,7 @@ class Page extends React.Component<Props, Readonly<typeof initialState>> {
         {tabs ? (
           <>
             <TabsBar>
-              {tabs.map(({ name }, i) => (
+              {tabs.filter(({ hidden }) => !hidden).map(({ name }, i) => (
                 <Tab key={i} active={i === activeTab} onClick={() => this.onTabClick(i)}>
                   {name}
                 </Tab>

--- a/packages/components/src/Page/README.md
+++ b/packages/components/src/Page/README.md
@@ -168,6 +168,57 @@ class Router extends React.Component {
 ;<Router />
 ```
 
+### With hidden tab
+
+```jsx
+const Tab = n => () => (
+  <PageContent>
+    <Card title={`${n} Tab`} />
+  </PageContent>
+)
+
+class Router extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      tabName: "jobs",
+    }
+  }
+
+  goTo(tabName) {
+    this.setState({ tabName })
+  }
+
+  render() {
+    return (
+      <>
+        <div style={{ paddingBottom: 10, marginBottom: 10, borderBottom: "1px black solid" }}>
+          <h1>Router actions</h1>
+          <p>Current route: {this.state.tabName}</p>
+          <Button onClick={() => this.goTo("overview")}>go to overview</Button>
+          <Button onClick={() => this.goTo("jobs")}>go to jobs</Button>
+          <Button onClick={() => this.goTo("functions")}>go to functions</Button>
+          <Button onClick={() => this.goTo("editor")}>go to editor</Button>
+        </div>
+        <Page
+          title="Bundle detail"
+          activeTabName={this.state.tabName}
+          onTabChange={this.goTo.bind(this)}
+          tabs={[
+            { name: "overview", component: Tab("overview") },
+            { name: "jobs", component: Tab("jobs") },
+            { name: "functions", component: Tab("functions") },
+            { name: "editor", component: Tab("editor"), hidden: true },
+          ]}
+        />
+      </>
+    )
+  }
+}
+
+;<Router />
+```
+
 ### With different layout
 
 ```jsx


### PR DESCRIPTION
⚠️ To be reviewed after #610 ⚠️ 

### Summary

![image](https://user-images.githubusercontent.com/1761469/42941659-bf3fd62a-8b5d-11e8-89af-d2c424e33811.png)

To integrate this kind of screen, we need to have a way to set some "hidden" tab (to have the routing working)

### Related issue

https://trello.com/c/3e7v8Lvc

### To be tested

Fabien 
- [x] No error/warning in the console

Tester 1

- [ ] The netlify build is working
- [ ] The hide tab working is expected (active tabs, sync with the routing…)

Tester 2

- [ ] The netlify build is working
- [ ] The hide tab working is expected (active tabs, synce with the routing…)
