### PR TITLE
Spread HTML props for Breadcrumbs

### DIFF
--- a/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Breadcrumbs/Breadcrumbs.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 import styled from "../utils/styled"
 
 export interface Props {
-  className?: string
   /** Children as `Breadcrumb` elements */
   children?: React.ReactNode
 }
@@ -36,8 +35,8 @@ const Slash = styled("span")(({ theme }) => ({
 const intersperseSlashes = (index: number) => ([head, ...tail]: React.ReactNode[]): React.ReactNode[] =>
   head ? [<Slash key={`divider-${index}`}>/</Slash>, head, ...intersperseSlashes(index + 1)(tail)] : []
 
-const Breadcrumbs = (props: Props) => (
-  <Container className={props.className}>{intersperseSlashes(0)(React.Children.toArray(props.children))}</Container>
+const Breadcrumbs: React.SFC<Props> = props => (
+  <Container {...props}>{intersperseSlashes(0)(React.Children.toArray(props.children))}</Container>
 )
 
 export default Breadcrumbs

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -22,6 +22,9 @@ module.exports = {
     HeadingRenderer: join(__dirname, "styleguide/HeadingRenderer"),
     TabButtonRenderer: join(__dirname, "styleguide/TabButtonRenderer"),
   },
+  context: {
+    styled: "react-emotion",
+  },
   dangerouslyUpdateWebpackConfig(webpackConfig, env) {
     webpackConfig.output = {
       path: join(__dirname, "dist"),


### PR DESCRIPTION
### Summary

Spreading HTML props on `Breadcrumbs` to allow `styled(Breadcrumbs)({})` usage and other behaviors such as keys and drag listeners.

Test like so (I have done this myself, but do feel free to reproduce):
* go to the netlify link
* add this to the top of one of the snippets:
```
const StyledBreadcrumbs = styled.default(Breadcrumbs)({ margin: 40 })
```
* change one `Breadcrumbs` to `StyledBreadcrumbs` somewhere in the code.
* watch it jump!

Tester 1

- [x] No error/warning in the console
- [x] All component functionality works as before
- [x] `styled(Breadcrumbs)({})` works

Tester 2

- [ ] No error/warning in the console
- [ ] All component functionality works as before
- [ ] `styled(Breadcrumbs)({})` works