### PR TITLE
Strict logo sizing inside header bar

### DIFF
--- a/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
+++ b/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
@@ -51,6 +51,9 @@ const containerStyles = ({
   width: ${size_ * (stack ? stackedSvgAspectRatio : svgAspectRatio)}px;
   height: ${size_}px;
   fill: ${expandColor(theme, color_) || theme.color.white};
+  & svg {
+    height: ${size_ - 12}px;
+  }
 `
 
 const Container = styled("div")(containerStyles)

--- a/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
+++ b/packages/components/src/ContiamoLogo/ContiamoLogo.tsx
@@ -36,6 +36,8 @@ const StackedSvg: React.SFC<{}> = props => (
 
 const stackedSvgAspectRatio = 860 / 560
 
+const logoPadding = 6
+
 const containerStyles = ({
   stack,
   color_,
@@ -47,12 +49,12 @@ const containerStyles = ({
   size_?: number
   theme?: OperationalStyleConstants
 }) => `
-  padding: 6px;
+  padding: ${logoPadding}px;
   width: ${size_ * (stack ? stackedSvgAspectRatio : svgAspectRatio)}px;
   height: ${size_}px;
   fill: ${expandColor(theme, color_) || theme.color.white};
   & svg {
-    height: ${size_ - 12}px;
+    height: ${size_ - 2 * logoPadding}px;
   }
 `
 

--- a/packages/components/src/HeaderBar/HeaderBar.tsx
+++ b/packages/components/src/HeaderBar/HeaderBar.tsx
@@ -29,7 +29,7 @@ const Bar = styled("div")(
   ({ theme }: { theme?: OperationalStyleConstants }) => {
     return {
       height: theme.titleHeight,
-      gridTemplateColumns: `${theme.sidebarWidth}px auto 50px`,
+      gridTemplateColumns: `${theme.sidebarWidth}px auto 250px`,
       backgroundColor: theme.color.background.dark,
       color: theme.color.white,
       " > *": {
@@ -43,7 +43,10 @@ const StartContainer = styled("div")()
 
 const CenterContainer = styled("div")()
 
-const EndContainer = styled("div")()
+const EndContainer = styled("div")`
+  display: flex;
+  justify-content: flex-end;
+`
 
 const HeaderBar: React.SFC<HeaderProps> = ({ logo, main, end }) => (
   <Bar>

--- a/packages/components/src/HeaderBar/README.md
+++ b/packages/components/src/HeaderBar/README.md
@@ -5,16 +5,16 @@ This bar composes the top frame of Contiamo UIs. [More Info](https://github.com/
 Below is the most common usage, across all of our apps at Contiamo.
 
 ```jsx
-const projectOptions = [
+const projects = [
   { key: "project1", label: "Project 1" },
   { key: "project2", label: "Project 2" },
   { key: "project3", label: "Project 3" },
 ]
 ;<HeaderBar
   logo={<ContiamoLogo />}
-  main={<Select naked options={[{ value: "Contiamo" }]} value="Contiamo" placeholder="Select Project..." />}
+  main={<HeaderMenu items={projects}>Project 1</HeaderMenu>}
   end={
-    <HeaderMenu items={projectOptions} align="right">
+    <HeaderMenu items={[{ key: "account", label: "My account" }, { key: "log-out", label: "Log out" }]} align="right">
       Imogen Mason <Avatar name="Imogen Mason" />
     </HeaderMenu>
   }

--- a/packages/components/src/HeaderBar/README.md
+++ b/packages/components/src/HeaderBar/README.md
@@ -5,9 +5,18 @@ This bar composes the top frame of Contiamo UIs. [More Info](https://github.com/
 Below is the most common usage, across all of our apps at Contiamo.
 
 ```jsx
-<HeaderBar
+const projectOptions = [
+  { key: "project1", label: "Project 1" },
+  { key: "project2", label: "Project 2" },
+  { key: "project3", label: "Project 3" },
+]
+;<HeaderBar
   logo={<ContiamoLogo />}
   main={<Select naked options={[{ value: "Contiamo" }]} value="Contiamo" placeholder="Select Project..." />}
-  end={<Avatar name="Tejas Kumar" />}
+  end={
+    <HeaderMenu items={projectOptions} align="right">
+      Imogen Mason <Avatar name="Imogen Mason" />
+    </HeaderMenu>
+  }
 />
 ```


### PR DESCRIPTION
### Summary

Adds strict sizing to the contiamo logo's svg child to fix the following layout issue in `HeaderBar`:

![image 1](https://user-images.githubusercontent.com/6738398/43119745-f3c36ebc-8f17-11e8-8029-d1e0c5bf968b.png) 

### To be tested

Tester 1 - Tejas

- [x] No error/warning in the console
- [x] Contiamo logo is properly sized and spaced in `HeaderBar`.
- [x] The user menu is in the page

Tester 2

- [ ] No error/warning in the console
- [ ] Contiamo logo is properly sized and spaced in `HeaderBar`.
- [ ] The user menu is in the page
