### PR TITLE
Spread HTML props one more batch of components

### DIFF
--- a/src/ActionMenu/ActionMenu.tsx
+++ b/src/ActionMenu/ActionMenu.tsx
@@ -1,12 +1,13 @@
 import * as React from "react"
 import ContextMenu, { Props as ContextMenuProps } from "../ContextMenu/ContextMenu"
 import Icon from "../Icon/Icon"
+import { DefaultProps } from "../types"
 import { darken } from "../utils"
 import styled from "../utils/styled"
 
 const width = 144
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Action when item in dropdown is selected - if specified here, it is applied to all dropdown items */
   onClick?: ContextMenuProps["onClick"]
   /** Title */

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -15,8 +15,6 @@ export interface Props {
   hideInitials?: boolean
   /** A URL to an image of the person */
   photo?: string
-  /** Class name */
-  className?: string
   /** Color assigned to the avatar circle (hex or named color from `theme.colors`) */
   color?: string
   /** Automatically assign a deterministic color. (Invalidates `color` assignment)  */

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -1,10 +1,11 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import { getInitials, readableTextColor } from "../utils"
 import { colorMapper } from "../utils/color"
 import { expandColor } from "../utils/constants"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Name of the person */
   name: string
   /** Title of the person */

--- a/src/AvatarGroup/AvatarGroup.tsx
+++ b/src/AvatarGroup/AvatarGroup.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import Avatar from "../Avatar/Avatar"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 export interface AvatarItem {
@@ -7,7 +8,7 @@ export interface AvatarItem {
   name: string
 }
 
-export interface Props {
+export interface Props extends DefaultProps {
   children?: React.ReactNode
   /** Avatars list */
   avatars?: AvatarItem[]

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
 import Icon, { IconName } from "../Icon/Icon"
 import OperationalContext from "../OperationalContext/OperationalContext"
+import { DefaultProps } from "../types"
 import { darken, isModifiedEvent } from "../utils"
 import { OperationalStyleConstants } from "../utils/constants"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Navigation property à la react-router <Link/> */
   to?: string
   onClick?: (ev?: React.SyntheticEvent<React.ReactNode>) => void

--- a/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Children as `Breadcrumb` elements */
   children?: React.ReactNode
 }

--- a/src/Breakdown/Breakdown.tsx
+++ b/src/Breakdown/Breakdown.tsx
@@ -1,10 +1,11 @@
 import * as React from "react"
 import { IconName } from "../"
+import { DefaultProps } from "../types"
 import { setBrightness } from "../utils"
 import { deprecatedExpandColor } from "../utils/constants"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   children: React.ReactNode
   /** A number by which the breakdown is represented */
   number?: number

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -4,10 +4,11 @@ import styled, { Interpolation, Themed } from "react-emotion"
 import Icon, { IconName } from "../Icon/Icon"
 import OperationalContext from "../OperationalContext/OperationalContext"
 import Spinner from "../Spinner/Spinner"
+import { DefaultProps } from "../types"
 import { darken, isModifiedEvent, isWhite, readableTextColor } from "../utils"
 import { expandColor, OperationalStyleConstants } from "../utils/constants"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Invoked when you click on the button */
   onClick?: (e?: React.SyntheticEvent<React.ReactNode>) => void
   type?: string

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -8,8 +8,6 @@ import { darken, isModifiedEvent, isWhite, readableTextColor } from "../utils"
 import { expandColor, OperationalStyleConstants } from "../utils/constants"
 
 export interface Props {
-  id?: string
-  className?: string
   /** Invoked when you click on the button */
   onClick?: (e?: React.SyntheticEvent<React.ReactNode>) => void
   type?: string
@@ -52,15 +50,19 @@ const makeColors = (theme: OperationalStyleConstants, color: string) => {
   }
 }
 
-const containerStyles: Interpolation<Themed<Props, OperationalStyleConstants>> = ({
-  theme,
-  color,
-  disabled,
-  condensed,
-  loading,
-  fullWidth,
-}) => {
-  const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color || "")
+const containerStyles: Interpolation<
+  Themed<
+    {
+      color_?: Props["color"]
+      disabled?: boolean
+      condensed?: Props["condensed"]
+      loading?: Props["loading"]
+      fullWidth?: Props["fullWidth"]
+    },
+    OperationalStyleConstants
+  >
+> = ({ theme, color_, disabled, condensed, loading, fullWidth }) => {
+  const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color_ || "")
   return {
     backgroundColor,
     lineHeight: `${condensed ? 28 : 36}px`,
@@ -107,34 +109,36 @@ const ButtonSpinner = styled(Spinner)<{ containerColor?: Props["color"] }>(({ th
   color: makeColors(theme, containerColor || "").foreground,
 }))
 
-const Button = (props: Props) => {
-  const ContainerComponent: React.ComponentType<any> = props.to ? ContainerLink : Container
+const Button: React.SFC<Props> = ({ to, children, icon, color, onClick, loading, ...props }) => {
+  const ContainerComponent: React.ComponentType<any> = to ? ContainerLink : Container
   return (
     <OperationalContext>
       {ctx => (
         <ContainerComponent
           {...props}
-          href={props.to}
+          color_={color}
+          loading={loading}
+          href={to}
           onClick={(ev: React.SyntheticEvent<React.ReactNode>) => {
             if (props.disabled) {
               ev.preventDefault()
               return
             }
 
-            if (props.onClick) {
-              props.onClick()
+            if (onClick) {
+              onClick()
             }
 
-            if (!isModifiedEvent(ev) && props.to && ctx.pushState) {
+            if (!isModifiedEvent(ev) && to && ctx.pushState) {
               ev.preventDefault()
-              ctx.pushState(props.to)
+              ctx.pushState(to)
             }
           }}
-          title={props.loading && props.children === String(props.children) ? String(props.children) : undefined}
+          title={loading && children === String(children) ? String(children) : undefined}
         >
-          {props.children}
-          {props.icon && <Icon right name={props.icon} size={18} />}
-          {props.loading && <ButtonSpinner containerColor={props.color} />}
+          {children}
+          {icon && <Icon right name={icon} size={18} />}
+          {loading && <ButtonSpinner containerColor={color} />}
         </ContainerComponent>
       )}
     </OperationalContext>

--- a/src/ButtonGroup/ButtonGroup.tsx
+++ b/src/ButtonGroup/ButtonGroup.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   children?: React.ReactNode
 }
 

--- a/src/ButtonGroup/ButtonGroup.tsx
+++ b/src/ButtonGroup/ButtonGroup.tsx
@@ -2,13 +2,6 @@ import * as React from "react"
 import styled from "../utils/styled"
 
 export interface Props {
-  /** Id */
-  id?: string
-  /** Class name */
-
-  className?: string
-  /** Children as a list of `Button` elements. Avoid mixing condensed and full-height buttons. */
-
   children?: React.ReactNode
 }
 
@@ -18,6 +11,8 @@ const Container = styled("div")({
     margin: 0,
   },
   "& > button:not(:first-child)": {
+    // To avoid overlapping borders
+    marginLeft: -1,
     borderLeft: 0,
     borderTopLeftRadius: 0,
     borderBottomLeftRadius: 0,
@@ -28,10 +23,6 @@ const Container = styled("div")({
   },
 })
 
-const ButtonGroup = (props: Props) => (
-  <Container id={props.id} className={props.className}>
-    {props.children}
-  </Container>
-)
+const ButtonGroup: React.SFC<Props> = ({ children, ...props }) => <Container {...props}>{children}</Container>
 
 export default ButtonGroup

--- a/src/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/src/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "enzyme"
 import * as React from "react"
-import { Button, ButtonGroup as ThemelessButtonGroup } from "../index"
-import wrapDefaultTheme from "../utils/wrap-default-theme"
+import { Button, ButtonGroup as ThemelessButtonGroup } from "../../index"
+import wrapDefaultTheme from "../../utils/wrap-default-theme"
 
 const ButtonGroup = wrapDefaultTheme(ThemelessButtonGroup)
 

--- a/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonGroup Component Should initialize properly 1`] = `
+<div
+  class="css-ftf61z"
+>
+  <div
+    class="css-ar73w8-Messages"
+  />
+  <div
+    class="css-1o7twmc-buttongroup"
+  >
+    <button
+      class="css-19mfxrd-button"
+    >
+      Hello
+    </button>
+  </div>
+</div>
+`;

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import { CardHeader, CardItem } from "../"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props<T = {}> {
+export interface Props<T = {}> extends DefaultProps {
   /** Any object to show. The key is the title of the data. */
   data?: T
   /**  A function to format keys of `data` */

--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Column title */
   title?: string
   /** Align the content to the right */

--- a/src/CardHeader/CardHeader.tsx
+++ b/src/CardHeader/CardHeader.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   id?: string
   className?: string
   /** As title, please note that is override by `title` if provided */

--- a/src/CardHeader/CardHeader.tsx
+++ b/src/CardHeader/CardHeader.tsx
@@ -3,8 +3,6 @@ import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 export interface Props extends DefaultProps {
-  id?: string
-  className?: string
   /** As title, please note that is override by `title` if provided */
   children?: React.ReactNode
   /** Main title */
@@ -54,10 +52,10 @@ const ActionsContainer = styled("div")`
   align-items: center;
 `
 
-const CardHeader = (props: Props) => (
-  <Container id={props.id} className={props.className}>
-    <div>{props.title || props.children}</div>
-    <ActionsContainer>{props.action}</ActionsContainer>
+const CardHeader: React.SFC<Props> = ({ title, children, action, ...props }) => (
+  <Container {...props}>
+    <div>{title || children}</div>
+    <ActionsContainer>{action}</ActionsContainer>
   </Container>
 )
 

--- a/src/CardItem/CardItem.tsx
+++ b/src/CardItem/CardItem.tsx
@@ -25,8 +25,8 @@ const CardItemBody = styled("div")(({ theme }) => ({
   marginBottom: theme.space.content,
 }))
 
-const CardItem: React.SFC<Props> = ({ title, value, children }) => (
-  <div>
+const CardItem: React.SFC<Props> = ({ title, value, children, ...props }) => (
+  <div {...props}>
     <CardItemTitle>{title}</CardItemTitle>
     <CardItemBody>{children || value}</CardItemBody>
   </div>

--- a/src/CardItem/CardItem.tsx
+++ b/src/CardItem/CardItem.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Title of the item */
   title: string
   /** Value of the item */

--- a/src/Chip/Chip.tsx
+++ b/src/Chip/Chip.tsx
@@ -1,10 +1,11 @@
 import * as React from "react"
 import tinycolor from "tinycolor2"
 import { Icon, IconName } from "../"
+import { DefaultProps } from "../types"
 import { expandColor } from "../utils/constants"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Chip color, provided as a hex value or a named theme color */
   color?: string
   /** Handle clicks on the chip's body. This is never triggered when the icon bar is clicked. When an icon is not specified, however, this basically turns into a full element click handler. */

--- a/src/Code/Code.tsx
+++ b/src/Code/Code.tsx
@@ -1,9 +1,10 @@
 import * as React from "react"
 import styled, { css } from "react-emotion"
 import Highlight from "react-highlight"
+import { DefaultProps } from "../types"
 import styles from "./styles"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Language for syntax highlighting */
   syntax?: string
   children?: string | string[]

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import ContextMenuItem from "./ContextMenu.Item"
@@ -8,7 +9,7 @@ export interface Item {
   onClick?: (item: string | Item) => void
 }
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Id */
   id?: string
   /** Class name */

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -1,12 +1,13 @@
 import * as React from "react"
 import { Icon } from "../"
+import { DefaultProps } from "../types"
 import { Label, LabelText } from "../utils/mixins"
 
 import Month from "./DatePicker.Month"
 import { Container, DatePickerCard, IconContainer, Input, MonthNav, Toggle } from "./DatePicker.styles"
 import { changeMonth, months, toDate, toYearMonthDay, validateDateString } from "./DatePicker.utils"
 
-export interface Props {
+export interface Props extends DefaultProps {
   id?: string
   label?: string
   /** Min date in the format YYYY-MM-DD. Dates lower than this cannot be selected. */

--- a/src/Grid/Grid.tsx
+++ b/src/Grid/Grid.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Either 'IDE', or of an `MxN` format, with `M` and `N` as integers. */
   type: string
   children?: React.ReactNode

--- a/src/HeaderBar/HeaderBar.tsx
+++ b/src/HeaderBar/HeaderBar.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface HeaderProps {
+export interface HeaderProps extends DefaultProps {
   /**
    * The "logo" element of the HeaderBar.
    * Typically, the leftmost element.

--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import ContextMenu, { Props as ContextMenuProps } from "../ContextMenu/ContextMenu"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Clickable component(s) from which menu appears  */
   children: React.ReactNode[]
   /** Action when item in dropdown is selected - if specified here, it is applied to all dropdown items */

--- a/src/Hint/Hint.tsx
+++ b/src/Hint/Hint.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import Icon from "../Icon/Icon"
 import Tooltip from "../Tooltip/Tooltip"
 import { hoverTooltip } from "../utils/mixins"
 
-export interface Props {
+export interface Props extends DefaultProps {
   className?: string
   children?: React.ReactNode
   /**

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -2,10 +2,11 @@ import * as React from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 import { Hint, Icon, IconName } from "../"
 import Tooltip from "../Tooltip/Tooltip" // Styled components appears to have an internal bug that breaks when this is imported from index.ts
+import { DefaultProps } from "../types"
 import { FormFieldControl, FormFieldControls, FormFieldError, inputFocus, Label, LabelText } from "../utils/mixins"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   className?: string
   /** Text displayed when the input field has no value. */
   placeholder?: string

--- a/src/Layout/Layout.tsx
+++ b/src/Layout/Layout.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import { Progress } from "../"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Side navigation, see `Sidenav` component */
   sidenav: React.ReactNode
   /** Header content, see `Page` component */

--- a/src/Logo/Logo.tsx
+++ b/src/Logo/Logo.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
 import OperationalContext from "../OperationalContext/OperationalContext"
+import { DefaultProps } from "../types"
 import { isModifiedEvent } from "../utils"
 import { expandColor, OperationalStyleConstants } from "../utils/constants"
 import styled from "../utils/styled"
 import shapes from "./Logo.Shapes"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Size, in pixels, that the logomark should be */
   size?: number
   /** A color from the constants, or an arbitrary hex value */

--- a/src/Message/Message.tsx
+++ b/src/Message/Message.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
 import tinycolor from "tinycolor2"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import { Icon } from "../"
 import { expandColor } from "../utils/constants"
 
-export interface Props {
+export interface Props extends DefaultProps {
   className?: string
   /** Message contents, can be any html element/React fragment. */
   children?: React.ReactNode

--- a/src/Messages/Messages.tsx
+++ b/src/Messages/Messages.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   children?: React.ReactNode
 }
 

--- a/src/NameTag/NameTag.tsx
+++ b/src/NameTag/NameTag.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import { readableTextColor } from "../utils"
 import { colorMapper } from "../utils/color"
 import { expandColor } from "../utils/constants"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Background color */
   color?: string
   /**

--- a/src/OperationalContext/OperationalContext.tsx
+++ b/src/OperationalContext/OperationalContext.tsx
@@ -1,8 +1,12 @@
 import * as React from "react"
 
-import OperationalContext, { Context, IMessage, MessageType, WindowSize } from "./OperationalContext.init"
-
-OperationalContext.displayName = "OperationalContext"
+import {
+  Context,
+  default as OperationalContextOriginal,
+  IMessage,
+  MessageType,
+  WindowSize,
+} from "./OperationalContext.init"
 
 export interface Props {
   children: (operationalContext: Context) => undefined | React.ReactNode
@@ -12,8 +16,10 @@ export interface Props {
  * This component simply wraps OperationalContext in order to allow styleguidist to pick up on
  * it and display it in the documentation page.
  */
-const OperationalContextWrapper: React.SFC<Props> = props => <OperationalContext>{props.children}</OperationalContext>
+const OperationalContext: React.SFC<Props> = props => (
+  <OperationalContextOriginal>{props.children}</OperationalContextOriginal>
+)
 
-export default OperationalContextWrapper
+export default OperationalContext
 
 export { Context, WindowSize, IMessage, MessageType }

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -2,11 +2,12 @@ import * as React from "react"
 import { Title } from ".."
 import PageArea from "../PageArea/PageArea"
 import PageContent, { PageContentProps } from "../PageContent/PageContent"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 export type Tabs = Array<{ name: string; children: React.ReactNode; hidden?: boolean }>
 
-export interface BaseProps {
+export interface BaseProps extends DefaultProps {
   /** Content of the page */
   children?: PageContentProps["children"]
   /** Page title */

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -174,10 +174,10 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   }
 
   public render() {
-    const { title, actions, tabs } = this.props
+    const { title, actions, tabs, ...props } = this.props
 
     return (
-      <Container>
+      <Container {...props}>
         {title && (
           <TitleBar>
             <Title color="white">{title}</Title>

--- a/src/PageArea/PageArea.tsx
+++ b/src/PageArea/PageArea.tsx
@@ -1,6 +1,7 @@
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface PageAreaProps {
+export interface PageAreaProps extends DefaultProps {
   /** Name of the area */
   name?: "main" | "side"
 }

--- a/src/PageAreas/PageAreas.tsx
+++ b/src/PageAreas/PageAreas.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Areas template for `PageArea` disposition */
   areas?: "main" | "main side" | "side main"
   /** Fill the entire width */

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import Confirm, { ConfirmOptions } from "../Internals/Confirm"
 import Modal, { ModalOptions } from "../Internals/Modal"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 export interface ModalConfirmContext {
@@ -8,7 +9,7 @@ export interface ModalConfirmContext {
   confirm: (confirmOptions: ConfirmOptions) => void
 }
 
-export interface PageContentProps {
+export interface PageContentProps extends DefaultProps {
   /** Children to render, you */
   children?: React.ReactNode | ((modalConfirmContext: ModalConfirmContext) => React.ReactNode)
   /** Areas template for `PageArea` disposition */

--- a/src/Paginator/Paginator.tsx
+++ b/src/Paginator/Paginator.tsx
@@ -1,9 +1,10 @@
 import * as React from "react"
 import * as Icon from "react-feather"
 import Button from "../Button/Button"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Function to be executed after changing page */
   onChange?: (page: Props["page"]) => void
   /** Index of the current selected page */

--- a/src/Progress/Progress.tsx
+++ b/src/Progress/Progress.tsx
@@ -1,9 +1,10 @@
 import * as React from "react"
 import styled, { keyframes } from "react-emotion"
 import { Icon } from "../"
+import { DefaultProps } from "../types"
 import { lighten } from "../utils"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Show an error instead of the progress */
   error?: string
   /** Provide a button to retry the action to load */

--- a/src/ProgressPanel/ProgressPanel.tsx
+++ b/src/ProgressPanel/ProgressPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import Icon from "../Icon/Icon"
@@ -7,7 +8,7 @@ import constants, { OperationalStyleConstants } from "../utils/constants"
 
 export type Status = "waiting" | "todo" | "running" | "success" | "failure" | "done" | "failed"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Progress items */
   items: Array<{
     /** Progress item status */

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import { floatIn, readableTextColor, resetTransform } from "../utils"
@@ -22,7 +23,7 @@ const displayOption = (opt: IOption): string => {
   return String(opt.value)
 }
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Id */
   id?: string
 

--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import { readableTextColor } from "../utils"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   children?: React.ReactNode
 }
 

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -3,9 +3,10 @@ import styled from "react-emotion"
 import Icon, { IconName } from "../Icon/Icon"
 import OperationalContext from "../OperationalContext/OperationalContext"
 import { Props as SidenavItemProps } from "../SidenavItem/SidenavItem"
+import { DefaultProps } from "../types"
 import { floatIn, isModifiedEvent } from "../utils"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Main label for the header */
   label: string | React.ReactNode
   /** Navigation property à la react-router <Link/> */

--- a/src/SidenavItem/SidenavItem.tsx
+++ b/src/SidenavItem/SidenavItem.tsx
@@ -2,10 +2,11 @@ import * as React from "react"
 import styled, { Interpolation, Themed } from "react-emotion"
 import Icon, { IconName } from "../Icon/Icon"
 import OperationalContext from "../OperationalContext/OperationalContext"
+import { DefaultProps } from "../types"
 import { isModifiedEvent } from "../utils"
 import { OperationalStyleConstants } from "../utils/constants"
 
-export interface Props {
+export interface Props extends DefaultProps {
   onClick?: () => void
   /** Navigation property à la react-router <Link/> */
   to?: string

--- a/src/Spinner/Spinner.tsx
+++ b/src/Spinner/Spinner.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import styled, { keyframes } from "react-emotion"
+import { DefaultProps } from "../types"
 import { expandColor } from "../utils/constants"
 
-export interface Props {
+export interface Props extends DefaultProps {
   id?: string
   /** Color as color key or a custom CSS color string */
   color?: string

--- a/src/Status/Status.tsx
+++ b/src/Status/Status.tsx
@@ -1,16 +1,17 @@
 import * as React from "react"
 import tinycolor from "tinycolor2"
+import { DefaultProps } from "../types"
 import { OperationalStyleConstants } from "../utils/constants"
 import styled from "../utils/styled"
 
-export interface DeprecatedProps {
+export interface DeprecatedProps extends DefaultProps {
   running?: boolean
   success?: boolean
   error?: boolean
   state?: never
 }
 
-export interface LatestProps {
+export interface LatestProps extends DefaultProps {
   running?: never
   success?: never
   error?: never

--- a/src/Switch/Switch.tsx
+++ b/src/Switch/Switch.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Is the switch on? */
   on: boolean
   /** A change handler. Passes the new `on` boolean */

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** Table columns headings */
   columns: string[]
   /** Table rows as an array of cells */

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
+import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import Hint from "../Hint/Hint"
@@ -9,7 +10,7 @@ import { FormFieldControls, FormFieldError, inputFocus, Label, LabelText, labelT
 
 type ResizeOptions = "none" | "both" | "vertical" | "horizontal"
 
-export interface Props {
+export interface Props extends DefaultProps {
   id?: string
   className?: string
   /** Controlled value of the field */

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -11,8 +11,6 @@ import { FormFieldControls, FormFieldError, inputFocus, Label, LabelText, labelT
 type ResizeOptions = "none" | "both" | "vertical" | "horizontal"
 
 export interface Props extends DefaultProps {
-  id?: string
-  className?: string
   /** Controlled value of the field */
   value: string
   /** Label of the field */
@@ -133,34 +131,49 @@ class Textarea extends React.Component<Props, State> {
   }
 
   public render() {
+    const {
+      fullWidth,
+      resize,
+      label,
+      hint,
+      disabled,
+      code,
+      value,
+      error,
+      action,
+      height,
+      copy,
+      onChange,
+      ...props
+    } = this.props
     return (
-      <Label fullWidth={this.props.fullWidth} className={this.props.className} id={this.props.id}>
-        {this.props.label && <LabelText>{this.props.label}</LabelText>}
-        {this.props.hint && (
+      <Label {...props} fullWidth={fullWidth}>
+        {label && <LabelText>{label}</LabelText>}
+        {hint && (
           <FormFieldControls>
-            <Hint>{this.props.hint}</Hint>
+            <Hint>{hint}</Hint>
           </FormFieldControls>
         )}
         <TextareaComp
-          disabled={this.props.disabled!}
-          isCode={this.props.code!}
-          value={this.props.value}
-          isError={Boolean(this.props.error)}
-          isAction={Boolean(this.props.action || this.props.copy)}
-          resize={this.props.resize!}
-          height={this.props.height}
+          disabled={disabled!}
+          isCode={code!}
+          value={value}
+          isError={Boolean(error)}
+          isAction={Boolean(action || copy)}
+          resize={resize!}
+          height={height}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            if (!this.props.onChange) {
+            if (!onChange) {
               return
             }
-            this.props.onChange(e.target.value)
+            onChange(e.target.value)
           }}
         />
         {(this.props.action || this.props.copy) && (
-          <ActionHeader isLabel={Boolean(this.props.label)}>
-            {this.props.action}
-            {this.props.copy && (
-              <CopyToClipboard text={this.props.value} onCopy={this.showTooltip}>
+          <ActionHeader isLabel={Boolean(label)}>
+            {action}
+            {copy && (
+              <CopyToClipboard text={value} onCopy={this.showTooltip}>
                 <div>
                   {this.state.showTooltip && <Tooltip right>Copied!</Tooltip>}
                   <Icon size={8} name="Copy" />
@@ -170,7 +183,7 @@ class Textarea extends React.Component<Props, State> {
             )}
           </ActionHeader>
         )}
-        {this.props.error && <FormFieldError>{this.props.error}</FormFieldError>}
+        {error && <FormFieldError>{error}</FormFieldError>}
       </Label>
     )
   }

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import OperationalContext from "../OperationalContext/OperationalContext"
+import { DefaultProps } from "../types"
 import Container, { Position } from "./Tooltip.Container"
 
 /**
@@ -10,7 +11,7 @@ import Container, { Position } from "./Tooltip.Container"
  * The actual tooltip is rendered with this information extracted from the DOM node.
  */
 
-export interface BaseProps {
+export interface BaseProps extends DefaultProps {
   className?: string
   children?: React.ReactNode
   /** Smart-positioned tooltip, with positioning reversed so it doesn't flow out of the window's bounding box. Currently works for left and top-positioned tooltips. */

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -1,13 +1,14 @@
 import * as React from "react"
-import styled from "../utils/styled"
 
 import Icon from "../Icon/Icon"
 import SmallNameTag from "../Internals/SmallNameTag"
+import { DefaultProps } from "../types"
 import constants, { expandColor } from "../utils/constants"
+import styled from "../utils/styled"
 import { Tree as ITree } from "./Tree.types"
 import { containsPath, getInitialOpenPaths, togglePath } from "./Tree.utils"
 
-export interface Props {
+export interface Props extends DefaultProps {
   /** An array of tree structures */
   trees: ITree[]
 }

--- a/src/__tests__/libExports.ts
+++ b/src/__tests__/libExports.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from "fs"
 import { join } from "path"
 
-const BLACK_LIST = ["Internals", "utils", "__tests__", "polyfills.ts", "index.ts", ".DS_Store"]
+const BLACK_LIST = ["Internals", "utils", "__tests__", "polyfills.ts", "index.ts", "types.ts", ".DS_Store"]
 
 describe("lib exports", () => {
   const mainExport = readFileSync(join(__dirname, "../index.ts"), "utf-8")

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export interface DefaultProps {
+  id?: string
+  className?: string
+}


### PR DESCRIPTION
### Summary

Same deal as before for `Card`, `CardHeader`, `Button`, `ButtonGroup` and `Textarea`. In order for the card typings to work, I introduced a `DefaultProps` interface that every component's props can extend from so we can stop duplicating `id` and `className`. `React.HTMLProps` and `React.HTMLAttributes<HTMLElement>` cause obscure typings errors at this point, but we can keep working with this `DefaultProps` interface in the future to make it more accurate/support more cases.

### To be tested

Tester 1

- [x] No error/warning in the console
- [x] `Card` works as before + `styled(Card)({})` applies styles
- [x] `CardHeader` works as before + `styled(CardHeader)({})` applies styles
- [x] `CardItem` works as before + `styled(CardItem)({})` applies styles
- [x] `Page` works as before + `styled(Page)({})` applies styles
- [x] `Button` works as before + `styled(Button)({})` applies styles
- [x] `ButtonGroup` works as before + `styled(ButtonGroup)({})` applies styles
- [x] `Textarea` works as before + `styled(Textarea)({})` applies styles

Tester 2

- [x] No error/warning in the console
- [x] `Card` works as before + `styled(Card)({})` applies styles
- [x] `CardHeader` works as before + `styled(CardHeader)({})` applies styles
- [x] `CardItem` works as before + `styled(CardItem)({})` applies styles
- [x] `Page` works as before + `styled(Page)({})` applies styles
- [x] `Button` works as before + `styled(Button)({})` applies styles
- [x] `ButtonGroup` works as before + `styled(ButtonGroup)({})` applies styles
- [x] `Textarea` works as before + `styled(Textarea)({})` applies styles