### PR TITLE
**Feature: ** Compact Sidenav

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     ]
   },
   "dependencies": {
+    "create-emotion-styled": "^9.2.6",
     "emotion": "^9.2.5",
     "emotion-theming": "^9.2.6",
     "lodash": "^4.17.10",

--- a/src/Sidenav/README.md
+++ b/src/Sidenav/README.md
@@ -33,8 +33,8 @@ class StatefulSidenav extends React.Component {
             active={this.state.activeHeaders.includes(1)}
             onToggle={this.toggle.bind(this, 1)}
           >
-            <SidenavItem label="The First Prize" shortLabel="First" icon="Add" />
-            <SidenavItem label="The Second Prize" shortLabel="Second" icon="Admin" />
+            <SidenavItem label="The First Prize" compactLabel="First" icon="Add" />
+            <SidenavItem label="The Second Prize" compactLabel="Second" icon="Admin" />
             <SidenavItem label="No Short Label" icon="Bundle" />
           </SidenavHeader>
           <SidenavHeader
@@ -42,19 +42,19 @@ class StatefulSidenav extends React.Component {
             active={this.state.activeHeaders.includes(2)}
             onToggle={this.toggle.bind(this, 2)}
           >
-            <SidenavItem label="The Fourth Prize" shortLabel="Fourth" icon="Catalog" />
-            <SidenavItem label="The Fifth Prize" shortLabel="Fifth" icon="ChevronDown" />
+            <SidenavItem label="The Fourth Prize" compactLabel="Fourth" icon="Catalog" />
+            <SidenavItem label="The Fifth Prize" compactLabel="Fifth" icon="ChevronDown" />
             {/* No Icon case */}
-            <SidenavItem label="The Sixth Prize" shortLabel="Sixth" />
+            <SidenavItem label="The Sixth Prize" compactLabel="Sixth" />
           </SidenavHeader>
           <SidenavHeader
             label="Let It Snow"
             active={this.state.activeHeaders.includes(3)}
             onToggle={this.toggle.bind(this, 3)}
           >
-            <SidenavItem label="The Seventh Prize" shortLabel="Seventh" icon="Document" />
-            <SidenavItem label="The Eighth Prize" shortLabel="Eighth" icon="Endpoint" />
-            <SidenavItem label="The Ninth Prize" shortLabel="Ninth" icon="Entity" />
+            <SidenavItem label="The Seventh Prize" compactLabel="Seventh" icon="Document" />
+            <SidenavItem label="The Eighth Prize" compactLabel="Eighth" icon="Endpoint" />
+            <SidenavItem label="The Ninth Prize" compactLabel="Ninth" icon="Entity" />
           </SidenavHeader>
         </Sidenav>
       </div>

--- a/src/Sidenav/README.md
+++ b/src/Sidenav/README.md
@@ -86,24 +86,13 @@ class StatefulSidenav extends React.Component {
 ### With a header placed at the bottom
 
 ```jsx
-<div style={{ height: 600, display: "flex" }}>
-  <div>
-    <Sidenav compact>
-      <SidenavHeader end label="Let It Snow">
-        <SidenavItem label="Steak" icon="Jobs" />
-        <SidenavItem label="Frites" active icon="Lock" />
-        <SidenavItem label="Rum" icon="No" />
-      </SidenavHeader>
-    </Sidenav>
-  </div>
-  <div>
-    <Sidenav compact>
-      <SidenavHeader label="Let It Snow">
-        <SidenavItem label="Steak" icon="Jobs" />
-        <SidenavItem label="Frites" active icon="Lock" />
-        <SidenavItem label="Rum" icon="No" />
-      </SidenavHeader>
-    </Sidenav>
-  </div>
+<div style={{ height: 600 }}>
+  <Sidenav compact>
+    <SidenavHeader label="Let It Snow">
+      <SidenavItem label="Steak" icon="Jobs" />
+      <SidenavItem label="Frites" active icon="Lock" />
+    </SidenavHeader>
+    <SidenavItem end label="Rum" icon="No" />
+  </Sidenav>
 </div>
 ```

--- a/src/Sidenav/README.md
+++ b/src/Sidenav/README.md
@@ -35,7 +35,7 @@ class StatefulSidenav extends React.Component {
           >
             <SidenavItem label="The First Prize" shortLabel="First" icon="Add" />
             <SidenavItem label="The Second Prize" shortLabel="Second" icon="Admin" />
-            <SidenavItem label="The Third Prize" shortLabel="Third" icon="Bundle" />
+            <SidenavItem label="No Short Label" icon="Bundle" />
           </SidenavHeader>
           <SidenavHeader
             label="Let It Snow"

--- a/src/Sidenav/README.md
+++ b/src/Sidenav/README.md
@@ -2,6 +2,8 @@ Sidenavs render a two-level hierarchical navigation element comprised of headers
 
 ### Usage
 
+<!-- -->
+
 Typical usage includes `to` props to navigate and to manage highlighted/active state automatically.
 
 ```jsx
@@ -31,27 +33,27 @@ class StatefulSidenav extends React.Component {
             active={this.state.activeHeaders.includes(1)}
             onToggle={this.toggle.bind(this, 1)}
           >
-            <SidenavItem label="The First Prize" icon="Settings" />
-            <SidenavItem label="The Second Prize" icon="Settings" />
-            <SidenavItem label="The Third Prize" icon="Settings" />
+            <SidenavItem label="The First Prize" shortLabel="First" icon="Add" />
+            <SidenavItem label="The Second Prize" shortLabel="Second" icon="Admin" />
+            <SidenavItem label="The Third Prize" shortLabel="Third" icon="Bundle" />
           </SidenavHeader>
           <SidenavHeader
             label="Let It Snow"
             active={this.state.activeHeaders.includes(2)}
             onToggle={this.toggle.bind(this, 2)}
           >
-            <SidenavItem label="The First Prize" icon="Settings" />
-            <SidenavItem label="The Second Prize" icon="Settings" />
-            <SidenavItem label="The Third Prize" icon="Settings" />
+            <SidenavItem label="The Fourth Prize" shortLabel="Fourth" icon="Catalog" />
+            <SidenavItem label="The Fifth Prize" shortLabel="Fifth" icon="ChevronDown" />
+            <SidenavItem label="The Sixth Prize" shortLabel="Sixth" icon="ChevronLeft" />
           </SidenavHeader>
           <SidenavHeader
             label="Let It Snow"
             active={this.state.activeHeaders.includes(3)}
             onToggle={this.toggle.bind(this, 3)}
           >
-            <SidenavItem label="The First Prize" icon="Settings" />
-            <SidenavItem label="The Second Prize" icon="Settings" />
-            <SidenavItem label="The Third Prize" icon="Settings" />
+            <SidenavItem label="The Seventh Prize" shortLabel="Seventh" icon="Document" />
+            <SidenavItem label="The Eighth Prize" shortLabel="Eighth" icon="Endpoint" />
+            <SidenavItem label="The Ninth Prize" shortLabel="Ninth" icon="Entity" />
           </SidenavHeader>
         </Sidenav>
       </div>
@@ -60,4 +62,22 @@ class StatefulSidenav extends React.Component {
 }
 
 ;<StatefulSidenav />
+```
+
+### Compact Mode
+
+```jsx
+<Sidenav compact>
+  <SidenavHeader condensed icon="Home" label="Project Home" />
+  <SidenavHeader label="The Prize">
+    <SidenavItem label="Overview" icon="Function" />
+    <SidenavItem label="Use Cases" icon="Funnel" />
+    <SidenavItem label="Guides" icon="Home" />
+  </SidenavHeader>
+  <SidenavHeader label="Let It Snow">
+    <SidenavItem label="Steak" icon="Jobs" />
+    <SidenavItem label="Frites" active icon="Lock" />
+    <SidenavItem label="Rum" icon="No" />
+  </SidenavHeader>
+</Sidenav>
 ```

--- a/src/Sidenav/README.md
+++ b/src/Sidenav/README.md
@@ -44,7 +44,8 @@ class StatefulSidenav extends React.Component {
           >
             <SidenavItem label="The Fourth Prize" shortLabel="Fourth" icon="Catalog" />
             <SidenavItem label="The Fifth Prize" shortLabel="Fifth" icon="ChevronDown" />
-            <SidenavItem label="The Sixth Prize" shortLabel="Sixth" icon="ChevronLeft" />
+            {/* No Icon case */}
+            <SidenavItem label="The Sixth Prize" shortLabel="Sixth" />
           </SidenavHeader>
           <SidenavHeader
             label="Let It Snow"
@@ -80,4 +81,29 @@ class StatefulSidenav extends React.Component {
     <SidenavItem label="Rum" icon="No" />
   </SidenavHeader>
 </Sidenav>
+```
+
+### With a header placed at the bottom
+
+```jsx
+<div style={{ height: 600, display: "flex" }}>
+  <div>
+    <Sidenav compact>
+      <SidenavHeader end label="Let It Snow">
+        <SidenavItem label="Steak" icon="Jobs" />
+        <SidenavItem label="Frites" active icon="Lock" />
+        <SidenavItem label="Rum" icon="No" />
+      </SidenavHeader>
+    </Sidenav>
+  </div>
+  <div>
+    <Sidenav compact>
+      <SidenavHeader label="Let It Snow">
+        <SidenavItem label="Steak" icon="Jobs" />
+        <SidenavItem label="Frites" active icon="Lock" />
+        <SidenavItem end label="Rum" icon="No" />
+      </SidenavHeader>
+    </Sidenav>
+  </div>
+</div>
 ```

--- a/src/Sidenav/README.md
+++ b/src/Sidenav/README.md
@@ -101,7 +101,7 @@ class StatefulSidenav extends React.Component {
       <SidenavHeader label="Let It Snow">
         <SidenavItem label="Steak" icon="Jobs" />
         <SidenavItem label="Frites" active icon="Lock" />
-        <SidenavItem end label="Rum" icon="No" />
+        <SidenavItem label="Rum" icon="No" />
       </SidenavHeader>
     </Sidenav>
   </div>

--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -34,10 +34,10 @@ const Container = styled("div")<{ compact?: SidenavProps["compact"] }>(({ theme,
 const Sidenav: React.SFC<SidenavProps> = ({ children, ...props }) => (
   <Container {...props}>
     {React.Children.map(children, child => {
-      const iKnowWhatTypeMyChildIs = child as React.ReactElement<any>
+      const dudeMyChildIsAnElementJustLetMeUseItUgh = child as React.ReactElement<any>
       return {
-        ...(iKnowWhatTypeMyChildIs as React.ReactElement<any>),
-        props: { ...iKnowWhatTypeMyChildIs.props, compact: props.compact },
+        ...dudeMyChildIsAnElementJustLetMeUseItUgh,
+        props: { ...dudeMyChildIsAnElementJustLetMeUseItUgh.props, compact: props.compact },
       }
     })}
   </Container>

--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -35,11 +35,11 @@ const Container = styled("div")<{ compact?: SidenavProps["compact"] }>(({ theme,
 const Sidenav: React.SFC<SidenavProps> = ({ children, ...props }) => (
   <Container {...props}>
     {React.Children.map(children, child => {
-      // see line 8
-      const dudeMyChildIsAnElementJustLetMeUseItUgh = child as React.ReactElement<any>
+      // see line 8 for the safety of this assertion
+      const childElement = child as React.ReactElement<any>
       return {
-        ...dudeMyChildIsAnElementJustLetMeUseItUgh,
-        props: { ...dudeMyChildIsAnElementJustLetMeUseItUgh.props, compact: props.compact },
+        ...childElement,
+        props: { ...childElement.props, compact: props.compact },
       }
     })}
   </Container>

--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -19,6 +19,7 @@ const Container = styled("div")<{ compact?: SidenavProps["compact"] }>(({ theme,
   const color = readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
   return {
     color,
+    position: "relative",
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",

--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -1,17 +1,20 @@
 import * as React from "react"
+
 import { DefaultProps } from "../types"
 import { readableTextColor } from "../utils"
 import styled from "../utils/styled"
 
 export interface SidenavProps extends DefaultProps {
-  children?: React.ReactNode
+  children: React.ReactElement<any> | Array<React.ReactElement<any>>
+  /** Show the sidebar in compact mode */
+  compact?: boolean
 }
 
 export interface State {
   isHovered: boolean
 }
 
-const Container = styled("div")(({ theme }) => {
+const Container = styled("div")<{ compact?: SidenavProps["compact"] }>(({ theme, compact }) => {
   const backgroundColor = theme.color.white
   const color = readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
   return {
@@ -20,7 +23,7 @@ const Container = styled("div")(({ theme }) => {
     flexDirection: "column",
     alignItems: "flex-start",
     overflow: "auto",
-    width: theme.sidebarWidth,
+    width: compact ? theme.compactSidebarWidth : theme.sidebarWidth,
     height: "100%",
     borderRight: "1px solid",
     borderRightColor: theme.color.separators.default,
@@ -28,6 +31,16 @@ const Container = styled("div")(({ theme }) => {
   }
 })
 
-const Sidenav: React.SFC<SidenavProps> = ({ children, ...props }) => <Container {...props}>{children}</Container>
+const Sidenav: React.SFC<SidenavProps> = ({ children, ...props }) => (
+  <Container {...props}>
+    {React.Children.map(children, child => {
+      const iKnowWhatTypeMyChildIs = child as React.ReactElement<any>
+      return {
+        ...(iKnowWhatTypeMyChildIs as React.ReactElement<any>),
+        props: { ...iKnowWhatTypeMyChildIs.props, compact: props.compact },
+      }
+    })}
+  </Container>
+)
 
 export default Sidenav

--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -34,6 +34,7 @@ const Container = styled("div")<{ compact?: SidenavProps["compact"] }>(({ theme,
 const Sidenav: React.SFC<SidenavProps> = ({ children, ...props }) => (
   <Container {...props}>
     {React.Children.map(children, child => {
+      // see line 8
       const dudeMyChildIsAnElementJustLetMeUseItUgh = child as React.ReactElement<any>
       return {
         ...dudeMyChildIsAnElementJustLetMeUseItUgh,

--- a/src/Sidenav/__tests__/Sidenav.test.tsx
+++ b/src/Sidenav/__tests__/Sidenav.test.tsx
@@ -6,5 +6,11 @@ import wrapDefaultTheme from "../../utils/wrap-default-theme"
 const Sidenav = wrapDefaultTheme(ThemelessSidenav)
 
 test("Sidenav component renders", () => {
-  expect(shallow(<Sidenav />)).toMatchSnapshot()
+  expect(
+    shallow(
+      <Sidenav>
+        <div>hello</div>
+      </Sidenav>,
+    ),
+  ).toMatchSnapshot()
 })

--- a/src/Sidenav/__tests__/__snapshots__/Sidenav.test.tsx.snap
+++ b/src/Sidenav/__tests__/__snapshots__/Sidenav.test.tsx.snap
@@ -5,6 +5,10 @@ exports[`Sidenav component renders 1`] = `
   errorBoundary={true}
   theme={Object {}}
 >
-  <Sidenav />
+  <Sidenav>
+    <div>
+      hello
+    </div>
+  </Sidenav>
 </OperationalUI>
 `;

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -1,10 +1,11 @@
 import * as React from "react"
-import styled from "react-emotion"
 import Icon, { IconName } from "../Icon/Icon"
 import OperationalContext from "../OperationalContext/OperationalContext"
+import { SidenavProps } from "../Sidenav/Sidenav"
 import { SidenavItemProps } from "../SidenavItem/SidenavItem"
 import { DefaultProps } from "../types"
 import { floatIn, isModifiedEvent } from "../utils"
+import styled from "../utils/styled"
 
 export interface SidenavHeaderProps extends DefaultProps {
   /** Main label for the header */
@@ -32,43 +33,48 @@ export interface SidenavHeaderProps extends DefaultProps {
   /** Close handler (via chevron button on the top right) */
   onClose?: () => void
   children?: React.ReactNode
+  compact?: SidenavProps["compact"]
 }
 
-const Container = styled("div")(({ theme }) => ({
+const Container = styled("div")<{ compact: SidenavHeaderProps["compact"] }>(({ theme, compact }) => ({
   label: "sidenavheader",
   textDecoration: "none",
   width: "100%",
   position: "relative",
-  borderBottom: "1px solid",
+  borderBottom: compact ? 0 : "1px solid",
   borderBottomColor: theme.color.separators.default,
 }))
 
-const ContainerLink = styled("a")(({ theme }) => ({
+const ContainerLink = styled("a")<{ compact: SidenavHeaderProps["compact"] }>(({ theme, compact }) => ({
   label: "sidenavheader",
   textDecoration: "none",
   width: "100%",
   position: "relative",
-  borderBottom: "1px solid",
+  borderBottom: compact ? 0 : "1px solid",
   borderBottomColor: theme.color.separators.default,
 }))
 
-const Content = styled("div")<{ isCondensed: boolean }>(({ theme, isCondensed }) => ({
-  textDecoration: "none",
-  cursor: "pointer",
-  position: "relative",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  justifyContent: "center",
-  height: isCondensed ? 60 : 73,
-  overflow: "hidden",
-  padding: `0 ${theme.space.content}px`,
-  width: "100%",
-}))
+const Content = styled("div")<{ isCondensed: boolean; isActive: boolean; compact: SidenavHeaderProps["compact"] }>(
+  ({ theme, isCondensed, compact, isActive }) => ({
+    textDecoration: "none",
+    cursor: "pointer",
+    position: "relative",
+    display: compact ? "none" : "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    justifyContent: "center",
+    height: isCondensed ? 60 : 73,
+    overflow: "hidden",
+    padding: `0 ${theme.space.content}px`,
+    width: "100%",
+    marginBottom: isActive ? -26 : 0,
+  }),
+)
 
-const LabelText = styled("div")<{ isActive: boolean }>`
+const LabelText = styled("div")<{ isActive: boolean; compact: SidenavHeaderProps["compact"] }>`
   position: relative;
-  font-weight: 500;
+  display: flex;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
   letter-spacing: 0.25;
   text-transform: uppercase;
   white-space: nowrap;
@@ -83,8 +89,6 @@ const LabelText = styled("div")<{ isActive: boolean }>`
 const ItemsContainer = styled("div")({
   animation: `${floatIn} .15s forwards ease`,
   position: "relative",
-  top: -16,
-  marginTop: -10,
 })
 
 const CloseButton = styled("div")(({ theme }) => ({
@@ -107,17 +111,17 @@ const CloseButton = styled("div")(({ theme }) => ({
   },
 }))
 
-const Summary = styled("div")<{ isActive: boolean }>`
+const Summary = styled("div")<{ isActive: boolean; compact: SidenavHeaderProps["compact"] }>`
   display: block;
   font-weight: normal;
   text-transform: none;
   user-select: none;
   margin-top: 4px;
-  ${({ theme, isActive }) => `
+  ${({ theme, isActive, compact }) => `
     font-size: ${theme.font.size.fineprint}px;
     color: ${theme.color.text.lightest};
     left: ${theme.space.content}px;
-    visibility: ${isActive ? "hidden" : "visible"};
+    visibility: ${compact || isActive ? "hidden" : "visible"};
   `};
 `
 
@@ -128,8 +132,8 @@ const truncate = (maxLength: number) => (text: string) => {
   return text.slice(0, maxLength) + "..."
 }
 
-const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, ...props }) => {
-  const isActive = Boolean(active)
+const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, compact, ...props }) => {
+  const isActive = Boolean(active) || Boolean(compact)
 
   // The implementation of this component relies on the fact that it only has valid
   // `SidenavItem` components as children. The type casting here expresses that assumption.
@@ -147,6 +151,7 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, ..
         return (
           <ContainerComponent
             {...props}
+            compact={compact}
             href={href}
             onClick={(ev: React.SyntheticEvent<Node>) => {
               if (props.onClick) {
@@ -164,13 +169,18 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, ..
               }
             }}
           >
-            <Content onClick={props.onClick} isCondensed={Boolean(props.condensed)}>
-              <LabelText isActive={isActive}>
+            <Content
+              isActive={isActive}
+              compact={compact}
+              onClick={props.onClick}
+              isCondensed={Boolean(props.condensed)}
+            >
+              <LabelText compact={compact} isActive={isActive}>
                 {props.label}
                 {props.icon && <Icon name={props.icon as IconName} right />}
               </LabelText>
               {!props.condensed && (
-                <Summary isActive={isActive}>
+                <Summary compact={compact} isActive={isActive}>
                   {truncate(24)(childSidenavItems.map(child => child.props.label).join(", "))}
                 </Summary>
               )}
@@ -188,7 +198,14 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, ..
                 <Icon name={active ? "ChevronUp" : "ChevronDown"} />
               </CloseButton>
             )}
-            {isActive && <ItemsContainer>{props.children}</ItemsContainer>}
+            {isActive && (
+              <ItemsContainer>
+                {React.Children.map(props.children, child => {
+                  const typedChild = child as React.ReactElement<SidenavItemProps>
+                  return { ...typedChild, props: { ...typedChild.props, compact } }
+                })}
+              </ItemsContainer>
+            )}
           </ContainerComponent>
         )
       }}

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -1,4 +1,3 @@
-import { FunctionInterpolation, Themed } from "create-emotion-styled"
 import * as React from "react"
 
 import Icon, { IconName } from "../Icon/Icon"
@@ -7,7 +6,6 @@ import { SidenavProps } from "../Sidenav/Sidenav"
 import { SidenavItemProps } from "../SidenavItem/SidenavItem"
 import { DefaultProps } from "../types"
 import { floatIn, isModifiedEvent } from "../utils"
-import { OperationalStyleConstants } from "../utils/constants"
 import styled from "../utils/styled"
 
 export interface SidenavHeaderProps extends DefaultProps {
@@ -41,26 +39,19 @@ export interface SidenavHeaderProps extends DefaultProps {
   compact?: SidenavProps["compact"]
 }
 
-const makeContainerStyles: FunctionInterpolation<Themed<Partial<SidenavHeaderProps>, OperationalStyleConstants>> = ({
-  theme,
-  compact,
-  end,
-}) => ({
-  label: "sidenavheader",
-  textDecoration: "none",
-  width: "100%",
-  position: "relative",
-  borderBottom: compact ? 0 : "1px solid",
-  borderBottomColor: theme.color.separators.default,
-  marginTop: end ? "auto" : 0,
-  alignSelf: end ? "flex-end" : "flex-start",
-})
-
-const Container = styled("div")<{ compact: SidenavHeaderProps["compact"]; end: SidenavHeaderProps["end"] }>(
-  makeContainerStyles,
-)
-
-const ContainerLink = styled("a")<{ compact: SidenavHeaderProps["compact"] }>(makeContainerStyles)
+const makeContainer = (type: "link" | "block") =>
+  styled(type === "link" ? "a" : "div")<{ compact: SidenavHeaderProps["compact"]; end_: SidenavHeaderProps["end"] }>(
+    ({ theme, compact, end_ }) => ({
+      label: "sidenavheader",
+      textDecoration: "none",
+      width: "100%",
+      position: "relative",
+      borderBottom: compact ? 0 : "1px solid",
+      borderBottomColor: theme.color.separators.default,
+      marginTop: end_ ? "auto" : 0,
+      alignSelf: end_ ? "flex-end" : "flex-start",
+    }),
+  )
 
 const Content = styled("div")<{ isCondensed: boolean; isActive: boolean; compact: SidenavHeaderProps["compact"] }>(
   ({ theme, isCondensed, compact, isActive }) => ({
@@ -151,15 +142,15 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, co
 
   // Actual `to` prop should invalidate if the element has sublinks and is active
   const href = isActive && hasChildLinks ? undefined : to
-  const ContainerComponent = href ? ContainerLink : Container
+  const Container = href ? makeContainer("link") : makeContainer("block")
 
   return (
     <OperationalContext>
       {ctx => {
         return (
-          <ContainerComponent
+          <Container
             {...props}
-            end={end}
+            end_={end}
             compact={compact}
             href={href}
             onClick={(ev: React.SyntheticEvent<Node>) => {
@@ -215,7 +206,7 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, co
                 })}
               </ItemsContainer>
             )}
-          </ContainerComponent>
+          </Container>
         )
       }}
     </OperationalContext>

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -23,8 +23,6 @@ export interface SidenavHeaderProps extends DefaultProps {
   active?: boolean
   /** Callback called when the active state changes */
   onToggle?: (newActiveState: boolean) => void
-  /** Place this item at the bottom? */
-  end?: boolean
   /**
    * Expanded state
    *
@@ -40,18 +38,13 @@ export interface SidenavHeaderProps extends DefaultProps {
 }
 
 const makeContainer = (type: "link" | "block") =>
-  styled(type === "link" ? "a" : "div")<{ compact: SidenavHeaderProps["compact"]; end_: SidenavHeaderProps["end"] }>(
-    ({ theme, compact, end_ }) => ({
-      label: "sidenavheader",
-      textDecoration: "none",
-      width: "100%",
-      position: "relative",
-      borderBottom: compact ? 0 : "1px solid",
-      borderBottomColor: theme.color.separators.default,
-      marginTop: end_ ? "auto" : 0,
-      alignSelf: end_ ? "flex-end" : "flex-start",
-    }),
-  )
+  styled(type === "link" ? "a" : "div")<{ compact: SidenavHeaderProps["compact"] }>(({ theme, compact }) => ({
+    label: "sidenavheader",
+    textDecoration: "none",
+    width: "100%",
+    borderBottom: compact ? 0 : "1px solid",
+    borderBottomColor: theme.color.separators.default,
+  }))
 
 const Content = styled("div")<{ isCondensed: boolean; isActive: boolean; compact: SidenavHeaderProps["compact"] }>(
   ({ theme, isCondensed, compact, isActive }) => ({
@@ -131,7 +124,7 @@ const truncate = (maxLength: number) => (text: string) => {
   return text.slice(0, maxLength) + "..."
 }
 
-const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, compact, end, ...props }) => {
+const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, compact, ...props }) => {
   const isActive = Boolean(active) || Boolean(compact)
 
   // The implementation of this component relies on the fact that it only has valid
@@ -150,7 +143,6 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, co
         return (
           <Container
             {...props}
-            end_={end}
             compact={compact}
             href={href}
             onClick={(ev: React.SyntheticEvent<Node>) => {

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -1,10 +1,13 @@
+import { FunctionInterpolation, Themed } from "create-emotion-styled"
 import * as React from "react"
+
 import Icon, { IconName } from "../Icon/Icon"
 import OperationalContext from "../OperationalContext/OperationalContext"
 import { SidenavProps } from "../Sidenav/Sidenav"
 import { SidenavItemProps } from "../SidenavItem/SidenavItem"
 import { DefaultProps } from "../types"
 import { floatIn, isModifiedEvent } from "../utils"
+import { OperationalStyleConstants } from "../utils/constants"
 import styled from "../utils/styled"
 
 export interface SidenavHeaderProps extends DefaultProps {
@@ -22,6 +25,8 @@ export interface SidenavHeaderProps extends DefaultProps {
   active?: boolean
   /** Callback called when the active state changes */
   onToggle?: (newActiveState: boolean) => void
+  /** Place this item at the bottom? */
+  end?: boolean
   /**
    * Expanded state
    *
@@ -36,23 +41,26 @@ export interface SidenavHeaderProps extends DefaultProps {
   compact?: SidenavProps["compact"]
 }
 
-const Container = styled("div")<{ compact: SidenavHeaderProps["compact"] }>(({ theme, compact }) => ({
+const makeContainerStyles: FunctionInterpolation<Themed<Partial<SidenavHeaderProps>, OperationalStyleConstants>> = ({
+  theme,
+  compact,
+  end,
+}) => ({
   label: "sidenavheader",
   textDecoration: "none",
   width: "100%",
   position: "relative",
   borderBottom: compact ? 0 : "1px solid",
   borderBottomColor: theme.color.separators.default,
-}))
+  marginTop: end ? "auto" : 0,
+  alignSelf: end ? "flex-end" : "flex-start",
+})
 
-const ContainerLink = styled("a")<{ compact: SidenavHeaderProps["compact"] }>(({ theme, compact }) => ({
-  label: "sidenavheader",
-  textDecoration: "none",
-  width: "100%",
-  position: "relative",
-  borderBottom: compact ? 0 : "1px solid",
-  borderBottomColor: theme.color.separators.default,
-}))
+const Container = styled("div")<{ compact: SidenavHeaderProps["compact"]; end: SidenavHeaderProps["end"] }>(
+  makeContainerStyles,
+)
+
+const ContainerLink = styled("a")<{ compact: SidenavHeaderProps["compact"] }>(makeContainerStyles)
 
 const Content = styled("div")<{ isCondensed: boolean; isActive: boolean; compact: SidenavHeaderProps["compact"] }>(
   ({ theme, isCondensed, compact, isActive }) => ({
@@ -132,7 +140,7 @@ const truncate = (maxLength: number) => (text: string) => {
   return text.slice(0, maxLength) + "..."
 }
 
-const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, compact, ...props }) => {
+const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, compact, end, ...props }) => {
   const isActive = Boolean(active) || Boolean(compact)
 
   // The implementation of this component relies on the fact that it only has valid
@@ -151,6 +159,7 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, co
         return (
           <ContainerComponent
             {...props}
+            end={end}
             compact={compact}
             href={href}
             onClick={(ev: React.SyntheticEvent<Node>) => {

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -5,7 +5,7 @@ import OperationalContext from "../OperationalContext/OperationalContext"
 import { SidenavProps } from "../Sidenav/Sidenav"
 import { SidenavItemProps } from "../SidenavItem/SidenavItem"
 import { DefaultProps } from "../types"
-import { floatIn, isModifiedEvent } from "../utils"
+import { isModifiedEvent } from "../utils"
 import styled from "../utils/styled"
 
 export interface SidenavHeaderProps extends DefaultProps {
@@ -79,7 +79,8 @@ const LabelText = styled("div")<{ isActive: boolean; compact: SidenavHeaderProps
 `
 
 const ItemsContainer = styled("div")({
-  animation: `${floatIn} .15s forwards ease`,
+  /** @todo add this animation when we move to a JSON-style API for SidenavHeaders */
+  // animation: `${floatIn} .15s forwards ease`,
   position: "relative",
 })
 

--- a/src/SidenavItem/SidenavItem.tsx
+++ b/src/SidenavItem/SidenavItem.tsx
@@ -80,28 +80,30 @@ const IconContainer = styled("span")<{ compact: SidenavItemProps["compact"] }>((
   }
 })
 
-const Label = styled("span")<{ compact: SidenavHeaderProps["compact"] }>(({ compact, theme }) => {
-  return compact
-    ? {
-        marginTop: theme.space.medium,
-        padding: 0,
-        display: "block",
-        fontSize: 11,
-        fontWeight: theme.font.weight.medium,
-        lineHeight: 1.18,
-        color: theme.color.text.lighter,
-        textTransform: "uppercase",
-        width: "100%",
-        wordBreak: "break-all",
-        wordWrap: "break-word",
-        overflow: "hidden",
-        textAlign: "center",
-      }
-    : {
-        display: "inline-block",
-        paddingLeft: theme.space.base,
-      }
-})
+const Label = styled("span")<{ compact: SidenavHeaderProps["compact"]; hasIcon: boolean }>(
+  ({ compact, theme, hasIcon }) => {
+    return compact
+      ? {
+          marginTop: theme.space.medium,
+          padding: 0,
+          display: "block",
+          fontSize: 11,
+          fontWeight: theme.font.weight.medium,
+          lineHeight: 1.18,
+          color: theme.color.text.lighter,
+          textTransform: "uppercase",
+          width: "100%",
+          wordBreak: "break-all",
+          wordWrap: "break-word",
+          overflow: "hidden",
+          textAlign: "center",
+        }
+      : {
+          display: "inline-block",
+          paddingLeft: hasIcon ? theme.space.base : 0,
+        }
+  },
+)
 
 const SidenavItem: React.SFC<SidenavItemProps> = ({ to, active, icon, label, compact, shortLabel, ...props }) => {
   const ContainerComponent = to ? ContainerLink : Container
@@ -126,10 +128,14 @@ const SidenavItem: React.SFC<SidenavItemProps> = ({ to, active, icon, label, com
           }}
           isActive={isActive}
         >
-          <IconContainer compact={compact}>
-            {icon === String(icon) ? <Icon name={icon} size={getSize(compact)} /> : icon}
-          </IconContainer>
-          <Label compact={compact}>{compact ? shortLabel || label : label}</Label>
+          {icon && (
+            <IconContainer compact={compact}>
+              <Icon name={icon} size={getSize(compact)} />
+            </IconContainer>
+          )}
+          <Label hasIcon={Boolean(icon)} compact={compact}>
+            {compact ? shortLabel || label : label}
+          </Label>
         </ContainerComponent>
       )}
     </OperationalContext>

--- a/src/SidenavItem/SidenavItem.tsx
+++ b/src/SidenavItem/SidenavItem.tsx
@@ -16,7 +16,7 @@ export interface SidenavItemProps extends DefaultProps {
   /** Is it currently active? */
   active?: boolean
   /** An Icon for the menu item */
-  icon?: IconName | React.ReactNode
+  icon?: IconName
   /** A label for the item when the containing sidenav is full */
   label: string
   /** A label for the item when the containing sidenav is compact */
@@ -80,14 +80,9 @@ const IconContainer = styled("span")<{ compact: SidenavItemProps["compact"] }>((
   }
 })
 
-const Label = styled("span")<{ compact: SidenavHeaderProps["compact"] }>(
-  ({ theme }) => ({
-    display: "inline-block",
-    paddingLeft: theme.space.base,
-  }),
-  ({ compact, theme }) => {
-    if (compact) {
-      return {
+const Label = styled("span")<{ compact: SidenavHeaderProps["compact"] }>(({ compact, theme }) => {
+  return compact
+    ? {
         marginTop: theme.space.medium,
         padding: 0,
         display: "block",
@@ -102,9 +97,11 @@ const Label = styled("span")<{ compact: SidenavHeaderProps["compact"] }>(
         overflow: "hidden",
         textAlign: "center",
       }
-    }
-  },
-)
+    : {
+        display: "inline-block",
+        paddingLeft: theme.space.base,
+      }
+})
 
 const SidenavItem: React.SFC<SidenavItemProps> = ({ to, active, icon, label, compact, shortLabel, ...props }) => {
   const ContainerComponent = to ? ContainerLink : Container
@@ -130,7 +127,7 @@ const SidenavItem: React.SFC<SidenavItemProps> = ({ to, active, icon, label, com
           isActive={isActive}
         >
           <IconContainer compact={compact}>
-            {icon === String(icon) ? <Icon name={icon as IconName} size={getSize(compact)} /> : icon}
+            {icon === String(icon) ? <Icon name={icon} size={getSize(compact)} /> : icon}
           </IconContainer>
           <Label compact={compact}>{compact ? shortLabel || label : label}</Label>
         </ContainerComponent>

--- a/src/SidenavItem/SidenavItem.tsx
+++ b/src/SidenavItem/SidenavItem.tsx
@@ -20,7 +20,7 @@ export interface SidenavItemProps extends DefaultProps {
   /** A label for the item when the containing sidenav is compact */
   shortLabel?: string
   compact?: SidenavHeaderProps["compact"]
-  /** **Compact-mode only:** Should we place this at the bottom? */
+  /** Should we place this at the bottom of its sidenav? */
   end?: boolean
 }
 
@@ -32,7 +32,6 @@ const makeContainer = (type: "link" | "block") =>
     isActive: SidenavHeaderProps["active"]
     end_: boolean
   }>(({ theme, compact, isActive, end_ }) => {
-    const shouldPlaceAtBottom = Boolean(end_)
     return {
       display: "flex",
       padding: `${compact ? 10 : 0}px ${compact ? 0 : theme.space.content}px`,
@@ -48,9 +47,12 @@ const makeContainer = (type: "link" | "block") =>
       color: isActive ? theme.color.primary : theme.color.text.lightest,
       fontWeight: theme.font.weight.regular,
       boxShadow: isActive && compact ? `2px 0 0 inset ${theme.color.primary}` : "none",
-      marginTop: shouldPlaceAtBottom ? "auto" : 0,
-      alignSelf: shouldPlaceAtBottom ? "flex-end" : "flex-start",
-      ...(shouldPlaceAtBottom ? { "& + &": { marginTop: 0 } } : {}),
+      marginTop: end_ ? "auto" : 0,
+      alignSelf: end_ ? "flex-end" : "flex-start",
+
+      // This allows stacking of `end` SidenavItems.
+      ...(end_ ? { "& + &": { marginTop: 0 } } : {}),
+
       // Specificity is piled up here to override default styles
       "a:link&, a:visited&": {
         textDecoration: "none",
@@ -61,7 +63,7 @@ const makeContainer = (type: "link" | "block") =>
         color: isActive ? theme.color.primary : theme.color.text.dark,
       },
       "&:last-child": {
-        marginBottom: shouldPlaceAtBottom ? 0 : theme.space.content,
+        marginBottom: end_ ? 0 : theme.space.content,
       },
     }
   })

--- a/src/SidenavItem/SidenavItem.tsx
+++ b/src/SidenavItem/SidenavItem.tsx
@@ -18,7 +18,7 @@ export interface SidenavItemProps extends DefaultProps {
   /** A label for the item when the containing sidenav is full */
   label: string
   /** A label for the item when the containing sidenav is compact */
-  shortLabel?: string
+  compactLabel?: string
   compact?: SidenavHeaderProps["compact"]
   /** Should we place this at the bottom of its sidenav? */
   end?: boolean
@@ -106,7 +106,16 @@ const Label = styled("span")<{ compact: SidenavHeaderProps["compact"]; hasIcon: 
   },
 )
 
-const SidenavItem: React.SFC<SidenavItemProps> = ({ to, active, icon, label, compact, shortLabel, end, ...props }) => {
+const SidenavItem: React.SFC<SidenavItemProps> = ({
+  to,
+  active,
+  icon,
+  label,
+  compact,
+  compactLabel,
+  end,
+  ...props
+}) => {
   const Container = to ? makeContainer("link") : makeContainer("block")
   const isActive = Boolean(active)
   return (
@@ -136,7 +145,7 @@ const SidenavItem: React.SFC<SidenavItemProps> = ({ to, active, icon, label, com
             </IconContainer>
           )}
           <Label hasIcon={Boolean(icon)} compact={compact}>
-            {compact ? shortLabel || label : label}
+            {compact ? compactLabel || label : label}
           </Label>
         </Container>
       )}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -188,6 +188,7 @@ const constants = {
   color,
   shadows,
   borderRadius: 2,
+  compactSidebarWidth: 90,
   sidebarWidth: 256,
   titleHeight: 50,
   /**

--- a/styleguide/TableOfContentsRenderer.tsx
+++ b/styleguide/TableOfContentsRenderer.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Input, Sidenav, SidenavHeader } from "../src"
 
 export interface TableOfContentsRendererProps {
-  children: React.ReactNode | React.ReactNode[]
+  children: React.ReactElement<any>
   searchTerm: string
   onSearchTermChange: (newVal: string) => void
 }


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

# [Go Play](http://deploy-preview-677--operational-ui.netlify.com/#!/Sidenav).

This PR adds support for a more compact sidenav component and fixes #666.

To test, check out the example. The first example _isn't_ in compact mode. Add a `compact` prop to `Sidenav` in the first example, and things should _JustWork™_. **There is a deliberate edge case in there where no `shortLabel` is provided and text overflows**.

Per the issue, there is also an `end` prop that can be added to any `SidenavHeader`, and, if it has room, it will be positioned on the bottom. By convention, this prop can and should only be applied to the _last_ `SidenavHeader` (logically) in the tree.

There is a little divergence from the issue spec here. From my perspective, `SidenavHeader` should be pinable to the bottom and then take all its children. I don't think `<SidenavItem end` makes sense because it would be strange to have a `SidenavHeader` contain _n_ items with item _n_ being at the bottom, forcing a giant height on the header.

## Related issue
#666 
<!-- Paste the github issue here -->

## To be tested

Me
- [x] No error/warning in the console

Tester 1 (fafa)

- [x] The netlify build is working
- [x] Component looks as expected
- [x] Component works as specified in #666 
- [x] Adding a `compact` prop to a regular old `Sidenav` compacts it
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] The netlify build is working
- [ ] Component looks as expected
- [ ] Component works as specified in #666 
- [ ] Adding a `compact` prop to a regular old `Sidenav` compacts it
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
