### PR TITLE
Add currentColor assignment to spinner svg shapes

### DIFF
--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -29,6 +29,7 @@ Using buttons is as simple as including the component with a text node as a chil
   <Button color="grey" icon="Open">Icon</Button>
   <Button color="success" icon="Labs">Icon</Button>
   <Button loading>Loading</Button>
+  <Button color="primary" loading>Loading</Button>
   <Button condensed icon="Open">Icon</Button>
   <Button condensed loading>Loading</Button>
 
@@ -37,6 +38,7 @@ Using buttons is as simple as including the component with a text node as a chil
   <Button disabled color="grey" icon="Open">Icon</Button>
   <Button disabled color="success" icon="Labs">Icon</Button>
   <Button disabled loading>Loading</Button>
+  <Button disabled color="primary" loading>Loading</Button>
   <Button disabled condensed icon="Open">Icon</Button>
   <Button disabled condensed loading>Loading</Button>
 </div>

--- a/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
+++ b/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`ProgressPanel Component Should initialize properly 1`] = `
         class="css-1q2u45i"
       >
         <div
-          class="css-1yhonro"
+          class="css-ph6up9"
         >
           <div
             class="css-qeu37x"

--- a/src/Spinner/Spinner.tsx
+++ b/src/Spinner/Spinner.tsx
@@ -64,7 +64,7 @@ const Container = styled("div")<{
   marginRight: left ? theme.space.small : 0,
   marginLeft: right ? theme.space.small : 0,
   "& svg": {
-    fill: expandColor(theme, color) || theme.color.text.lighter,
+    fill: expandColor(theme, color) || "currentColor",
   },
 }))
 

--- a/src/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
+++ b/src/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Spinner Component Should render 1`] = `
     class="css-ar73w8-Messages"
   />
   <div
-    class="css-1w0xah4"
+    class="css-110u284"
   >
     <div
       class="css-qeu37x"


### PR DESCRIPTION
### Summary

Change back `currentColor` assignment to the `Spinner component`. The current strict default color behavior can be replicated by writing `<Spinner color="lightGrey" />`.

### Related issue

Fixes #659.

### To be tested

Me
- [x] No error/warning in the console
- [x] Spinners inherit color from their containers (test for example by wrapping a spinner in a `<div style={{ color: "red" }} />`).

Tester 1 - @tejasq

- [x] The netlify build is working
- [x] Spinners inherit color from their containers (test for example by wrapping a spinner in a `<div style={{ color: "red" }} />`).
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] The netlify build is working
- [ ] Spinners inherit color from their containers (test for example by wrapping a spinner in a `<div style={{ color: "red" }} />`).
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
