### PR TITLE
Adjust default color of the spinner

### DIFF
--- a/packages/components/src/Spinner/README.md
+++ b/packages/components/src/Spinner/README.md
@@ -44,11 +44,14 @@ In addition to the regular spinning animation, there is a bouncing one that is d
     <circle r="15px" fill="gold" cx="340" cy="90" />
     <circle r="10px" fill="orange" cx="15" cy="90" />
   </svg>
-  <div style={{ position: "absolute", bottom: 11, left: 60 }}>
+  <div style={{ position: "absolute", bottom: 11, left: 60, zIndex: 2 }}>
     <Spinner color="black" size={60} />
   </div>
-  <div style={{ position: "absolute", bottom: 11, left: 240 }}>
+  <div style={{ position: "absolute", bottom: 11, left: 240, zIndex: 2 }}>
     <Spinner color="black" size={60} />
+  </div>
+  <div style={{ position: "absolute", bottom: 53, left: 59, zIndex: 1 }}>
+    <ContiamoLogo size={50} />
   </div>
 </div>
 ```

--- a/packages/components/src/Spinner/README.md
+++ b/packages/components/src/Spinner/README.md
@@ -7,7 +7,11 @@ Spinners render in custom sizes and colors.
 ```js
 <>
   <Spinner />
+  <br />
   <Spinner color="primary" />
+  <br />
+  <Spinner color="#f0f" />
+  <br />
   <Spinner size={12} />
 </>
 ```
@@ -19,5 +23,32 @@ In addition to the regular spinning animation, there is a bouncing one that is d
 ```js
 <>
   <Spinner bounce />
+  <br />
+  <Spinner color="success" bounce />
+  <br />
+  <Spinner color="#f0f" bounce />
 </>
+```
+
+### Fun mode
+
+```js
+<div style={{ position: "relative" }}>
+  <svg width="365" height="185">
+    <rect x="70" y="10" width="220" height="130" fill="transparent" rx="150" stroke="#1499cc" strokeWidth="10" />
+    <rect x="10" y="70" width="340" height="80" fill="#1499cc" rx="30" />
+    <line x1="145" y1="10" x2="145" y2="80" stroke="#1499cc" strokeWidth="10" />
+    <line x1="215" y1="10" x2="215" y2="80" stroke="#1499cc" strokeWidth="10" />
+    <rect x="0" y="110" width="40" height="20" fill="#999" rx="10" />
+    <rect x="325" y="110" width="40" height="20" fill="#999" rx="10" />
+    <circle r="15px" fill="gold" cx="340" cy="90" />
+    <circle r="10px" fill="orange" cx="15" cy="90" />
+  </svg>
+  <div style={{ position: "absolute", bottom: 11, left: 60 }}>
+    <Spinner color="black" size={60} />
+  </div>
+  <div style={{ position: "absolute", bottom: 11, left: 240 }}>
+    <Spinner color="black" size={60} />
+  </div>
+</div>
 ```

--- a/packages/components/src/Spinner/Spinner.tsx
+++ b/packages/components/src/Spinner/Spinner.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import styled, { keyframes } from "react-emotion"
 import { OperationalStyleConstants, expandColor } from "../utils/constants"
-import { WithTheme, Css, CssStatic } from "../types"
 
 export interface Props {
   id?: string
@@ -55,7 +54,6 @@ const Container = styled("div")(
   ({
     size,
     color,
-    bounce,
     theme,
     left,
     right,
@@ -70,11 +68,10 @@ const Container = styled("div")(
     display: "inline-block",
     width: size || defaultSize,
     height: size || defaultSize,
-    color: expandColor(theme, color) || "currentColor",
     marginRight: left ? theme.space.small : 0,
     marginLeft: right ? theme.space.small : 0,
     "& svg": {
-      fill: "currentColor",
+      fill: expandColor(theme, color) || theme.color.text.lighter,
     },
   }),
 )
@@ -96,7 +93,7 @@ const AnimationContainer = styled("div")(({ bounce, size }: { bounce?: boolean; 
   animation: bounce ? "none" : `${spinKeyframes} 1.5s infinite linear`,
 }))
 
-const RegularSpinner = () => (
+const RegularSpinner = (_: { color?: Props["color"] }) => (
   <svg viewBox="0 0 360 360">
     <path d="M160,0 L160,100 L200,100 L200,0Z" />
     <path d="M321.396,67.075l-70.697,70.697l-28.284,-28.284l70.697,-70.697c9.428,9.428 18.856,18.856 28.284,28.284Z" />
@@ -121,32 +118,34 @@ const BouncingSpinnerContainer = styled("div")({
  * The math used in here lays these boxes out so they're vertically centered and spaced
  * equally on the horizontal axis without any gutter.
  */
-const BouncingSpinnerBox = styled("div")(({ no }: { no: number }) => ({
-  width: `${(80 / 360) * 100}%`,
-  height: `${(80 / 360) * 100}%`,
-  position: "absolute",
-  top: `${(140 / 360) * 100}%`,
-  left: `${((no * 140) / 360) * 100}%`,
-  backgroundColor: "currentColor",
-  animation: `${bounceKeyframes} 1s infinite ease-in-out`,
-  /*
+const BouncingSpinnerBox = styled("div")(
+  ({ no, theme, color }: { no: number; theme?: OperationalStyleConstants; color?: Props["color"] }) => ({
+    width: `${(80 / 360) * 100}%`,
+    height: `${(80 / 360) * 100}%`,
+    position: "absolute",
+    top: `${(140 / 360) * 100}%`,
+    left: `${((no * 140) / 360) * 100}%`,
+    backgroundColor: expandColor(theme, color) || theme.color.text.lighter,
+    animation: `${bounceKeyframes} 1s infinite ease-in-out`,
+    /*
    * Achieve the wave effect through incremental animation delays on the individual elements.
    */
-  animationDelay: `${no * 0.16}s`,
-}))
+    animationDelay: `${no * 0.16}s`,
+  }),
+)
 
-const BouncingSpinner = () => (
+const BouncingSpinner = (props: Props) => (
   <BouncingSpinnerContainer>
-    <BouncingSpinnerBox no={0} />
-    <BouncingSpinnerBox no={1} />
-    <BouncingSpinnerBox no={2} />
+    <BouncingSpinnerBox color={props.color} no={0} />
+    <BouncingSpinnerBox color={props.color} no={1} />
+    <BouncingSpinnerBox color={props.color} no={2} />
   </BouncingSpinnerContainer>
 )
 
 const Spinner = (props: Props) => (
   <Container {...props}>
     <AnimationContainer bounce={props.bounce} size={props.size}>
-      {props.bounce ? <BouncingSpinner /> : <RegularSpinner />}
+      {props.bounce ? <BouncingSpinner color={props.color} /> : <RegularSpinner color={props.color} />}
     </AnimationContainer>
   </Container>
 )


### PR DESCRIPTION
## [Go Play! 🎉](https://deploy-preview-615--operational-ui.netlify.com/#!/Spinner)

### Summary
The current spinner takes on the text-color of its parent as its fill color, so it's usually black. This PR makes it grey by default according to our design.
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

### Related issue
https://trello.com/c/OURJ6v33

<!-- Paste the github issue here -->

### To be tested

Fabien

- [x] The netlify build is working
- [x] The spinner looks good
- [x] The car is sexy 🚗 
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Imogen

- [x] The netlify build is working
- [x] The spinner looks good
- [ ] The car is sexy :car:
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
