### PR TITLE
**Feature: ** Deterministic ordering for card items

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -10,6 +10,8 @@ export interface CardProps<T extends {} = {}> extends DefaultProps {
   keyFormatter?: (key: Extract<keyof T, string>) => string
   /** A key-value object to format values of `data`. */
   valueFormatters?: { [P in Extract<keyof T, string>]?: (value: T[P]) => React.ReactNode }
+  /** Sort method for keys. By default, they will be sorted alphabetically as regular JavaScript strings */
+  sortKeys?: (a: keyof T, b: keyof T) => number
   /** An ordered array to pick only some keys to display  */
   keys?: Array<Extract<keyof T, string>>
   /** Title of the card */
@@ -37,8 +39,8 @@ const Container = styled("div")(({ theme }) => ({
 const objectKeys = <T extends {}>(x: T) => Object.keys(x) as Array<keyof T>
 
 export default function Card<T extends {}>(props: CardProps<T>) {
-  const { title, keyFormatter, valueFormatters = {}, data, keys, children, action: Action, ...rest } = props
-  const _keys = keys ? keys : objectKeys(data || {})
+  const { title, keyFormatter, valueFormatters = {}, data, keys, sortKeys, children, action: Action, ...rest } = props
+  const _keys = (keys ? keys : objectKeys(data || {})).sort(sortKeys)
   const titles = keyFormatter ? _keys.map(keyFormatter) : _keys
   const values = _keys.map(i => {
     const valueFormatter = valueFormatters[i]


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

## Summary

If the `Card` component is used as a data card (`data` + `keyFormatters` + `valueFormatters`), the order in which the keys are rendered is unpredictable and not guaranteed to be the same in every browser. This PR adds a deterministic sort order (just as regular JS strings), and allows the sorting to be customizable with a `sortKeysWith` method, which works the same way as in vanilla JS sorting, e.g. `[1, 2, 3].sort((no1, no2) => no1 - no2)`.

Test by changing the first data card example to the following:
`<Card data={myData} title="Details" sortKeysWith={(key1, key2) => key1 > key2 ? -1 : 1} />`, which will reverse the order of the keys.

## To be tested

Me
- [x] No error/warning in the console
- [x] Keys are sorted alphabetically if no sort function is specified
- [x] Sort function works as expected in vanilla JS sorting

Tester 1

- [x] The netlify build is working
- [x] Keys are sorted alphabetically if no sort function is specified
- [x] Sort function works as expected in vanilla JS sorting

Tester 2

- [x] The netlify build is working
- [x] Keys are sorted alphabetically if no sort function is specified
- [x] Sort function works as expected in vanilla JS sorting
