### PR TITLE
Spread HTML props for remaining components

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -130,7 +130,11 @@ class DatePicker extends React.Component<DatePickerProps, State> {
   }
 
   public render() {
-    const { onChange, placeholder, start, end, label, min, max, ...props } = this.props
+    /**
+     * Contrary to other component implementations, the `className` prop is destructured from the spread `props` object.
+     * This is to allow for it to only apply to the datepicker's container, which may be the label or the picker itself.
+     */
+    const { onChange, placeholder, start, end, label, min, max, className, ...props } = this.props
     const { isExpanded, month, year } = this.state
     const domId = props.id || (label && label.toLowerCase ? label.toLowerCase().replace(/\s/g, "-") : undefined)
 
@@ -139,9 +143,10 @@ class DatePicker extends React.Component<DatePickerProps, State> {
     const canGoToPreviousMonth = !min || min < toDate(this.state.year, this.state.month, 0)
     const canGoToNextMonth = !max || max >= toDate(nextMonth.year, nextMonth.month, 0)
 
-    const datePickerWithoutLabel = (
+    const datePickerWithoutLabel = (isStandalone: boolean) => (
       <Container
         {...props}
+        className={isStandalone ? className : undefined}
         innerRef={(node: React.ReactNode) => {
           this.containerNode = node
         }}
@@ -217,12 +222,12 @@ class DatePicker extends React.Component<DatePickerProps, State> {
       </Container>
     )
     return label ? (
-      <Label>
+      <Label {...props} className={className}>
         <LabelText>{label}</LabelText>
-        {datePickerWithoutLabel}
+        {datePickerWithoutLabel(false)}
       </Label>
     ) : (
-      datePickerWithoutLabel
+      datePickerWithoutLabel(true)
     )
   }
 }

--- a/src/HeaderBar/HeaderBar.tsx
+++ b/src/HeaderBar/HeaderBar.tsx
@@ -48,8 +48,8 @@ const EndContainer = styled("div")`
   justify-content: flex-end;
 `
 
-const HeaderBar: React.SFC<HeaderBarProps> = ({ logo, main, end }) => (
-  <Bar>
+const HeaderBar: React.SFC<HeaderBarProps> = ({ logo, main, end, ...props }) => (
+  <Bar {...props}>
     <StartContainer>{logo}</StartContainer>
     <CenterContainer>{main}</CenterContainer>
     <EndContainer>{end}</EndContainer>

--- a/src/Layout/Layout.tsx
+++ b/src/Layout/Layout.tsx
@@ -67,13 +67,13 @@ const Header = styled("div")({
   gridRowEnd: "span 1",
 })
 
-const Layout: React.SFC<LayoutProps> = props => (
-  <Container>
-    {props.loading && <Progress />}
+const Layout: React.SFC<LayoutProps> = ({ loading, header, sidenav, main, ...props }) => (
+  <Container {...props}>
+    {loading && <Progress />}
     <GridContainer>
-      <Header>{props.header}</Header>
-      <Side>{props.sidenav}</Side>
-      <Main>{props.main}</Main>
+      <Header>{header}</Header>
+      <Side>{sidenav}</Side>
+      <Main>{main}</Main>
     </GridContainer>
   </Container>
 )

--- a/src/NameTag/NameTag.tsx
+++ b/src/NameTag/NameTag.tsx
@@ -24,15 +24,15 @@ export interface NameTagProps extends DefaultProps {
 }
 
 const Container = styled("div")<{
-  color?: NameTagProps["color"]
+  color_?: NameTagProps["color"]
   left?: NameTagProps["left"]
   right?: NameTagProps["right"]
   children: string
   assignColor: boolean
-}>(({ theme, color, left, right, children, assignColor }) => {
+}>(({ theme, color_, left, right, children, assignColor }) => {
   const backgroundColor = assignColor
     ? colorMapper(theme.color.palette)(children)
-    : expandColor(theme, color) || theme.color.primary
+    : expandColor(theme, color_) || theme.color.primary
   const textColor = readableTextColor(backgroundColor, [theme.color.white, theme.color.black])
   return {
     backgroundColor,
@@ -50,9 +50,9 @@ const Container = styled("div")<{
   }
 })
 
-const NameTag: React.SFC<NameTagProps> = props => (
-  <Container {...props} assignColor={Boolean(!props.color)}>
-    {props.children || ""}
+const NameTag: React.SFC<NameTagProps> = ({ color, children, ...props }) => (
+  <Container {...props} color_={color} assignColor={Boolean(!color)}>
+    {children || ""}
   </Container>
 )
 

--- a/src/NameTag/__tests__/__snapshots__/NameTag.test.tsx.snap
+++ b/src/NameTag/__tests__/__snapshots__/NameTag.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`NameTag Component Should render 1`] = `
   />
   <div
     class="css-1w6ld2o"
-    color="primary"
   >
     PG
   </div>

--- a/src/PageAreas/PageAreas.tsx
+++ b/src/PageAreas/PageAreas.tsx
@@ -9,7 +9,7 @@ export interface PageAreasProps extends DefaultProps {
   fill?: boolean
 }
 
-const StyledPageAreas = styled("div")<{ areas?: PageAreasProps["areas"]; isFill?: boolean }>(props => {
+const Container = styled("div")<{ areas?: PageAreasProps["areas"]; fill_?: boolean }>(props => {
   const gridTemplateColumns = {
     main: "auto",
     "main side": "auto 280px",
@@ -22,13 +22,12 @@ const StyledPageAreas = styled("div")<{ areas?: PageAreasProps["areas"]; isFill?
     alignItems: "stretch",
     gridTemplateAreas: `"${props.areas}"`,
     gridGap: props.theme.space.element,
-    maxWidth: props.isFill ? "none" : 1150,
+    maxWidth: props.fill_ ? "none" : 1150,
     minWidth: 800,
     width: "100%",
   }
 })
 
-// `fill` must be rename internally to avoid conflict with the native `fill` DOM attribute
-const PageAreas: React.SFC<PageAreasProps> = ({ fill, ...props }) => <StyledPageAreas {...props} isFill={fill} />
+const PageAreas: React.SFC<PageAreasProps> = ({ fill, ...props }) => <Container {...props} fill_={fill} />
 
 export default PageAreas


### PR DESCRIPTION
### Summary

Same deal as before for `DatePicker` (fix), `NameTag`, `Layout` and `HeaderBar`. This concludes props spreading and fixes #517.

Test like so (I have done this myself, but do feel free to reproduce):
* go to the netlify link
* add this to the top of one of the snippets:
```
const StyledNameTag = styled.default(NameTag)({ margin: 40 })
```
* change one `NameTag` to `StyledNameTag` somewhere in the code.
* watch it jump!

### To be tested

Tester 1

- [ ] No error/warning in the console
- [x] `DatePicker` works as before + `styled(DatePicker)({})` applies styles
- [x] `NameTag` works as before + `styled(NameTag)({})` applies styles
- [x] `Layout` works as before + `styled(Layout)({})` applies styles
- [x] `HeaderBar` works as before + `styled(HeaderBar)({})` applies styles

Tester 2

- [ ] No error/warning in the console
- [x] `DatePicker` works as before + `styled(DatePicker)({})` applies styles
- [x] `NameTag` works as before + `styled(NameTag)({})` applies styles
- [x] `Layout` works as before + `styled(Layout)({})` applies styles
- [x] `HeaderBar` works as before + `styled(HeaderBar)({})` applies styles