### PR TITLE
Spread html props for AvatarGroup

### DIFF
--- a/src/AvatarGroup/AvatarGroup.tsx
+++ b/src/AvatarGroup/AvatarGroup.tsx
@@ -9,16 +9,12 @@ export interface AvatarItem {
 
 export interface Props {
   children?: React.ReactNode
-
   /** Avatars list */
   avatars?: AvatarItem[]
-
   /** Maximum number of avatars to display */
   maximumToDisplay?: number
-
   /** More button handler */
   onMoreClick?: () => void
-
   /** Size of avatars */
   size?: "small" | "medium"
 }
@@ -31,18 +27,18 @@ const GroupedAvatar = styled(Avatar)({
   marginLeft: -8,
 })
 
-const AvatarGroup: React.SFC<Props> = props => {
-  const avatarsToDisplay = props.avatars
-    ? props.avatars.map((avatar, i) => <GroupedAvatar addBorder size={props.size} key={i} {...avatar} />)
+const AvatarGroup: React.SFC<Props> = ({ avatars, size, onMoreClick, ...props }) => {
+  const avatarsToDisplay = avatars
+    ? avatars.map((avatar, i) => <GroupedAvatar addBorder size={size} key={i} {...avatar} />)
     : props.children
   const count = React.Children.count(avatarsToDisplay)
   const mustSlice = props.maximumToDisplay! < count
 
   return (
-    <Container>
+    <Container {...props}>
       {mustSlice ? React.Children.toArray(avatarsToDisplay).slice(0, props.maximumToDisplay! - 1) : avatarsToDisplay}
       {mustSlice && (
-        <GroupedAvatar addBorder size={props.size} onClick={props.onMoreClick} name="more" assignColor={false}>
+        <GroupedAvatar addBorder size={size} onClick={onMoreClick} name="more" assignColor={false}>
           +{count - props.maximumToDisplay! + 1}
         </GroupedAvatar>
       )}


### PR DESCRIPTION
### Summary

Spreading HTML props on `AvatarGroup` to allow `styled(AvatarGroup)({})` usage and other behaviors such as keys and drag listeners.

Test like so (I have done this myself, but do feel free to reproduce):
* go to `AvatarGroup/README.md`
* add this to the top of one of the snippets:
```
const styled = require("react-emotion").default
const StyledAvatarGroup = styled(AvatarGroup)({ marginTop: 60 })
```
* change one `AvatarGroup` to `StyledAvatarGroup` somewhere in the code.
* watch it jump down.

Tester 1

- [x] No error/warning in the console
- [x] All component functionality works as before
- [x] `styled(Component)({})` works

Tester 2

- [x] No error/warning in the console
- [x] All component functionality works as before
- [x] `styled(Component)({})` works