### PR TITLE
Spread HTML props for Breadcrumb

### DIFF
--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -6,9 +6,9 @@ import { OperationalStyleConstants } from "../utils/constants"
 import styled from "../utils/styled"
 
 export interface Props {
-  className?: string
   /** Navigation property à la react-router <Link/> */
   to?: string
+  onClick?: (ev?: React.SyntheticEvent<React.ReactNode>) => void
   children?: React.ReactNode
   icon?: IconName
 }
@@ -34,23 +34,26 @@ const ContainerLink = styled("a")(containerStyles, ({ theme }: { theme: Operatio
 
 const Content = styled("span")()
 
-const Breadcrumb = (props: Props) => {
-  const ContainerComponent: any = props.to ? ContainerLink : Container
+const Breadcrumb: React.SFC<Props> = ({ to, icon, onClick, ...props }) => {
+  const ContainerComponent: any = to ? ContainerLink : Container
   return (
     <OperationalContext>
       {ctx => (
         <ContainerComponent
-          className={props.className}
-          href={props.to}
+          {...props}
+          href={to}
           onClick={(ev: React.SyntheticEvent<Node>) => {
-            if (!isModifiedEvent(ev) && props.to && ctx.pushState) {
+            if (onClick) {
+              onClick(ev)
+            }
+            if (!isModifiedEvent(ev) && to && ctx.pushState) {
               ev.preventDefault()
-              ctx.pushState(props.to)
+              ctx.pushState(to)
             }
           }}
         >
           <Content>{props.children}</Content>
-          {props.icon && <Icon name={props.icon} size={12} />}
+          {icon && <Icon name={icon} size={12} />}
         </ContainerComponent>
       )}
     </OperationalContext>


### PR DESCRIPTION
### Summary

Spreading HTML props on `Breadcrumb` to allow `styled(Breadcrumb)({})` usage and other behaviors such as keys and drag listeners.

Test like so (I have done this myself, but do feel free to reproduce):
* go to `Breadcrumb/README.md`
* add this to the top of one of the snippets:
```
const styled = require("react-emotion").default
const StyledBreadcrumb = styled(Breadcrumb)({ backgroundColor: "red" })
```
* change one `Breadcrumb` to `StyledBreadcrumb` somewhere in the code.
* watch it jump down.

Tester 1

- [ ] No error/warning in the console
- [ ] All component functionality works as before
- [ ] `styled(Component)({})` works

Tester 2

- [ ] No error/warning in the console
- [ ] All component functionality works as before
- [ ] `styled(Component)({})` works