### PR TITLE
**Feature: ** Add condensedTitle option to Page component.

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -26,7 +26,7 @@ export interface PropsWithSimplePage extends BaseProps {
   tabs?: never
   activeTabName?: never
   onTabChange?: never
-  condensedTabs?: never
+  condensedTitle?: never
 }
 
 export interface PropsWithComplexPage extends BaseProps {
@@ -37,7 +37,7 @@ export interface PropsWithComplexPage extends BaseProps {
   tabs?: never
   activeTabName?: never
   onTabChange?: never
-  condensedTabs?: never
+  condensedTitle?: never
 }
 
 export interface PropsWithTabs extends BaseProps {
@@ -60,7 +60,7 @@ export interface PropsWithTabs extends BaseProps {
   areas?: never
   fill?: never
   /** Condensed option */
-  condensedTabs?: boolean
+  condensedTitle?: boolean
 }
 
 export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTabs
@@ -172,12 +172,12 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   private renderTabsBar() {
     const tabs = this.props.tabs!
     const activeTab = this.getActiveTab(tabs)
-    const { condensedTabs } = this.props
+    const { condensedTitle } = this.props
 
     return (
-      <TabsBar condensed={condensedTabs}>
+      <TabsBar condensed={condensedTitle}>
         {tabs.filter(({ hidden }) => !hidden).map(({ name }, i) => (
-          <Tab condensed={condensedTabs} key={i} active={i === activeTab} onClick={() => this.onTabClick(i, tabs)}>
+          <Tab condensed={condensedTitle} key={i} active={i === activeTab} onClick={() => this.onTabClick(i, tabs)}>
             {name}
           </Tab>
         ))}
@@ -189,7 +189,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
     const tabs = this.props.tabs!
     const activeTab = this.getActiveTab(tabs)
     const currentTabChildren = tabs[activeTab].children
-    const { title, actions, actionsPosition, condensedTabs } = this.props
+    const { title, actions, actionsPosition, condensedTitle } = this.props
 
     return (
       <>
@@ -197,10 +197,10 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
           <>
             <TitleBar actionPosition={actionsPosition}>
               <Title color="white">{title}</Title>
-              {condensedTabs && this.renderTabsBar()}
-              <ActionsContainer actionPosition={actionsPosition} condensed={condensedTabs}>{actions}</ActionsContainer>
+              {condensedTitle && this.renderTabsBar()}
+              <ActionsContainer actionPosition={actionsPosition} condensed={condensedTitle}>{actions}</ActionsContainer>
             </TitleBar>
-            {!condensedTabs && this.renderTabsBar()}
+            {!condensedTitle && this.renderTabsBar()}
           </>
         )}
         <ViewContainer isInTab>{currentTabChildren}</ViewContainer>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -80,9 +80,9 @@ const TitleBar = styled("div")<{ actionPosition: PageProps["actionsPosition"] }>
   fontWeight: theme.font.weight.medium,
   ...(actionPosition === "start"
     ? {
-      flexDirection: "row-reverse",
-      justifyContent: "flex-end",
-    }
+        flexDirection: "row-reverse",
+        justifyContent: "flex-end",
+      }
     : {}),
 }))
 
@@ -117,23 +117,16 @@ const ViewContainer = styled("div")<{ isInTab?: boolean }>(({ theme, isInTab }) 
   position: "relative",
 }))
 
-const ActionsContainer = styled("div")<{ actionPosition: PageProps["actionsPosition"], condensed?: boolean }>(
-  ({ theme, actionPosition, condensed }) => ({
+const ActionsContainer = styled("div")<{ actionPosition: PageProps["actionsPosition"] }>(
+  ({ theme, actionPosition }) => ({
     ...(actionPosition === "start"
       ? {
-        // Deal with the button margin (theme.space.small)
-        marginRight: theme.space.element - theme.space.small,
-      }
+          // Deal with the button margin (theme.space.small)
+          marginRight: theme.space.element - theme.space.small,
+        }
       : {
-        marginLeft: theme.space.element,
-      }),
-    ...(condensed
-      ? {
-        flexGrow: 1,
-        display: "flex",
-        justifyContent: "flex-end",
-      }
-      : {}),
+          marginLeft: theme.space.element,
+        }),
   }),
 )
 
@@ -198,7 +191,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
             <TitleBar actionPosition={actionsPosition}>
               <Title color="white">{title}</Title>
               {condensedTitle && this.renderTabsBar()}
-              <ActionsContainer actionPosition={actionsPosition} condensed={condensedTitle}>{actions}</ActionsContainer>
+              <ActionsContainer actionPosition={actionsPosition}>{actions}</ActionsContainer>
             </TitleBar>
             {!condensedTitle && this.renderTabsBar()}
           </>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -15,7 +15,7 @@ export interface BaseProps extends DefaultProps {
   /** Page actions, typically `condensed button` component inside a fragment */
   actions?: React.ReactNode
   /** Actions position */
-  actionsPosition?: "start" | "end"
+  actionsPosition?: "start" | "main" | "end"
 }
 
 export interface PropsWithSimplePage extends BaseProps {
@@ -71,19 +71,13 @@ const Container = styled("div")(({ theme }) => ({
   backgroundColor: theme.color.background.lighter,
 }))
 
-const TitleBar = styled("div")<{ actionPosition: PageProps["actionsPosition"] }>(({ theme, actionPosition }) => ({
+const TitleBar = styled("div")(({ theme }) => ({
   backgroundColor: theme.color.primary,
   display: "flex",
   alignItems: "center",
   padding: theme.space.element,
   height: theme.titleHeight,
   fontWeight: theme.font.weight.medium,
-  ...(actionPosition === "start"
-    ? {
-        flexDirection: "row-reverse",
-        justifyContent: "flex-end",
-      }
-    : {}),
 }))
 
 const tabsBarHeight = 43
@@ -121,12 +115,20 @@ const ActionsContainer = styled("div")<{ actionPosition: PageProps["actionsPosit
   ({ theme, actionPosition }) => ({
     ...(actionPosition === "start"
       ? {
+          order: -1,
           // Deal with the button margin (theme.space.small)
           marginRight: theme.space.element - theme.space.small,
         }
       : {
           marginLeft: theme.space.element,
         }),
+    ...(actionPosition === "end"
+      ? {
+          flexGrow: 1,
+          display: "flex",
+          justifyContent: "flex-end",
+        }
+      : {}),
   }),
 )
 
@@ -138,7 +140,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   public static defaultProps: Partial<PageProps> = {
     areas: "main",
     fill: false,
-    actionsPosition: "end",
+    actionsPosition: "main",
   }
 
   public readonly state = initialState
@@ -188,7 +190,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
       <>
         {title && (
           <>
-            <TitleBar actionPosition={actionsPosition}>
+            <TitleBar>
               <Title color="white">{title}</Title>
               {condensedTitle && this.renderTabsBar()}
               <ActionsContainer actionPosition={actionsPosition}>{actions}</ActionsContainer>
@@ -207,7 +209,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
     return (
       <>
         {title && (
-          <TitleBar actionPosition={actionsPosition}>
+          <TitleBar>
             <Title color="white">{title}</Title>
             <ActionsContainer actionPosition={actionsPosition}>{actions}</ActionsContainer>
           </TitleBar>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -194,13 +194,15 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
     return (
       <>
         {title && (
-          <TitleBar actionPosition={actionsPosition}>
-            <Title color="white">{title}</Title>
-            {condensedTabs && this.renderTabsBar()}
-            <ActionsContainer actionPosition={actionsPosition} condensed={condensedTabs}>{actions}</ActionsContainer>
-          </TitleBar>
+          <>
+            <TitleBar actionPosition={actionsPosition}>
+              <Title color="white">{title}</Title>
+              {condensedTabs && this.renderTabsBar()}
+              <ActionsContainer actionPosition={actionsPosition} condensed={condensedTabs}>{actions}</ActionsContainer>
+            </TitleBar>
+            {!condensedTabs && this.renderTabsBar()}
+          </>
         )}
-        {!condensedTabs && this.renderTabsBar()}
         <ViewContainer isInTab>{currentTabChildren}</ViewContainer>
       </>
     )

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -68,6 +68,20 @@ const actions = (
 </Page>
 ```
 
+### With actions on end
+
+```jsx
+/* Always use condensed buttons in page actions */
+const actions = (
+  <Button condensed icon="ExternalLink" color="ghost">
+    Go somewhere else
+  </Button>
+)
+;<Page title="Settings Page" actions={actions} actionsPosition="end">
+  <Card>Hello, this is page content</Card>
+</Page>
+```
+
 ### With tabs
 
 ```jsx
@@ -165,6 +179,78 @@ const actions = (
     { name: "sql", children: <Tab title="SQL" /> },
   ]}
   actions={actions}
+/>
+```
+
+### With condensed title bar and actions on start
+
+```jsx
+const Tab = props => (
+  <PageContent>
+    <Card title={props.title}>The tabs are not working because nothing update `activeTabName`!</Card>
+  </PageContent>
+)
+const options = [
+  { label: "Payroll", onClick: () => {} },
+  { label: "All Databases", onClick: () => {} },
+  { label: "Sales - Germany only", onClick: () => {} },
+  { label: "Sales - global", onClick: () => {} },
+  { label: "Reporting", onClick: () => {} },
+  { label: "Logistics", onClick: () => {} },
+]
+const actions = (
+  <HeaderMenu items={options} withCaret>
+    Sales / Foodmart
+  </HeaderMenu>
+)
+;<Page
+  title="Bundle detail"
+  condensedTitle
+  activeTabName="sql"
+  onTabChange={console.log}
+  tabs={[
+    { name: "olap", children: <Tab title="OLAP" /> },
+    { name: "entity", children: <Tab title="Entity" /> },
+    { name: "sql", children: <Tab title="SQL" /> },
+  ]}
+  actions={actions}
+  actionsPosition="start"
+/>
+```
+
+### With condensed title bar and actions on end
+
+```jsx
+const Tab = props => (
+  <PageContent>
+    <Card title={props.title}>The tabs are not working because nothing update `activeTabName`!</Card>
+  </PageContent>
+)
+const options = [
+  { label: "Payroll", onClick: () => {} },
+  { label: "All Databases", onClick: () => {} },
+  { label: "Sales - Germany only", onClick: () => {} },
+  { label: "Sales - global", onClick: () => {} },
+  { label: "Reporting", onClick: () => {} },
+  { label: "Logistics", onClick: () => {} },
+]
+const actions = (
+  <HeaderMenu items={options} withCaret>
+    Sales / Foodmart
+  </HeaderMenu>
+)
+;<Page
+  title="Bundle detail"
+  condensedTitle
+  activeTabName="sql"
+  onTabChange={console.log}
+  tabs={[
+    { name: "olap", children: <Tab title="OLAP" /> },
+    { name: "entity", children: <Tab title="Entity" /> },
+    { name: "sql", children: <Tab title="SQL" /> },
+  ]}
+  actions={actions}
+  actionsPosition="end"
 />
 ```
 

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -133,6 +133,41 @@ const Tab = props => (
 />
 ```
 
+### With condensed title bar
+
+```jsx
+const Tab = props => (
+  <PageContent>
+    <Card title={props.title}>The tabs are not working because nothing update `activeTabName`!</Card>
+  </PageContent>
+)
+const options = [
+  { label: "Payroll", onClick: () => {} },
+  { label: "All Databases", onClick: () => {} },
+  { label: "Sales - Germany only", onClick: () => {} },
+  { label: "Sales - global", onClick: () => {} },
+  { label: "Reporting", onClick: () => {} },
+  { label: "Logistics", onClick: () => {} },
+]
+const actions = (
+  <HeaderMenu items={options} withCaret>
+    Sales / Foodmart
+  </HeaderMenu>
+)
+;<Page
+  title="Bundle detail"
+  condensedTabs
+  activeTabName="sql"
+  onTabChange={console.log}
+  tabs={[
+    { name: "olap", children: <Tab title="OLAP" /> },
+    { name: "entity", children: <Tab title="Entity" /> },
+    { name: "sql", children: <Tab title="SQL" /> },
+  ]}
+  actions={actions}
+/>
+```
+
 ### With activeTabName controlled (classically with a router)
 
 ```jsx

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -156,7 +156,7 @@ const actions = (
 )
 ;<Page
   title="Bundle detail"
-  condensedTabs
+  condensedTitle
   activeTabName="sql"
   onTabChange={console.log}
   tabs={[


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

## Summary

<blockquote class="trello-card"><a href="https://trello.com/c/tfzDlrV0/377-condensed-page-title-with-tabs">Condensed page title with tabs</a></blockquote>

![image](https://user-images.githubusercontent.com/14272822/44395464-4048d000-a53a-11e8-93bf-6c3232fc31f0.png)

- Tabs moved to inside the title bar if `condensedTitle` is true

## Related issue

<!-- Paste the github issue here -->

## To be tested

Me
- [x] No error/warning in the console

Tester 1

- [x] The netlify build is working
- [x] Layout looks good
- [x] No existing examples are broken
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [x] The netlify build is working
- [x] Layout looks good
- [x] No existing examples are broken
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
