### PR TITLE
Fix Theme typings import error

### DIFF
--- a/src/utils/mixins.ts
+++ b/src/utils/mixins.ts
@@ -6,6 +6,11 @@
  */
 // @ts-ignore
 import * as React from "react"
+/**
+ * Same issue for deprecated `Theme` object.
+ */
+// @ts-ignore
+import { Theme } from "./constants/deprecatedTheme"
 
 import styled, { keyframes } from "react-emotion"
 import { dangerousTooltipContainerClassName } from "../Tooltip/Tooltip"


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

## Summary

Fixes one more out-of-scope-typing-reference issue.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

## Related issue

<!-- Paste the github issue here -->

## To be tested

Me
- [x] No error/warning in the console

Tester 1

- [x] The netlify build is working
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [x] The netlify build is working
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
