### PR TITLE
Allow Page to show actions on the start or end of the title bar

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -66,13 +66,19 @@ const Container = styled("div")(({ theme }) => ({
   backgroundColor: theme.color.background.lighter,
 }))
 
-const TitleBar = styled("div")(({ theme }) => ({
+const TitleBar = styled("div")<{ actionsPosition: "start" | "end" }>(({ theme, actionsPosition }) => ({
   backgroundColor: theme.color.primary,
   display: "flex",
   alignItems: "center",
   padding: theme.space.element,
   height: theme.titleHeight,
   fontWeight: theme.font.weight.medium,
+  "& > :nth-child(n)": {
+    marginRight: theme.space.element,
+  },
+  "& > :nth-child(2)": {
+    order: actionsPosition === "start" ? -1 : undefined,
+  },
 }))
 
 const tabsBarHeight = 43
@@ -105,9 +111,7 @@ const ViewContainer = styled("div")<{ isInTab?: boolean }>(({ theme, isInTab }) 
   position: "relative",
 }))
 
-const EndContainer = styled("div")(({ theme }) => ({
-  marginLeft: theme.space.element,
-}))
+const ActionsContainer = styled("div")(() => ({}))
 
 const initialState = {
   activeTab: 0,
@@ -176,25 +180,14 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   }
 
   public render() {
-    const { title, actions, tabs, areas, activeTabName, onTabChange, fill, ...props } = this.props
+    const { title, actions, tabs, areas, activeTabName, onTabChange, fill, actionsPosition, ...props } = this.props
 
     return (
       <Container {...props}>
         {title && (
-          <TitleBar>
-            {props.actionsPosition === "end" ? (
-              <>
-                <Title color="white">{title}</Title>
-                <EndContainer>{actions}</EndContainer>
-              </>
-            ) : (
-              <>
-                {actions}
-                <EndContainer>
-                  <Title color="white">{title}</Title>
-                </EndContainer>
-              </>
-            )}
+          <TitleBar actionsPosition={actionsPosition || "end"}>
+            <Title color="white">{title}</Title>
+            <ActionsContainer>{actions}</ActionsContainer>
           </TitleBar>
         )}
         {tabs ? this.renderPageWithTabs() : this.renderPageWithoutTabs()}

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -14,6 +14,7 @@ export interface BaseProps extends DefaultProps {
   title?: string
   /** Page actions, typically `condensed button` component inside a fragment */
   actions?: React.ReactNode
+  actionsPosition?: "start" | "end"
 }
 
 export interface PropsWithSimplePage extends BaseProps {
@@ -104,7 +105,7 @@ const ViewContainer = styled("div")<{ isInTab?: boolean }>(({ theme, isInTab }) 
   position: "relative",
 }))
 
-const ActionsContainer = styled("div")(({ theme }) => ({
+const EndContainer = styled("div")(({ theme }) => ({
   marginLeft: theme.space.element,
 }))
 
@@ -116,6 +117,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   public static defaultProps = {
     areas: "main",
     fill: false,
+    actionsPosition: "end",
   }
 
   public readonly state = initialState
@@ -180,8 +182,19 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
       <Container {...props}>
         {title && (
           <TitleBar>
-            <Title color="white">{title}</Title>
-            <ActionsContainer>{actions}</ActionsContainer>
+            {props.actionsPosition === "end" ? (
+              <>
+                <Title color="white">{title}</Title>
+                <EndContainer>{actions}</EndContainer>
+              </>
+            ) : (
+              <>
+                {actions}
+                <EndContainer>
+                  <Title color="white">{title}</Title>
+                </EndContainer>
+              </>
+            )}
           </TitleBar>
         )}
         {tabs ? this.renderPageWithTabs() : this.renderPageWithoutTabs()}

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -54,6 +54,20 @@ const actions = (
 </Page>
 ```
 
+### With actions on the left
+
+```jsx
+/* Always use condensed buttons in page actions */
+const actions = (
+  <Button condensed icon="ExternalLink" color="ghost">
+    Go somewhere else
+  </Button>
+)
+;<Page title="Settings Page" actions={actions} actionsPosition="start">
+  <Card>Hello, this is page content</Card>
+</Page>
+```
+
 ### With tabs
 
 ```jsx


### PR DESCRIPTION
## Summary

Hi! Thought I'd jump right in with this PR...

Allows setting the position of actions as described in https://github.com/contiamo/operational-ui/issues/676.  This doesn't address the idea of having buttons with configurable icon positions; figured that was a separate change.

You do get a bit of extra spacing between elements when putting actions on the left; not sure if this is desired or not.

![image](https://user-images.githubusercontent.com/674511/44326044-5148f280-a40f-11e8-95d5-d0b21a295c43.png)

## Related issue

https://github.com/contiamo/operational-ui/issues/676

## To be tested

Me
- [x] No error/warning in the console

Tester 1

- [ ] The netlify build is working
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] The netlify build is working
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
