### PR TITLE
Remove non-HTML attributes from Page component props spread

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -174,7 +174,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   }
 
   public render() {
-    const { title, actions, tabs, ...props } = this.props
+    const { title, actions, tabs, areas, activeTabName, onTabChange, fill, ...props } = this.props
 
     return (
       <Container {...props}>


### PR DESCRIPTION
### Summary

Fix html props spreading-related warnings on the `Page` component.

### To be tested

Tester 1

- [x] No error/warning in the console
- [x] The `Page` component works as before

Tester 2

- [ ] No error/warning in the console
- [ ] The `Page` component works as before
