### PR TITLE
Add aliases to ProgressPanel to match more usages

### DIFF
--- a/packages/components/src/ProgressPanel/ProgressPanel.tsx
+++ b/packages/components/src/ProgressPanel/ProgressPanel.tsx
@@ -26,27 +26,27 @@ const getVariation = (status: Status, theme: OperationalStyleConstants = default
       return {
         iconColor: theme.color.success,
         textColor: theme.color.text.default,
-        Icon: <Icon left name="Yes" />,
+        icon: <Icon left name="Yes" />,
       }
     case "failure":
     case "failed":
       return {
         iconColor: theme.color.error,
         textColor: theme.color.text.default,
-        Icon: <Icon left name="No" />,
+        icon: <Icon left name="No" />,
       }
     case "waiting":
     case "todo":
       return {
         iconColor: theme.color.text.lightest,
         textColor: theme.color.text.lighter,
-        Icon: <Icon left name="EmptyCircle" />,
+        icon: <Icon left name="EmptyCircle" />,
       }
     case "running":
       return {
         iconColor: theme.color.text.dark,
         textColor: theme.color.text.lightest,
-        Icon: <Spinner left />,
+        icon: <Spinner left />,
       }
   }
 }
@@ -86,7 +86,7 @@ const ProgressPanel: React.SFC<Props> = props => (
     {props.items.map(({ status, title, error }, index) => (
       <Item key={index}>
         <Body status={status}>
-          {getVariation(status).Icon}
+          {getVariation(status).icon}
           {title}
         </Body>
         {error && <Error>{error}</Error>}

--- a/packages/components/src/ProgressPanel/ProgressPanel.tsx
+++ b/packages/components/src/ProgressPanel/ProgressPanel.tsx
@@ -5,7 +5,7 @@ import { OperationalStyleConstants } from "../utils/constants"
 import Icon from "../Icon/Icon"
 import Spinner from "../Spinner/Spinner"
 
-export type Status = "waiting" | "running" | "success" | "failure"
+export type Status = "waiting" | "todo" | "running" | "success" | "failure" | "done" | "failed"
 
 export interface Props {
   /** Progress items */
@@ -22,10 +22,13 @@ export interface Props {
 const makeIconColor = (status: Status, theme: OperationalStyleConstants) => {
   switch (status) {
     case "success":
+    case "done":
       return theme.color.success
     case "failure":
+    case "failed":
       return theme.color.error
     case "waiting":
+    case "todo":
       return theme.color.text.lightest
     case "running":
       return theme.color.text.dark
@@ -35,12 +38,15 @@ const makeIconColor = (status: Status, theme: OperationalStyleConstants) => {
 const makeTextColor = (status: Status, theme: OperationalStyleConstants) => {
   switch (status) {
     case "success":
+    case "done":
       return theme.color.text.default
     case "failure":
+    case "failed":
       return theme.color.text.default
     case "running":
       return theme.color.text.lighter
     case "waiting":
+    case "todo":
       return theme.color.text.lightest
   }
 }
@@ -78,10 +84,13 @@ const Error = styled("p")`
 const ProgressPanelIcon: React.SFC<{ status: Status }> = props => {
   switch (props.status) {
     case "success":
+    case "done":
       return <Icon left name="Yes" />
     case "failure":
+    case "failed":
       return <Icon left name="No" />
     case "waiting":
+    case "todo":
       return <Icon left name="EmptyCircle" />
     case "running":
       return <Spinner left />

--- a/packages/components/src/ProgressPanel/ProgressPanel.tsx
+++ b/packages/components/src/ProgressPanel/ProgressPanel.tsx
@@ -19,35 +19,35 @@ export interface Props {
   }[]
 }
 
-const makeIconColor = (status: Status, theme: OperationalStyleConstants) => {
+const getVariation = (status: Status, theme: OperationalStyleConstants = { color: { text: {} } } as any) => {
   switch (status) {
     case "success":
     case "done":
-      return theme.color.success
+      return {
+        iconColor: theme.color.success,
+        textColor: theme.color.text.default,
+        Icon: <Icon left name="Yes" />,
+      }
     case "failure":
     case "failed":
-      return theme.color.error
+      return {
+        iconColor: theme.color.error,
+        textColor: theme.color.text.default,
+        Icon: <Icon left name="No" />,
+      }
     case "waiting":
     case "todo":
-      return theme.color.text.lightest
+      return {
+        iconColor: theme.color.text.lightest,
+        textColor: theme.color.text.lighter,
+        Icon: <Icon left name="EmptyCircle" />,
+      }
     case "running":
-      return theme.color.text.dark
-  }
-}
-
-const makeTextColor = (status: Status, theme: OperationalStyleConstants) => {
-  switch (status) {
-    case "success":
-    case "done":
-      return theme.color.text.default
-    case "failure":
-    case "failed":
-      return theme.color.text.default
-    case "running":
-      return theme.color.text.lighter
-    case "waiting":
-    case "todo":
-      return theme.color.text.lightest
+      return {
+        iconColor: theme.color.text.dark,
+        textColor: theme.color.text.lightest,
+        Icon: <Spinner left />,
+      }
   }
 }
 
@@ -64,10 +64,10 @@ const Body = styled("div")`
   align-items: center;
   justify-content: flex-start;
   ${({ theme, status }: { theme?: OperationalStyleConstants; status: Status }) => `
-    color: ${makeTextColor(status, theme)};
+    color: ${getVariation(status, theme).textColor};
     font-size: ${theme.font.size.body}px;
     & svg {
-      color: ${makeIconColor(status, theme)};
+      color: ${getVariation(status, theme).iconColor};
     }
   `};
 `
@@ -81,28 +81,12 @@ const Error = styled("p")`
   `};
 `
 
-const ProgressPanelIcon: React.SFC<{ status: Status }> = props => {
-  switch (props.status) {
-    case "success":
-    case "done":
-      return <Icon left name="Yes" />
-    case "failure":
-    case "failed":
-      return <Icon left name="No" />
-    case "waiting":
-    case "todo":
-      return <Icon left name="EmptyCircle" />
-    case "running":
-      return <Spinner left />
-  }
-}
-
 const ProgressPanel: React.SFC<Props> = props => (
   <Container>
     {props.items.map(({ status, title, error }, index) => (
       <Item key={index}>
         <Body status={status}>
-          <ProgressPanelIcon status={status} />
+          {getVariation(status).Icon}
           {title}
         </Body>
         {error && <Error>{error}</Error>}

--- a/packages/components/src/ProgressPanel/ProgressPanel.tsx
+++ b/packages/components/src/ProgressPanel/ProgressPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import styled from "react-emotion"
 
-import { OperationalStyleConstants } from "../utils/constants"
+import defaultTheme, { OperationalStyleConstants } from "../utils/constants"
 import Icon from "../Icon/Icon"
 import Spinner from "../Spinner/Spinner"
 
@@ -19,7 +19,7 @@ export interface Props {
   }[]
 }
 
-const getVariation = (status: Status, theme: OperationalStyleConstants = { color: { text: {} } } as any) => {
+const getVariation = (status: Status, theme: OperationalStyleConstants = defaultTheme) => {
   switch (status) {
     case "success":
     case "done":

--- a/packages/components/src/ProgressPanel/README.md
+++ b/packages/components/src/ProgressPanel/README.md
@@ -25,3 +25,29 @@ Progress panels indicate progress on a list of steps making up a larger process 
   ]}
 />
 ```
+
+### Usage with aliases
+
+```jsx
+<ProgressPanel
+  items={[
+    {
+      status: "done",
+      title: "Something",
+    },
+    {
+      status: "failed",
+      title: "Something",
+      error: "Failed to fetch your account data",
+    },
+    {
+      status: "running",
+      title: "Something",
+    },
+    {
+      status: "todo",
+      title: "Something",
+    },
+  ]}
+/>
+```

--- a/packages/components/src/ResourceName/ResourceName.tsx
+++ b/packages/components/src/ResourceName/ResourceName.tsx
@@ -2,8 +2,8 @@ import styled from "react-emotion"
 import { OperationalStyleConstants } from "../utils/constants"
 
 export const ResourceName = styled("span")`
-  font-family: ${({ theme }: { theme: OperationalStyleConstants }) => theme.font.family.code};
-  color: ${({ theme }: { theme: OperationalStyleConstants }) => theme.color.text.dark};
+  font-family: ${({ theme }: { theme?: OperationalStyleConstants }) => theme.font.family.code};
+  color: ${({ theme }: { theme?: OperationalStyleConstants }) => theme.color.text.dark};
 `
 
 export default ResourceName


### PR DESCRIPTION
### Summary

Just add some aliases to ProgressPanel to match our current backend convention

### To be tested

Fabien 
- [x] No error/warning in the console

Tester 1 - Peter
- [x] The netlify build is working
- [x] The component works with all kind of status

Tester 2 - Tejas

- [x] The netlify build is working
- [x] The component works with all kind of status