### PR TITLE
**Fix:** Clipped tooltip

### DIFF
--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -151,7 +151,7 @@ class Input extends React.Component<InputProps, State> {
     return this.props.copy ? (
       <CopyToClipboard text={this.props.value || ""} onCopy={this.showTooltip}>
         <InputButton>
-          {this.state.showTooltip && <Tooltip left>Copied!</Tooltip>}
+          {this.state.showTooltip && <Tooltip bottom>Copied to clipboard</Tooltip>}
           <Icon name="Copy" size={16} />
         </InputButton>
       </CopyToClipboard>

--- a/src/Layout/Layout.tsx
+++ b/src/Layout/Layout.tsx
@@ -43,17 +43,25 @@ const GridContainer = styled("div")(
 )
 
 const Main = styled("div")(({ theme }) => ({
-  overflow: "hidden",
+  overflowY: "hidden",
+  overflowX: "auto",
   gridColumnEnd: "span 1",
   gridColumnStart: "2",
   gridRowStart: "2",
   gridRowEnd: "span 1",
   height: `calc(100% - ${theme.titleHeight}px)`, // FORCE a height that is the page - the logo so that children with 100% have context
   backgroundColor: theme.color.white,
+  position: "relative",
+  zIndex: 2,
 }))
 
 const Side = styled(Main)({
   gridColumnStart: "1",
+  gridColumnEnd: "span 1",
+  gridRowStart: "2",
+  gridRowEnd: "span 1",
+  position: "relative",
+  zIndex: 1,
 })
 
 const Header = styled("div")({


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

## Summary

Attempting to fix the left-positioned copy-to-clipboard tooltip that is currently clipped by the sidenav. As a last resort, we can bottom-position like in the image below, but we should investigate a proper solutions first.

<img width="399" alt="screen shot 2018-08-15 at 11 24 43 am" src="https://user-images.githubusercontent.com/6738398/44141837-960879f2-a07e-11e8-9f50-60936c5ca847.png">

Things I'm trying:
* higher z-index hierarchies for `Main` than for `Side` in `Layout.tsx`.
* a number of components (`Main` in `Layout.tsx`, `ViewContainer` in `Page.tsx` have `overflow: hidden` to prevent double scrollbars, which unfortunately also clips sticking out horizontally. Changing those to `overflow-y: hidden; overflow-x: auto;` should help.

Some reading: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context.

## To be tested

Me
- [ ] No error/warning in the console
- [ ] copy to clipboard note isn't clipped by sidenav

Tester 1

- [ ] The netlify build is working
- [ ] copy to clipboard note isn't clipped by sidenav

Tester 2

- [ ] The netlify build is working
- [ ] copy to clipboard note isn't clipped by sidenav
