### PR TITLE
Spread HTML props for input components

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -25,7 +25,6 @@ export interface Props extends DefaultProps {
       end?: string
     },
   ) => void
-  className?: string
   /** Placeholder text when no dates selected */
   placeholder?: string
 }
@@ -131,9 +130,9 @@ class DatePicker extends React.Component<Props, State> {
   }
 
   public render() {
-    const { onChange, placeholder, start, end, label, min, max, id } = this.props
+    const { onChange, placeholder, start, end, label, min, max, ...props } = this.props
     const { isExpanded, month, year } = this.state
-    const domId = id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : undefined)
+    const domId = props.id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : undefined)
 
     const nextMonth = changeMonth(1, { month: this.state.month, year: this.state.year })
 
@@ -142,10 +141,10 @@ class DatePicker extends React.Component<Props, State> {
 
     const datePickerWithoutLabel = (
       <Container
+        {...props}
         innerRef={(node: React.ReactNode) => {
           this.containerNode = node
         }}
-        key={id}
         isExpanded={isExpanded}
       >
         {!!(start && end) && (

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -191,9 +191,9 @@ class Input extends React.Component<PropsWithoutCopy | PropsWithCopy, State> {
       onBlur,
       placeholder,
       isError: Boolean(error),
-      onChange: (e: any) => {
+      onChange: (ev: React.FormEvent<HTMLInputElement>) => {
         if (onChange) {
-          onChange(e.target.value)
+          onChange(ev.currentTarget.value)
         }
       },
     }

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -7,14 +7,12 @@ import { FormFieldControl, FormFieldControls, FormFieldError, inputFocus, Label,
 import styled from "../utils/styled"
 
 export interface Props extends DefaultProps {
-  className?: string
   /** Text displayed when the input field has no value. */
   placeholder?: string
   /** The name used to refer to the input, for forms. */
   name?: string
   /** The current value of the input field. You must always supply this from the parent component, as per https://facebook.github.io/react/docs/forms.html#controlled-components. */
   value?: string
-  id?: string
   /** Specifies the id that should be used when hooking up label for attributes with input id attributes, if a label is present. */
   labelId?: string
   /** Label text, rendering the input inside a tag if specified. The `labelId` props is responsible for specifying for and id attributes. */
@@ -156,75 +154,91 @@ class Input extends React.Component<PropsWithoutCopy | PropsWithCopy, State> {
   }
 
   public render() {
-    const props = this.props
+    const {
+      fullWidth,
+      copy,
+      icon,
+      onIconClick,
+      label,
+      labelId,
+      inputRef,
+      autoFocus,
+      name,
+      hint,
+      autoComplete,
+      onToggle,
+      disabled,
+      value,
+      type,
+      onFocus,
+      onBlur,
+      placeholder,
+      error,
+      onChange,
+      ...props
+    } = this.props
 
-    const forAttributeId = props.label && props.labelId
+    const forAttributeId = label && labelId
     const commonInputProps = {
-      innerRef: props.inputRef,
-      autoFocus: props.autoFocus,
-      name: props.name,
-      disabled: Boolean(props.disabled),
-      value: props.value || "",
-      isStandalone: !Boolean(props.label),
-      type: props.type,
-      onFocus: props.onFocus,
-      onBlur: props.onBlur,
-      placeholder: props.placeholder,
-      isError: Boolean(props.error),
+      innerRef: inputRef,
+      autoFocus,
+      name,
+      disabled: Boolean(disabled),
+      value: value || "",
+      isStandalone: !Boolean(label),
+      type,
+      onFocus,
+      onBlur,
+      placeholder,
+      isError: Boolean(error),
       onChange: (e: any) => {
-        if (props.onChange) {
-          props.onChange(e.target.value)
+        if (onChange) {
+          onChange(e.target.value)
         }
       },
     }
 
-    const withIconButton = Boolean(props.icon && props.onIconClick) || Boolean(props.copy)
+    const withIconButton = Boolean(icon && onIconClick) || Boolean(copy)
     const inputButtonElement = this.getButtonElement()
 
-    if (props.label) {
+    if (label) {
       return (
-        <Label fullWidth={props.fullWidth} id={props.id} htmlFor={forAttributeId} className={props.className} left>
-          <LabelText>{props.label}</LabelText>
-          {(props.hint || props.onToggle) && (
+        <Label {...props} fullWidth={fullWidth} htmlFor={forAttributeId} left>
+          <LabelText>{label}</LabelText>
+          {(hint || onToggle) && (
             <FormFieldControls>
-              {props.hint && <Hint>{props.hint}</Hint>}
-              {props.onToggle ? (
+              {hint && <Hint>{hint}</Hint>}
+              {onToggle ? (
                 <FormFieldControl
                   onClick={() => {
-                    if (props.onToggle) {
-                      props.onToggle()
+                    if (onToggle) {
+                      onToggle()
                     }
                   }}
                 >
-                  <Icon name={props.disabled ? "Lock" : "Unlock"} size={12} />
+                  <Icon name={disabled ? "Lock" : "Unlock"} size={12} />
                 </FormFieldControl>
               ) : null}
             </FormFieldControls>
           )}
-          <InputFieldContainer fullWidth={props.fullWidth} withLabel>
+          <InputFieldContainer fullWidth={fullWidth} withLabel>
             {inputButtonElement}
             <InputField
               {...commonInputProps}
               id={forAttributeId}
-              autoComplete={props.autoComplete}
+              autoComplete={autoComplete}
               withIconButton={withIconButton}
             />
           </InputFieldContainer>
-          {props.error ? <FormFieldError>{props.error}</FormFieldError> : null}
+          {error ? <FormFieldError>{error}</FormFieldError> : null}
         </Label>
       )
     }
 
     return (
-      <InputFieldContainer fullWidth={props.fullWidth}>
+      <InputFieldContainer {...props} fullWidth={fullWidth}>
         {inputButtonElement}
-        <InputField
-          {...commonInputProps}
-          id={props.id}
-          className={props.className}
-          autoComplete={props.autoComplete}
-          withIconButton={withIconButton}
-        />
+        <InputField {...commonInputProps} autoComplete={autoComplete} withIconButton={withIconButton} />
       </InputFieldContainer>
     )
   }

--- a/src/Select/Select.Option.tsx
+++ b/src/Select/Select.Option.tsx
@@ -31,7 +31,7 @@ const Container = styled("div")<{ selected: boolean }>(({ theme, selected }) => 
 })
 
 const IconContainer = styled("div")(({ theme }) => {
-  const size = 14
+  const size = 18
   return {
     display: "flex",
     alignItems: "center",

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -24,33 +24,22 @@ const displayOption = (opt: IOption): string => {
 }
 
 export interface Props extends DefaultProps {
-  /** Id */
-  id?: string
-
   /** Options available */
   options: IOption[]
-
   /** Current value */
   value: null | Value | Value[]
-
   /** Make the list filterable */
   filterable?: boolean
-
   /** Disable the component */
   disabled?: boolean
-
   /** Callback trigger on any changes */
   onChange?: (newValue: null | Value | Value[], changedItem?: Value) => void
-
   /** Text color */
   color?: string
-
   /** Text to display when no active selection */
   placeholder?: string
-
   /** Label text */
   label?: string
-
   /** Should the Select be rendered with a full box style? */
   naked?: boolean
 }
@@ -241,11 +230,11 @@ class Select extends React.Component<Props, State> {
   }
 
   public render() {
-    const { id, color, disabled, naked, value, options, filterable, label } = this.props
+    const { color, disabled, naked, value, options, filterable, label, onChange, ...props } = this.props
     const { open, search } = this.state
     const selectWithoutLabel = (
       <Container
-        id={id}
+        {...props}
         color={color}
         disabled={disabled}
         naked={naked}
@@ -294,7 +283,7 @@ class Select extends React.Component<Props, State> {
       </Container>
     )
     return label ? (
-      <Label>
+      <Label {...props}>
         <LabelText>{label}</LabelText>
         {selectWithoutLabel}
       </Label>

--- a/src/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Select Should render correctly 1`] = `
   />
   <div
     class="css-2xp493-select"
+    placeholder="Select me"
     role="listbox"
     tabindex="-2"
   >


### PR DESCRIPTION
### Summary

! this is a finicky refactor, help me test this carefully :) !

Spreading HTML props on input components to allow `styled(ContextMenu)({})` usage and other behaviors such as keys and drag listeners.

Test like so (I have done this myself, but do feel free to reproduce):
* go to the netlify link
* add this to the top of one of the snippets:
```
const StyledComponent = styled.default(Component)({ margin: 40 })
```
* change one `Component` to `StyledComponent` somewhere in the code.
* watch it jump!

Tester 1

- [x] No error/warning in the console
- [x] All component functionality works as before
- [x] `styled(Input)({})` works
- [x] `styled(Select)({})` works
- [x] `styled(DatePicker)({})` works

Tester 2

- [x] No error/warning in the console
- [x] `styled(Input)({})` works
- [x] `styled(Select)({})` works
- [x] `styled(DatePicker)({})` works