### PR TITLE
Fix layout main overflow

### DIFF
--- a/packages/components/src/Layout/Layout.tsx
+++ b/packages/components/src/Layout/Layout.tsx
@@ -43,7 +43,7 @@ const GridContainer = styled("div")(
 )
 
 const Main = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) => ({
-  overflow: "auto",
+  overflow: "hidden",
   backgroundColor: theme.color.white,
   gridColumnStart: "2",
   gridColumnEnd: "span 1",
@@ -52,7 +52,7 @@ const Main = styled("div")(({ theme }: { theme?: OperationalStyleConstants }) =>
 }))
 
 const Side = styled("div")({
-  overflow: "auto",
+  overflow: "hidden",
   gridColumnStart: "1",
   gridColumnEnd: "span 1",
   gridRowStart: "2",


### PR DESCRIPTION
### Summary

Removes double scrollbars by setting the `Layout` component's main section's overflow to hidden. Overflow setting is the responsibility of the child component, which `Page` takes care of already.

### To be tested

Tester 1

- [x] No error/warning in the console
- [x] Layout overflow as expected

Tester 2

- [ ] No error/warning in the console
- [ ] Layout overflow as expected
