### PR TITLE
Modal redesign.

### DIFF
--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -35,8 +35,6 @@ const Container = styled("div")(({ theme }: { theme?: OperationalStyleConstants 
 }))
 
 class Card<T = {}> extends React.PureComponent<Props<T>> {
-  containerNode: HTMLElement
-
   static defaultProps = {
     keyFormatter: (title: string) => title,
   }
@@ -51,12 +49,7 @@ class Card<T = {}> extends React.PureComponent<Props<T>> {
     )
 
     return (
-      <Container
-        {...props}
-        innerRef={containerNode => {
-          this.containerNode = containerNode
-        }}
-      >
+      <Container {...props}>
         {(title || action) && <CardHeader title={title} action={action && <this.props.action />} />}
         {data && titles.map((title, i) => <CardItem key={i} value={values[i]} title={title} />)}
         {children}

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -35,6 +35,8 @@ const Container = styled("div")(({ theme }: { theme?: OperationalStyleConstants 
 }))
 
 class Card<T = {}> extends React.PureComponent<Props<T>> {
+  containerNode: HTMLElement
+
   static defaultProps = {
     keyFormatter: (title: string) => title,
   }
@@ -49,7 +51,12 @@ class Card<T = {}> extends React.PureComponent<Props<T>> {
     )
 
     return (
-      <Container {...props}>
+      <Container
+        {...props}
+        innerRef={containerNode => {
+          this.containerNode = containerNode
+        }}
+      >
         {(title || action) && <CardHeader title={title} action={action && <this.props.action />} />}
         {data && titles.map((title, i) => <CardItem key={i} value={values[i]} title={title} />)}
         {children}

--- a/packages/components/src/Confirm/Confirm.tsx
+++ b/packages/components/src/Confirm/Confirm.tsx
@@ -1,37 +1,12 @@
 import * as React from "react"
-import styled, { keyframes } from "react-emotion"
-import Card from "../Card/Card"
+import styled from "react-emotion"
 import { Props as ButtonProps } from "../Button/Button"
-import { OperationalStyleConstants } from "../utils/constants"
-import Overlay from "../Internals/Overlay"
+import Modal from "../Modal/Modal"
 
-const fromBottom = keyframes`
-  0% {
-    top: -10px
-  }
-
-  100% {
-    top: 0
-  }
-`
-
-const Modal = styled(Card)`
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translate(-50%, 0);
-  animation: ${fromBottom} 0.2s;
-  min-width: 600px;
-  min-height: 200px;
-  z-index: ${({ theme }: { theme?: OperationalStyleConstants }) => theme.zIndex.confirm + 1};
-`
-
-const Actions = styled("div")`
-  text-align: right;
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-`
+const Actions = styled("div")({
+  paddingTop: 20,
+  float: "right",
+})
 
 export interface ConfirmOptions {
   title: React.ReactNode
@@ -74,27 +49,22 @@ export class Confirm extends React.Component<Props, Readonly<State>> {
   }
 
   render() {
-    const { children } = this.props
     const isOpen = Boolean(this.state.options)
 
-    if (isOpen) {
-      const { title, body, cancelButton, actionButton } = this.state.options
-      return (
-        <>
-          <Modal title={title}>
-            {body}
+    return (
+      <>
+        {this.props.children(this.openConfirm)}
+        {isOpen && (
+          <Modal title={this.state.options.title} onClose={this.closeConfirm.bind(this)}>
+            {this.state.options.body}
             <Actions>
-              {React.cloneElement(cancelButton, { onClick: this.onCancelClick })}
-              {React.cloneElement(actionButton, { onClick: this.onActionClick })}
+              {React.cloneElement(this.state.options.cancelButton, { onClick: this.onCancelClick })}
+              {React.cloneElement(this.state.options.actionButton, { onClick: this.onActionClick })}
             </Actions>
           </Modal>
-          {children(this.openConfirm)}
-          <Overlay onClick={this.onCancelClick} />
-        </>
-      )
-    }
-
-    return children(this.openConfirm)
+        )}
+      </>
+    )
   }
 }
 

--- a/packages/components/src/Confirm/Confirm.tsx
+++ b/packages/components/src/Confirm/Confirm.tsx
@@ -1,12 +1,14 @@
 import * as React from "react"
 import styled from "react-emotion"
+import { OperationalStyleConstants } from "../utils/constants"
+
 import { Props as ButtonProps } from "../Button/Button"
 import Modal from "../Modal/Modal"
 
-const Actions = styled("div")({
-  paddingTop: 20,
+const Actions = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
+  marginTop: theme.space.element,
   float: "right",
-})
+}))
 
 export interface ConfirmOptions {
   title: React.ReactNode

--- a/packages/components/src/Confirm/README.md
+++ b/packages/components/src/Confirm/README.md
@@ -28,7 +28,7 @@ To have the correct style, this `Confirm` must be the first child of a `PageArea
                   <p>You can continue safely if you are a bad guy!</p>
                 </>
               ),
-              cancelButton: <Button color="success">I'm feel guilty :-/</Button>,
+              cancelButton: <Button color="success">I feel guilty :-/</Button>,
               actionButton: <Button color="error">I'm a bad guy!</Button>,
               onConfirm: () => alert("boooooommm!"),
             })

--- a/packages/components/src/Internals/Overlay.tsx
+++ b/packages/components/src/Internals/Overlay.tsx
@@ -19,7 +19,7 @@ export const Overlay = styled("div")`
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.6);
   animation: ${fadeIn} 0.1s ease-in;
-  z-index: ${({ theme }: { theme?: OperationalStyleConstants }) => theme.zIndex.confirm};
+  z-index: ${({ theme }: { theme?: OperationalStyleConstants }) => theme.zIndex.modal - 1};
 `
 
 export default Overlay

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -19,14 +19,8 @@ export interface Props {
   action?: CardProps["action"]
 }
 
-const Container = styled(Overlay)({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-})
-
 const Content = styled(Card)(({ theme }: { theme?: OperationalStyleConstants }) => ({
-  position: "absolute",
+  position: "fixed",
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
@@ -35,39 +29,13 @@ const Content = styled(Card)(({ theme }: { theme?: OperationalStyleConstants }) 
   zIndex: theme.zIndex.confirm + 1,
 }))
 
-class Modal extends React.Component<Props, {}> {
-  contentNode: HTMLElement
-
-  handleClick = (event: MouseEvent) => {
-    if (this.contentNode && !this.contentNode.contains(event.target as HTMLElement)) {
-      this.props.onClose && this.props.onClose()
-    }
-  }
-
-  componentDidMount() {
-    document.body.addEventListener("click", this.handleClick)
-  }
-
-  componentWillUnmount() {
-    document.body.removeEventListener("click", this.handleClick)
-  }
-
-  render() {
-    return (
-      <Container id={this.props.id} className={this.props.className}>
-        <Content
-          innerRef={card => {
-            this.contentNode = card && card.containerNode
-          }}
-          className={this.props.contentClassName}
-          title={this.props.title}
-          action={this.props.action}
-        >
-          {this.props.children}
-        </Content>
-      </Container>
-    )
-  }
-}
+const Modal: React.SFC<Props> = (props: Props) => (
+  <>
+    <Overlay id={props.id} className={props.className} onClick={props.onClose} />
+    <Content className={props.contentClassName} title={props.title} action={props.action}>
+      {props.children}
+    </Content>
+  </>
+)
 
 export default Modal

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -24,7 +24,7 @@ const Content = styled(Card)(({ theme }: { theme?: OperationalStyleConstants }) 
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  zIndex: theme.zIndex.confirm + 1,
+  zIndex: theme.zIndex.modal,
 }))
 
 const Modal: React.SFC<Props> = (props: Props) => (

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -30,8 +30,8 @@ const Content = styled(Card)(({ theme }: { theme?: OperationalStyleConstants }) 
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  minWidth: 400,
-  minHeight: 150,
+  minWidth: 600,
+  minHeight: 200,
   zIndex: theme.zIndex.confirm + 1,
 }))
 

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
 import styled from "react-emotion"
-import { WithTheme, Css, CssStatic } from "../types"
+import { OperationalStyleConstants } from "../utils/constants"
+
 import Overlay from "../Internals/Overlay"
+import Card from "../Card/Card"
 
 export interface Props {
   id?: string
@@ -13,6 +15,8 @@ export interface Props {
 
   children: React.ReactNode
   onClose?: () => void
+  /** Title */
+  title?: string
 }
 
 const Container = styled(Overlay)({
@@ -21,13 +25,15 @@ const Container = styled(Overlay)({
   justifyContent: "center",
 })
 
-const Content = styled("div")(
-  ({ theme }: WithTheme): CssStatic => ({
-    backgroundColor: theme.deprecated.colors.white,
-    padding: theme.deprecated.spacing,
-    boxShadow: theme.deprecated.shadows.popup,
-  }),
-)
+const Content = styled(Card)(({ theme }: { theme?: OperationalStyleConstants }) => ({
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  minWidth: 400,
+  minHeight: 150,
+  zIndex: theme.zIndex.confirm + 1,
+}))
 
 class Modal extends React.Component<Props, {}> {
   contentNode: HTMLElement
@@ -50,10 +56,11 @@ class Modal extends React.Component<Props, {}> {
     return (
       <Container id={this.props.id} className={this.props.className}>
         <Content
-          innerRef={contentNode => {
-            this.contentNode = contentNode
+          innerRef={card => {
+            this.contentNode = card && card.containerNode
           }}
           className={this.props.contentClassName}
+          title={this.props.title}
         >
           {this.props.children}
         </Content>

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -24,8 +24,6 @@ const Content = styled(Card)(({ theme }: { theme?: OperationalStyleConstants }) 
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  minWidth: 600,
-  minHeight: 200,
   zIndex: theme.zIndex.confirm + 1,
 }))
 

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -3,20 +3,20 @@ import styled from "react-emotion"
 import { OperationalStyleConstants } from "../utils/constants"
 
 import Overlay from "../Internals/Overlay"
-import Card from "../Card/Card"
+import Card, { Props as CardProps } from "../Card/Card"
 
 export interface Props {
   id?: string
   className?: string
   /** Content class name */
-
   contentClassName?: string
   /** Children */
-
-  children: React.ReactNode
+  children: CardProps["children"]
   onClose?: () => void
   /** Title */
-  title?: string
+  title?: CardProps["title"]
+  /** Action(s) to appear in top-right */
+  action?: CardProps["action"]
 }
 
 const Container = styled(Overlay)({
@@ -61,6 +61,7 @@ class Modal extends React.Component<Props, {}> {
           }}
           className={this.props.contentClassName}
           title={this.props.title}
+          action={this.props.action}
         >
           {this.props.children}
         </Content>

--- a/packages/components/src/Modal/README.md
+++ b/packages/components/src/Modal/README.md
@@ -24,8 +24,8 @@ class ContentWithModal extends React.Component {
           <Modal title="Modal header" onClose={this.onClose.bind(this)}>
             <p>Modal content</p>
             Any <Icon name="OperationalUI" size={16} /> components or HTML elements can be rendered here.
-            <div style={{ position: "absolute", bottom: 20, right: 20 }}>
-              <Button style={{ marginRight: 0 }} onClick={this.onClose.bind(this)}>
+            <div style={{ width: "100%", marginTop: 20 }}>
+              <Button style={{ marginRight: 0, float: "right" }} onClick={this.onClose.bind(this)}>
                 OK
               </Button>
             </div>
@@ -48,11 +48,3 @@ class ContentWithModal extends React.Component {
 
 ;<ContentWithModal />
 ```
-
-### Props
-
-| Name           | Description                                                                                                               | Type   | Default | Required |
-| :------------- | :------------------------------------------------------------------------------------------------------------------------ | :----- | :------ | :------- |
-| childCss       | Glamor CSS object passed down to the container's immediate child, which holds the content. Use to specify/override styles | string | -       | Yes      |
-| childClassName | Class name for the modal container's immediate child, which holds the content. Use to specify/override styles.            | string | -       | Yes      |
-| onClose        | Callback called when the modal is closed (outside area is clicked).                                                       | string | -       | Yes      |

--- a/packages/components/src/Modal/README.md
+++ b/packages/components/src/Modal/README.md
@@ -11,18 +11,24 @@ class ContentWithModal extends React.Component {
     }
   }
 
+  onClose() {
+    this.setState(prevState => ({
+      isModalOpen: false,
+    }))
+  }
+
   render() {
     return (
       <div>
         {this.state.isModalOpen ? (
-          <Modal
-            onClose={() => {
-              this.setState(prevState => ({
-                isModalOpen: false,
-              }))
-            }}
-          >
-            <div style={{ width: 300, height: 240 }}>Hello</div>
+          <Modal title="Modal header" onClose={this.onClose.bind(this)}>
+            <p>Modal content</p>
+            Any <Icon name="OperationalUI" size={16} /> components or HTML elements can be rendered here.
+            <div style={{ width: "100%", paddingTop: 20 }}>
+              <Button style={{ float: "right", marginRight: 0 }} onClick={this.onClose.bind(this)}>
+                OK
+              </Button>
+            </div>
           </Modal>
         ) : null}
         <Button

--- a/packages/components/src/Modal/README.md
+++ b/packages/components/src/Modal/README.md
@@ -24,8 +24,8 @@ class ContentWithModal extends React.Component {
           <Modal title="Modal header" onClose={this.onClose.bind(this)}>
             <p>Modal content</p>
             Any <Icon name="OperationalUI" size={16} /> components or HTML elements can be rendered here.
-            <div style={{ width: "100%", paddingTop: 20 }}>
-              <Button style={{ float: "right", marginRight: 0 }} onClick={this.onClose.bind(this)}>
+            <div style={{ position: "absolute", bottom: 20, right: 20 }}>
+              <Button style={{ marginRight: 0 }} onClick={this.onClose.bind(this)}>
                 OK
               </Button>
             </div>

--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -167,7 +167,7 @@ const zIndex = {
   selectOptions: 300,
   formFieldError: 299,
   tooltip: 400,
-  confirm: 500,
+  modal: 500,
 }
 
 /**


### PR DESCRIPTION
### Summary

Redesign of the `Modal` component.

- `title` and `action` props added: passed directly to styled `Card` component.
- `Confirm` component restructured to make use of this

Specifically intended to facilitate: 

<blockquote class="trello-card"><a href="https://trello.com/c/JdshXW0a/274-display-ssh-key-in-bundle-settings">Display ssh key in bundle settings</a></blockquote>

### To be tested

Tester 1

- [ ] No error/warning in the console
- [ ] The netlify build is working
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] No error/warning in the console
- [ ] The netlify build is working
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
