### PR TITLE
Deprecate the explicit use of the CardHeader component

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { CardHeader, CardItem } from "../"
 import { DefaultProps } from "../types"
+import deprecate from "../utils/deprecate"
 import styled from "../utils/styled"
 
 export interface CardProps<T extends {} = {}> extends DefaultProps {
@@ -38,7 +39,7 @@ const Container = styled("div")(({ theme }) => ({
 
 const objectKeys = <T extends {}>(x: T) => Object.keys(x) as Array<keyof T>
 
-export default function Card<T extends {}>(props: CardProps<T>) {
+function Card<T extends {}>(props: CardProps<T>) {
   const { title, keyFormatter, valueFormatters = {}, data, keys, sortKeys, children, action: Action, ...rest } = props
   const _keys = (keys ? keys : objectKeys(data || {})).sort(sortKeys)
   const titles = keyFormatter ? _keys.map(keyFormatter) : _keys
@@ -56,3 +57,17 @@ export default function Card<T extends {}>(props: CardProps<T>) {
     </Container>
   )
 }
+
+const CardWithWarning = deprecate(props => {
+  const children = React.Children.toArray((props as any).children)
+  const hasCardHeader = children.some((child: any) => child.props && child.props.__isCardHeader)
+  if (hasCardHeader) {
+    return [
+      "<CardHeader/> components are deprecated - use the `title` and `action` props in `<Card/>` to achieve the same behavior.",
+    ]
+  }
+  return []
+})(Card)
+
+/** @component */
+export default CardWithWarning as typeof Card

--- a/src/CardHeader/CardHeader.tsx
+++ b/src/CardHeader/CardHeader.tsx
@@ -9,6 +9,7 @@ export interface CardHeaderProps extends DefaultProps {
   title?: React.ReactNode
   /** Action part (right side), this is typically where to put a button */
   action?: React.ReactNode
+  __isCardHeader?: boolean
 }
 
 const Container = styled("div")(({ theme }) => ({
@@ -58,5 +59,9 @@ const CardHeader: React.SFC<CardHeaderProps> = ({ title, children, action, ...pr
     <ActionsContainer>{action}</ActionsContainer>
   </Container>
 )
+
+CardHeader.defaultProps = {
+  __isCardHeader: true,
+}
 
 export default CardHeader


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

## Summary

This PR deprecates the direct use of the `CardHeader` component:

```
<Card>
  <CardHeader title="Title" action={<Button />}>
</Card>
```
in favor of simply writing
```
<Card title="Title" action={<Button />}>
```

This deprecation preps the breaking change in #675.

WIP: typings could use some improvements, which is proving to be challenging because of the rather complex interaction between `Card` and `deprecate` typings.

## To be tested

Me
- [x] No error/warning in the console
- [x] `Card` and `CardHeader` examples look the same
- [x] Using `CardHeader` directly throws a deprecation error

Tester 1

- [ ] The netlify build is working
- [ ] `Card` and `CardHeader` examples look the same
- [ ] Using `CardHeader` directly throws a deprecation error

Tester 2

- [ ] The netlify build is working
- [ ] `Card` and `CardHeader` examples look the same
- [ ] Using `CardHeader` directly throws a deprecation error
