### PR TITLE
Spread HTML props for low-risk components

### DIFF
--- a/src/Breakdown/Breakdown.tsx
+++ b/src/Breakdown/Breakdown.tsx
@@ -5,39 +5,19 @@ import { deprecatedExpandColor } from "../utils/constants"
 import styled from "../utils/styled"
 
 export interface Props {
-  /** Id */
-  id?: string
-  /** Class name */
-
-  className?: string
   children: React.ReactNode
   /** A number by which the breakdown is represented */
-
   number?: number
   /** A statistic number label within the bar of the breakdown */
-
   label: string
   /** The percentage to fill the bar. This is typically passed in from a container component that calculates percentages at large */
-
   fill: number
   /** A theme palette color name, or a hex code that the bar will be colored with */
-
   color?: string
   /** Bar color */
-
   barColor?: string
   /** An icon that is displayed on the breakdown */
-
   icon?: IconName
-  /** Invoked weth the mouse click the breakdown */
-
-  onClick?: () => void
-  /** Invoked when the mouse enters the breakdown. Useful for tooltips/infowindows */
-
-  onMouseEnter?: () => void
-  /** Invoked when the mouse leaves the breakdown. Useful for tooltips/infowindows */
-
-  onMouseLeave?: () => void
 }
 
 const Container = styled("div")<{ onClick?: () => void }>(
@@ -138,19 +118,13 @@ const Number = styled("div")(
 
 const Span = styled("span")({ fontFeatureSettings: "'tnum'" })
 
-const Breakdown: React.SFC<Props> = props => (
-  <Container
-    id={props.id}
-    className={props.className}
-    onClick={props.onClick}
-    onMouseEnter={props.onMouseEnter}
-    onMouseLeave={props.onMouseLeave}
-  >
-    <Number>{props.number}</Number>
+const Breakdown: React.SFC<Props> = ({ number, color, fill, label, children, ...props }) => (
+  <Container {...props}>
+    <Number>{number}</Number>
     <Content>
-      <Label>{props.children}</Label>
-      <Bar color={props.color} fill={props.fill}>
-        <Span>{props.label}</Span>
+      <Label>{children}</Label>
+      <Bar color={color} fill={fill}>
+        <Span>{label}</Span>
       </Bar>
     </Content>
   </Container>

--- a/src/Chip/Chip.tsx
+++ b/src/Chip/Chip.tsx
@@ -5,29 +5,19 @@ import { expandColor } from "../utils/constants"
 import styled from "../utils/styled"
 
 export interface Props {
-  /** Id */
-  id?: string
-
   /** Chip color, provided as a hex value or a named theme color */
   color?: string
-
   /** Handle clicks on the chip's body. This is never triggered when the icon bar is clicked. When an icon is not specified, however, this basically turns into a full element click handler. */
   onClick?: () => void
-
   /** Handle clicks on the chip's icon area on the right. */
   onIconClick?: () => void
-
-  /** Class name */
-  className?: string
-
-  children: React.ReactNode
-
   /** The name of the icon shown in the right icon bar area of the chip. A typical use here would be the `X` icon for closing the chip. Note that this icon is only displayed if there is an `onIconClick` prop present.  */
   icon?: IconName | React.ReactNode
+  children: React.ReactNode
 }
 
-const Container = styled("div")<{ color?: string }>(({ theme, color }) => {
-  const backgroundColor = tinycolor(expandColor(theme, color) || theme.color.primary)
+const Container = styled("div")<{ color_?: string }>(({ theme, color_ }) => {
+  const backgroundColor = tinycolor(expandColor(theme, color_) || theme.color.primary)
     .setAlpha(0.1)
     .toString()
   return {
@@ -73,12 +63,12 @@ const Action = styled("div")(({ theme }) => {
   }
 })
 
-const Chip: React.SFC<Props> = (props: Props) => (
-  <Container id={props.id} className={props.className} color={props.color}>
-    <Content onClick={props.onClick}>{props.children}</Content>
-    {props.onIconClick && (
-      <Action onClick={props.onIconClick}>
-        {typeof props.icon === "string" ? <Icon name={props.icon as IconName} size={12} /> : props.icon}
+const Chip: React.SFC<Props> = ({ onClick, onIconClick, icon, children, ...props }) => (
+  <Container color_={props.color} {...props}>
+    <Content onClick={onClick}>{children}</Content>
+    {onIconClick && (
+      <Action onClick={onIconClick}>
+        {typeof icon === "string" ? <Icon name={icon as IconName} size={12} /> : icon}
       </Action>
     )}
   </Container>

--- a/src/Chip/__tests__/Chip.test.tsx
+++ b/src/Chip/__tests__/Chip.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "enzyme"
 import * as React from "react"
-import { Chip as ThemelessChip } from "../index"
-import wrapDefaultTheme from "../utils/wrap-default-theme"
+import { Chip as ThemelessChip } from "../../index"
+import wrapDefaultTheme from "../../utils/wrap-default-theme"
 
 const Chip = wrapDefaultTheme(ThemelessChip)
 

--- a/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Chip Should render 1`] = `
+Array [
+  <div
+    class="css-ar73w8-Messages"
+  />,
+  <div
+    class="css-t1h0j7-chip"
+  >
+    <div
+      class="css-1k6isyt"
+    >
+      Hi
+    </div>
+  </div>,
+]
+`;

--- a/src/Code/Code.tsx
+++ b/src/Code/Code.tsx
@@ -4,8 +4,6 @@ import Highlight from "react-highlight"
 import styles from "./styles"
 
 export interface Props {
-  /** Id */
-  id?: string
   /** Language for syntax highlighting */
   syntax?: string
   children?: string | string[]
@@ -49,9 +47,9 @@ const Code = styled(Highlight)(({ theme }) => {
   }
 })
 
-const StyledCode = (props: Props) => (
-  <Container>
-    <Code className={`${css(styles)} ${props.syntax}`}>{props.children}</Code>
+const StyledCode: React.SFC<Props> = ({ syntax, children, ...props }) => (
+  <Container {...props}>
+    <Code className={`${css(styles)} ${syntax}`}>{children}</Code>
   </Container>
 )
 

--- a/src/Code/__tests__/Code.test.tsx
+++ b/src/Code/__tests__/Code.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "enzyme"
 import * as React from "react"
-import { Code as ThemelessCode } from "../index"
-import wrapDefaultTheme from "../utils/wrap-default-theme"
+import { Code as ThemelessCode } from "../../index"
+import wrapDefaultTheme from "../../utils/wrap-default-theme"
 
 const Code = wrapDefaultTheme(ThemelessCode)
 

--- a/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
+++ b/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code Should render 1`] = `
+Array [
+  <div
+    class="css-ar73w8-Messages"
+  />,
+  <div
+    class="css-tj45kb"
+  >
+    <pre>
+      <code
+        class="json css-10jr7dl"
+      >
+        {
+  "properties": {
+    "startAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "endAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}
+      </code>
+    </pre>
+  </div>,
+]
+`;

--- a/src/Grid/Grid.tsx
+++ b/src/Grid/Grid.tsx
@@ -2,9 +2,6 @@ import * as React from "react"
 import styled from "../utils/styled"
 
 export interface Props {
-  id?: string
-  className?: string
-
   /** Either 'IDE', or of an `MxN` format, with `M` and `N` as integers. */
   type: string
   children?: React.ReactNode
@@ -45,8 +42,8 @@ const Container = styled("div")<{ gridType: string }>(({ theme, gridType }) => (
   ...getGridCSSProperties(gridType),
 }))
 
-const Grid: React.SFC<Props> = (props: Props) => (
-  <Container id={props.id} className={props.className} gridType={props.type}>
+const Grid: React.SFC<Props> = ({ type, ...props }) => (
+  <Container {...props} gridType={type}>
     {props.children}
   </Container>
 )

--- a/src/Message/Message.tsx
+++ b/src/Message/Message.tsx
@@ -15,8 +15,8 @@ export interface Props {
   onClose?: () => void
 }
 
-const Container = styled("div")<{ color?: string }>(({ theme, color }) => {
-  const backgroundColor = tinycolor(expandColor(theme, color) || theme.color.primary)
+const Container = styled("div")<{ color_?: string }>(({ theme, color_ }) => {
+  const backgroundColor = tinycolor(expandColor(theme, color_) || theme.color.primary)
     .setAlpha(0.9)
     .toString()
   return {
@@ -52,12 +52,12 @@ const IconContainer = styled("div")(({ theme }) => ({
   },
 }))
 
-const Message = (props: Props) => (
-  <Container className={props.className} color={props.color}>
-    <IconContainer onClick={props.onClose}>
+const Message: React.SFC<Props> = ({ color, onClose, children, ...props }) => (
+  <Container {...props} color_={color}>
+    <IconContainer onClick={onClose}>
       <Icon name="No" />
     </IconContainer>
-    {props.children}
+    {children}
   </Container>
 )
 

--- a/src/Messages/Messages.tsx
+++ b/src/Messages/Messages.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 import styled from "../utils/styled"
 
 export interface Props {
-  className?: string
   children?: React.ReactNode
 }
 
@@ -19,6 +18,6 @@ const Container = styled("div")(({ theme }) => ({
   },
 }))
 
-const Messages = (props: Props) => <Container className={props.className}>{props.children}</Container>
+const Messages: React.SFC<Props> = ({ children, ...props }) => <Container {...props}>{children}</Container>
 
 export default Messages

--- a/src/Paginator/Paginator.tsx
+++ b/src/Paginator/Paginator.tsx
@@ -4,8 +4,6 @@ import Button from "../Button/Button"
 import styled from "../utils/styled"
 
 export interface Props {
-  id?: string
-  className?: string
   /** Function to be executed after changing page */
   onChange?: (page: Props["page"]) => void
   /** Index of the current selected page */
@@ -90,17 +88,17 @@ const Container = styled("div")(({ theme }) => ({
   },
 }))
 
-const Paginator: React.SFC<Props> = props => {
+const Paginator: React.SFC<Props> = ({ itemCount, itemsPerPage, page, onChange, ...props }) => {
   const controlProps = {
-    itemCount: props.itemCount,
-    itemsPerPage: props.itemsPerPage,
-    page: props.page!,
-    onChange: props.onChange,
+    itemCount,
+    itemsPerPage,
+    page: page!,
+    onChange,
   }
-  const isFirstDisabled = props.page === 1
-  const isLastDisabled = props.itemsPerPage * props.page! >= props.itemCount
+  const isFirstDisabled = page === 1
+  const isLastDisabled = itemsPerPage * page! >= itemCount
   return (
-    <Container id={props.id} className={props.className}>
+    <Container {...props}>
       <PaginatorControl type="first" {...controlProps} isDisabled={isFirstDisabled}>
         first
       </PaginatorControl>
@@ -108,9 +106,8 @@ const Paginator: React.SFC<Props> = props => {
         <Icon.ChevronsLeft size="11" />
         <span>prev</span>
       </PaginatorControl>
-      <PaginatorSpan key={props.page}>
-        <span>{getRange({ page: props.page, itemCount: props.itemCount, itemsPerPage: props.itemsPerPage })}</span> of{" "}
-        {props.itemCount}
+      <PaginatorSpan key={page}>
+        <span>{getRange({ page, itemCount, itemsPerPage })}</span> of {itemCount}
       </PaginatorSpan>
       <PaginatorControl type="next" {...controlProps} isDisabled={isLastDisabled}>
         <span>next</span>

--- a/src/Progress/Progress.tsx
+++ b/src/Progress/Progress.tsx
@@ -4,16 +4,11 @@ import { Icon } from "../"
 import { lighten } from "../utils"
 
 export interface Props {
-  id?: string
-  className?: string
   /** Show an error instead of the progress */
-
   error?: string
   /** Provide a button to retry the action to load */
-
   onRetry?: () => void
   /** OnClose callback */
-
   onClose?: () => void
 }
 
@@ -93,20 +88,20 @@ const Action = styled("div")(({ theme }) => ({
   },
 }))
 
-const Progress: React.SFC<Props> = props => (
-  <Container id={props.id} className={props.className}>
-    <Bar isError={Boolean(props.error)} />
-    {props.error ? (
+const Progress: React.SFC<Props> = ({ error, onRetry, onClose, ...props }) => (
+  <Container {...props}>
+    <Bar isError={Boolean(error)} />
+    {error ? (
       <ErrorMessage>
-        {props.error}
-        {props.onRetry && (
-          <Action onClick={props.onRetry}>
+        {error}
+        {onRetry && (
+          <Action onClick={onRetry}>
             <Icon name="Sync" />
             <span>Retry</span>
           </Action>
         )}
-        {props.onClose && (
-          <Action onClick={props.onClose}>
+        {onClose && (
+          <Action onClick={onClose}>
             <Icon name="No" />
             <span>Dismiss</span>
           </Action>

--- a/src/ProgressPanel/ProgressPanel.tsx
+++ b/src/ProgressPanel/ProgressPanel.tsx
@@ -81,9 +81,9 @@ const Error = styled("p")`
   `};
 `
 
-const ProgressPanel: React.SFC<Props> = props => (
-  <Container>
-    {props.items.map(({ status, title, error }, index) => (
+const ProgressPanel: React.SFC<Props> = ({ items, ...props }) => (
+  <Container {...props}>
+    {items.map(({ status, title, error }, index) => (
       <Item key={index}>
         <Body status={status}>
           {getVariation(status).icon}

--- a/src/Sha/Sha.tsx
+++ b/src/Sha/Sha.tsx
@@ -5,6 +5,8 @@ interface ShaProps {
   children: string
 }
 
-const Sha: React.SFC<ShaProps> = ({ children, short }) => <span>{short ? children.slice(0, 11) : children}</span>
+const Sha: React.SFC<ShaProps> = ({ children, short, ...props }) => (
+  <span {...props}>{short ? children.slice(0, 11) : children}</span>
+)
 
 export default Sha

--- a/src/Switch/Switch.tsx
+++ b/src/Switch/Switch.tsx
@@ -2,14 +2,10 @@ import * as React from "react"
 import styled from "../utils/styled"
 
 export interface Props {
-  id?: string
   /** Is the switch on? */
-
   on: boolean
   /** A change handler. Passes the new `on` boolean */
-
   onChange?: (on: boolean) => void
-  className?: string
 }
 
 const width: number = 28
@@ -74,18 +70,17 @@ const Rail = styled("div")<Props>(
   }),
 )
 
-const Switch = (props: Props) => (
+const Switch: React.SFC<Props> = ({ on, onChange, ...props }) => (
   <Container
-    id={props.id}
-    className={props.className}
+    {...props}
     onClick={() => {
-      if (props.onChange) {
-        props.onChange(!props.on)
+      if (onChange) {
+        onChange(!on)
       }
     }}
   >
-    <Button on={props.on} />
-    <Rail on={props.on} />
+    <Button on={on} />
+    <Rail on={on} />
   </Container>
 )
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -5,26 +5,16 @@ export interface Props {
   /** Table columns headings */
   columns: string[]
   /** Table rows as an array of cells */
-
   rows: Array<Array<string | React.ReactNode>>
   /** Called on row click */
-
   onRowClick?: (row: Array<string | React.ReactNode>, index: number) => void
   /**
    * Text to display on right on row hover
    */
-
   rowActionName?: string
-  /**
-   * This will not work anymore!
-   * @deprecated
-   */
-
-  __experimentalColumnCss?: any
   /**
    * Add actions on the end of each row
    */
-
   __experimentalRowActions?: React.ReactNode[]
 }
 

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -127,9 +127,10 @@ class Tree extends React.Component<Props, State> {
   }
 
   public render() {
+    const { trees, ...props } = this.props
     return (
-      <Container {...this.props}>
-        {this.props.trees.map((tree, index) => (
+      <Container {...props}>
+        {trees.map((tree, index) => (
           <TreeRecursive
             key={index}
             tree={tree}


### PR DESCRIPTION
### Summary

Spreading HTML props on low-risk components to allow `styled(Component)({})` usage and other behaviors such as keys and drag listeners.

Test like so (I have done this myself, but do feel free to reproduce):
* go to `SomeComponent/README.md`
* add this to the top of one of the snippets:
```
const StyledSomeComponent = styled.default(SomeComponent)({ margin: 40 })
```
* change one `SomeComponent` to `StyledSomeComponent` somewhere in the code.
* watch it jump down.

Tester 1

- [x] No error/warning in the console
- [x] `Breakdown` works as before + `styled(Breakdown)({})` applies styles
- [x] `Chip` works as before + `styled(Chip)({})` applies styles
- [x] `Code` works as before + `styled(Code)({})` applies styles
- [x] `Message` works as before + `styled(Message)({})` applies styles
- [x] `Messages` works as before + `styled(Messages)({})` applies styles
- [x] `Paginator` works as before + `styled(Paginator)({})` applies styles
- [x] `Progress` works as before + `styled(Progress)({})` applies styles
- [x] `ProgressPanel` works as before + `styled(ProgressPanel)({})` applies styles
- [x] `Sha` works as before + `styled(Sha)({})` applies styles
- [x] `Switch` works as before + `styled(Switch)({})` applies styles
- [x] `Table` works as before + `styled(Table)({})` applies styles
- [x] `Tree` works as before + `styled(TaTreeble)({})` applies styles

Tester 2

- [x] No error/warning in the console
- [x] `Breakdown` works as before + `styled(Breakdown)({})` applies styles
- [x] `Chip` works as before + `styled(Chip)({})` applies styles
- [x] `Code` works as before + `styled(Code)({})` applies styles
- [x] `Message` works as before + `styled(Message)({})` applies styles
- [x] `Messages` works as before + `styled(Messages)({})` applies styles
- [x] `Paginator` works as before + `styled(Paginator)({})` applies styles
- [x] `Progress` works as before + `styled(Progress)({})` applies styles
- [x] `ProgressPanel` works as before + `styled(ProgressPanel)({})` applies styles
- [x] `Sha` works as before + `styled(Sha)({})` applies styles
- [x] `Switch` works as before + `styled(Switch)({})` applies styles
- [x] `Table` works as before + `styled(Table)({})` applies styles
- [x] `Tree` works as before + `styled(TaTreeble)({})` applies styles