### PR TITLE
Feature: Error Boundary

### DIFF
--- a/src/Internals/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/Internals/ErrorBoundary/ErrorBoundary.tsx
@@ -44,8 +44,10 @@ const ErrorBoundary: React.SFC<ErrorBoundaryProps> = ({ environment, error }) =>
       color="error"
       title={!isProduction ? error.message : "Something Went Wrong"}
       actions={
-        !isProduction && (
+        !isProduction ? (
           <Button to="https://reactjs.org/docs/error-boundaries.html">Learn More about Error Boundaries</Button>
+        ) : (
+          <Button to="/">Reload</Button>
         )
       }
     >
@@ -59,7 +61,11 @@ const ErrorBoundary: React.SFC<ErrorBoundaryProps> = ({ environment, error }) =>
 
           {error.stack && (
             <StackTrace>
-              {error.stack.split("\n").map((line, index) => <p style={{ paddingLeft: `${index * 8}px` }}>{line}</p>)}
+              {error.stack.split("\n").map((line, index) => (
+                <p key={index} style={{ paddingLeft: `${index * 8}px` }}>
+                  {line}
+                </p>
+              ))}
             </StackTrace>
           )}
         </>

--- a/src/Internals/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/Internals/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import Button from "../../Button/Button"
+import Splash from "../../Splash/Splash"
+import styled from "../../utils/styled"
+
+export interface ErrorBoundaryProps {
+  /*
+   * What environment are we currently in?
+   * @default process.env.NODE_ENV
+   */
+  environment?: string
+  error: Error
+}
+
+const StackTrace = styled("div")`
+  font-size: ${props => props.theme.font.size.small}px;
+  max-height: 240px;
+  overflow: auto;
+
+  p {
+    margin-top: ${props => props.theme.space.small}px;
+  }
+
+  ::before {
+    content: "Stack Trace";
+    font-size: 16px;
+    font-weight: 500;
+    display: block;
+    padding-bottom: ${props => props.theme.space.small}px;
+    margin-bottom: ${props => props.theme.space.element}px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  }
+`
+
+const ErrorBoundary: React.SFC<ErrorBoundaryProps> = ({ environment, error }) => {
+  const isProduction = environment === "production"
+
+  return (
+    <Splash
+      color="error"
+      title={!isProduction ? error.message : "Something Went Wrong"}
+      actions={
+        !isProduction && (
+          <Button to="https://reactjs.org/docs/error-boundaries.html">Learn More about Error Boundaries</Button>
+        )
+      }
+    >
+      {!isProduction ? (
+        <>
+          <p>
+            One of your components further down in the component tree has errored, causing your app to unmount and
+            instead, show this screen.
+          </p>
+          <p>Please handle your errors in your components further down the React tree.</p>
+
+          {error.stack && (
+            <StackTrace>
+              {error.stack.split("\n").map((line, index) => <p style={{ paddingLeft: `${index * 8}px` }}>{line}</p>)}
+            </StackTrace>
+          )}
+        </>
+      ) : (
+        <p>
+          An unexpected error occured.<br />Please check back later.
+        </p>
+      )}
+    </Splash>
+  )
+}
+
+ErrorBoundary.defaultProps = {
+  environment: process.env.NODE_ENV,
+}
+
+export default ErrorBoundary

--- a/src/Internals/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/Internals/ErrorBoundary/ErrorBoundary.tsx
@@ -10,6 +10,9 @@ export interface ErrorBoundaryProps {
    * @default process.env.NODE_ENV
    */
   environment?: string
+  /**
+   * The error that is thrown.
+   */
   error: Error
 }
 

--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -139,7 +139,7 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
     this.setState(() => ({ isLoading }))
   }
 
-  public componentDidCatch(error: any) {
+  public componentDidCatch(error: Error) {
     this.setState({ error })
   }
 


### PR DESCRIPTION
### Summary
This PR adds a catch-all error boundary above all contained Operational components – at the point where this error boundary is invoked, the app is completely unmounted. Because of this, we have a choice: either we unmount the whole app, or tell users to implement more localized error boundaries with a handy docs link. 

This PR aims to make Operational a little more developer friendly.

In a production environment, the error is a little more obscured.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

### Related issue
https://trello.com/c/mil1pcAI

<!-- Paste the github issue here -->

### Screens
Production:
![Production](https://user-images.githubusercontent.com/9947422/43573612-6e404044-9642-11e8-8a8b-3e7beee1ad93.png)

Development:
<img width="1440" alt="Development" src="https://user-images.githubusercontent.com/9947422/43573637-7a252230-9642-11e8-8006-bc81648001b1.png">

### To be tested
It's an internal, so really nothing. Try to cause an error in the playground?

Me
- [ ] No error/warning in the console

Tester 1

- [ ] The netlify build is working
- [ ] **Looks good in production**: in any playground on the Netlify-deployed styleguide, enter `window.haha.hoho` to trigger an error.
- [ ] **Looks good in development**: run locally and in any playground on the styleguide, enter `window.haha.hoho` to trigger an error.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] The netlify build is working
- [ ] **Looks good in production**: in any playground on the Netlify-deployed styleguide, enter `window.haha.hoho` to trigger an error.
- [ ] **Looks good in development**: run locally and in any playground on the styleguide, enter `window.haha.hoho` to trigger an error.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
