### PR TITLE
Enable custom starting textarea height.

### DIFF
--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -12,6 +12,7 @@ class MyForm extends React.Component {
       v5: "",
       v6: "",
       v7: "",
+      v8: "",
     }
     this.handleChange = key => value => {
       this.setState({ [key]: value })
@@ -19,7 +20,7 @@ class MyForm extends React.Component {
   }
 
   render() {
-    const { v1, v2, v3, v4, v5, v6, v7 } = this.state
+    const { v1, v2, v3, v4, v5, v6, v7, v8 } = this.state
 
     return (
       <Form>
@@ -40,6 +41,7 @@ class MyForm extends React.Component {
         <Textarea value={v5} onChange={this.handleChange("v5")} label="with hint" hint="this is a hint" />
         <Textarea value={v6} onChange={this.handleChange("v6")} label="disabled" disabled />
         <Textarea value={v7} onChange={this.handleChange("v7")} label="a code" code />
+        <Textarea value={v8} onChange={this.handleChange("v7")} label="fixed height" height={200} />
       </Form>
     )
   }

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -20,6 +20,8 @@ export interface Props {
   onChange?: (val: string) => void
   /** Change the font to monospace to better display of code */
   code?: boolean
+  /** Custom starting height */
+  height?: number
   /** Text for a hint */
   hint?: string
   /** Error text */
@@ -46,9 +48,11 @@ const TextareaComp = styled("textarea")<{
   isAction: boolean
   disabled: boolean
   resize: ResizeOptions
-}>(({ theme, isCode, isError, isAction, disabled, resize }) => {
+  height?: number
+}>(({ theme, isCode, isError, isAction, disabled, resize, height }) => {
   const topPadding = (isAction ? 20 : 0) + theme.space.small
   return {
+    height,
     resize,
     fontSize: theme.font.size.small,
     fontWeight: theme.font.weight.regular,
@@ -143,6 +147,7 @@ class Textarea extends React.Component<Props, State> {
           isError={Boolean(this.props.error)}
           isAction={Boolean(this.props.action || this.props.copy)}
           resize={this.props.resize!}
+          height={this.props.height}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             if (!this.props.onChange) {
               return


### PR DESCRIPTION
### Summary

Previously: Textarea width can be controlled by using the `fullWidth` flag, but the height always started at the `minHeight` value of 120. 

Now: Textarea has a `height` prop which sets the starting height of the component. `minHeight` remains the same, and resizing is not affected.

Needed for <blockquote class="trello-card"><a href="https://trello.com/c/JdshXW0a/274-display-ssh-key-in-bundle-settings">Display ssh key in bundle settings</a></blockquote>

### To be tested

Tester 1

- [x] No error/warning in the console
- [x] The netlify build is working
- [x] `height` prop works and doesn't break resizing or affect minimum height
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [x] No error/warning in the console
- [x] The netlify build is working
- [x] `height` prop works and doesn't break resizing or affect minimum height
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
