### PR TITLE
Explicit overflow on sidenav header

### DIFF
--- a/packages/components/src/Sidenav/README.md
+++ b/packages/components/src/Sidenav/README.md
@@ -9,7 +9,7 @@ class StatefulSidenav extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      activeHeaders: [1],
+      activeHeaders: [1, 3],
     }
   }
 
@@ -23,27 +23,38 @@ class StatefulSidenav extends React.Component {
 
   render() {
     return (
-      <Sidenav>
-        <SidenavHeader condensed icon="Home" label="Project Home" />
-        <SidenavHeader
-          label="The Prize"
-          active={this.state.activeHeaders.includes(1)}
-          onToggle={this.toggle.bind(this, 1)}
-        >
-          <SidenavItem label="The First Prize" icon="Settings" />
-          <SidenavItem label="The Second Prize" icon="Settings" />
-          <SidenavItem label="The Third Prize" icon="Settings" />
-        </SidenavHeader>
-        <SidenavHeader
-          label="Let It Snow"
-          active={this.state.activeHeaders.includes(2)}
-          onToggle={this.toggle.bind(this, 2)}
-        >
-          <SidenavItem label="The First Prize" icon="Settings" />
-          <SidenavItem label="The Second Prize" icon="Settings" />
-          <SidenavItem label="The Third Prize" icon="Settings" />
-        </SidenavHeader>
-      </Sidenav>
+      <div style={{ height: 400 }}>
+        <Sidenav>
+          <SidenavHeader condensed icon="Home" label="Project Home" />
+          <SidenavHeader
+            label="The Prize"
+            active={this.state.activeHeaders.includes(1)}
+            onToggle={this.toggle.bind(this, 1)}
+          >
+            <SidenavItem label="The First Prize" icon="Settings" />
+            <SidenavItem label="The Second Prize" icon="Settings" />
+            <SidenavItem label="The Third Prize" icon="Settings" />
+          </SidenavHeader>
+          <SidenavHeader
+            label="Let It Snow"
+            active={this.state.activeHeaders.includes(2)}
+            onToggle={this.toggle.bind(this, 2)}
+          >
+            <SidenavItem label="The First Prize" icon="Settings" />
+            <SidenavItem label="The Second Prize" icon="Settings" />
+            <SidenavItem label="The Third Prize" icon="Settings" />
+          </SidenavHeader>
+          <SidenavHeader
+            label="Let It Snow"
+            active={this.state.activeHeaders.includes(3)}
+            onToggle={this.toggle.bind(this, 3)}
+          >
+            <SidenavItem label="The First Prize" icon="Settings" />
+            <SidenavItem label="The Second Prize" icon="Settings" />
+            <SidenavItem label="The Third Prize" icon="Settings" />
+          </SidenavHeader>
+        </Sidenav>
+      </div>
     )
   }
 }

--- a/packages/components/src/Sidenav/Sidenav.tsx
+++ b/packages/components/src/Sidenav/Sidenav.tsx
@@ -34,6 +34,7 @@ const Container = styled("div")(({ theme }: { theme?: OperationalStyleConstants 
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",
+    overflow: "auto",
     width: theme.sidebarWidth,
     height: "100%",
     borderRight: "1px solid",


### PR DESCRIPTION
### Summary

Sets an explicit overflow auto property on the sidenav, taking care of cases when its contents overflow and as a result, sidenav headers/items flow out of the sidenav container.

### Related issue

https://github.com/contiamo/operational-visualizations/pull/3

### To be tested

Tejas Kumar

- [x] No error/warning in the console
- [x] Short sidenavs with many headers overflow as expected (sidenav netlify example)

Imogen

- [x] No error/warning in the console
- [x] Short sidenavs with many headers overflow as expected (sidenav netlify example)
