### PR TITLE
Spread HTML props for sidenav components

### DIFF
--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -1,24 +1,9 @@
 import * as React from "react"
 import { readableTextColor } from "../utils"
-import deprecate from "../utils/deprecate"
 import styled from "../utils/styled"
 
 export interface Props {
-  id?: string
-  className?: string
   children?: React.ReactNode
-  /**
-   * Expanded state
-   *
-   * @deprecated this prop is ignored as per design decision (all sidenavs are expanded)
-   */
-  expanded?: boolean
-  /**
-   * Specifies whether sidenav should expand on hover
-   *
-   * @deprecated this prop is ignored as per design decision (all sidenavs are expanded)
-   */
-  expandOnHover?: boolean
 }
 
 export interface State {
@@ -42,19 +27,6 @@ const Container = styled("div")(({ theme }) => {
   }
 })
 
-export class Sidenav extends React.Component<Props, State> {
-  public render() {
-    return (
-      <Container id={this.props.id} className={this.props.className}>
-        {this.props.children}
-      </Container>
-    )
-  }
-}
+const Sidenav: React.SFC<Props> = ({ children, ...props }) => <Container {...props}>{children}</Container>
 
-export default deprecate<Props>(
-  props =>
-    props.expanded || props.expandOnHover
-      ? ["`expanded` and `expandOnHover` props are no longer supported. Sidenavs are expanded by default."]
-      : [],
-)(Sidenav)
+export default Sidenav

--- a/src/Sidenav/__tests__/__snapshots__/Sidenav.test.tsx.snap
+++ b/src/Sidenav/__tests__/__snapshots__/Sidenav.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`Sidenav component renders 1`] = `
 <OperationalUI>
-  <DeprecatedComponent />
+  <Sidenav />
 </OperationalUI>
-`
+`;

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -6,8 +6,6 @@ import { Props as SidenavItemProps } from "../SidenavItem/SidenavItem"
 import { floatIn, isModifiedEvent } from "../utils"
 
 export interface Props {
-  id?: string
-  className?: string
   /** Main label for the header */
   label: string | React.ReactNode
   /** Navigation property à la react-router <Link/> */
@@ -129,8 +127,8 @@ const truncate = (maxLength: number) => (text: string) => {
   return text.slice(0, maxLength) + "..."
 }
 
-const SidenavHeader = (props: Props) => {
-  const isActive = Boolean(props.active)
+const SidenavHeader: React.SFC<Props> = ({ onToggle, active, to, ...props }) => {
+  const isActive = Boolean(active)
 
   // The implementation of this component relies on the fact that it only has valid
   // `SidenavItem` components as children. The type casting here expresses that assumption.
@@ -139,30 +137,29 @@ const SidenavHeader = (props: Props) => {
   const hasChildLinks = childSidenavItems.some(child => Boolean(child.props.to))
 
   // Actual `to` prop should invalidate if the element has sublinks and is active
-  const to = isActive && hasChildLinks ? undefined : props.to
-  const ContainerComponent = to ? ContainerLink : Container
+  const href = isActive && hasChildLinks ? undefined : to
+  const ContainerComponent = href ? ContainerLink : Container
 
   return (
     <OperationalContext>
       {ctx => {
         return (
           <ContainerComponent
-            id={props.id}
-            href={to}
-            className={[props.className, "op_sidenavheader"].filter(cls => Boolean(cls)).join(" ")}
+            {...props}
+            href={href}
             onClick={(ev: React.SyntheticEvent<Node>) => {
               if (props.onClick) {
                 props.onClick()
               }
-              if (props.onToggle) {
-                props.onToggle(!props.active)
+              if (onToggle) {
+                onToggle(!active)
               }
 
-              if (!isModifiedEvent(ev) && ctx.pushState && props.to) {
+              if (!isModifiedEvent(ev) && ctx.pushState && to) {
                 ev.preventDefault()
 
                 // Even if the `props.to` prop was ignored, redirect should still happen here
-                ctx.pushState(props.to)
+                ctx.pushState(to)
               }
             }}
           >
@@ -182,12 +179,12 @@ const SidenavHeader = (props: Props) => {
                 onClick={(ev: React.SyntheticEvent<Node>) => {
                   // Prevent clicks on parent in order to avoid conflicting behavior
                   ev.stopPropagation()
-                  if (props.onToggle) {
-                    props.onToggle(!props.active)
+                  if (onToggle) {
+                    onToggle(!active)
                   }
                 }}
               >
-                <Icon name={props.active ? "ChevronUp" : "ChevronDown"} />
+                <Icon name={active ? "ChevronUp" : "ChevronDown"} />
               </CloseButton>
             )}
             {isActive && <ItemsContainer>{props.children}</ItemsContainer>}

--- a/src/SidenavItem/SidenavItem.tsx
+++ b/src/SidenavItem/SidenavItem.tsx
@@ -6,8 +6,6 @@ import { isModifiedEvent } from "../utils"
 import { OperationalStyleConstants } from "../utils/constants"
 
 export interface Props {
-  id?: string
-  className?: string
   onClick?: () => void
   /** Navigation property à la react-router <Link/> */
   to?: string
@@ -67,33 +65,30 @@ const Label = styled("span")(({ theme }) => ({
   paddingLeft: theme.space.base,
 }))
 
-const SidenavItem = (props: Props) => {
-  const ContainerComponent = props.to ? ContainerLink : Container
-  const isActive = !!props.active
+const SidenavItem: React.SFC<Props> = ({ to, active, icon, label, ...props }) => {
+  const ContainerComponent = to ? ContainerLink : Container
+  const isActive = Boolean(active)
   return (
     <OperationalContext>
       {ctx => (
         <ContainerComponent
-          href={props.to}
-          id={props.id}
-          className={props.className}
+          {...props}
+          href={to}
           onClick={(ev: React.SyntheticEvent<Node>) => {
             ev.stopPropagation()
             if (props.onClick) {
               props.onClick()
             }
 
-            if (!isModifiedEvent(ev) && props.to && ctx.pushState) {
+            if (!isModifiedEvent(ev) && to && ctx.pushState) {
               ev.preventDefault()
-              ctx.pushState(props.to)
+              ctx.pushState(to)
             }
           }}
           isActive={isActive}
         >
-          <IconContainer>
-            {props.icon === String(props.icon) ? <Icon name={props.icon as IconName} size={18} /> : props.icon}
-          </IconContainer>
-          <Label>{props.label}</Label>
+          <IconContainer>{icon === String(icon) ? <Icon name={icon as IconName} size={18} /> : icon}</IconContainer>
+          <Label>{label}</Label>
         </ContainerComponent>
       )}
     </OperationalContext>


### PR DESCRIPTION
### Summary

Spreading HTML props on low-risk components to allow `styled(Component)({})` usage and other behaviors such as keys and drag listeners.

Test like so (I have done this myself, but do feel free to reproduce):
* go to `SomeComponent/README.md`
* add this to the top of one of the snippets:
```
const StyledSomeComponent = styled.default(SomeComponent)({ margin: 40 })
```
* change one `SomeComponent` to `StyledSomeComponent` somewhere in the code.
* watch it jump down.

Tester 1

- [x] No error/warning in the console
- [x] `Sidenav` works as before + `styled(Sidenav)({})` applies styles
- [x] `SidenavHeader` works as before + `styled(SidenavHeader)({})` applies styles
- [x] `SidenavItem` works as before + `styled(SidenavItem)({})` applies styles

Tester 2

- [x] No error/warning in the console
- [x] `Sidenav` works as before + `styled(Sidenav)({})` applies styles
- [x] `SidenavHeader` works as before + `styled(SidenavHeader)({})` applies styles
- [x] `SidenavItem` works as before + `styled(SidenavItem)({})` applies styles