### PR TITLE
Remove react-feather

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.4.1",
     "react-emotion": "^9.2.6",
-    "react-feather": "^1.1.1",
     "react-highlight": "^0.12.0",
     "react-waypoint": "^8.0.3",
     "tinycolor2": "^1.4.1"

--- a/src/Paginator/Paginator.tsx
+++ b/src/Paginator/Paginator.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
-import * as Icon from "react-feather"
+
 import Button from "../Button/Button"
+import Icon from "../Icon/Icon"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
@@ -104,7 +105,7 @@ const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page, o
         first
       </PaginatorControl>
       <PaginatorControl type="previous" {...controlProps} isDisabled={isFirstDisabled}>
-        <Icon.ChevronsLeft size="11" />
+        <Icon name="ChevronLeft" size={11} />
         <span>prev</span>
       </PaginatorControl>
       <PaginatorSpan key={page}>
@@ -112,7 +113,7 @@ const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page, o
       </PaginatorSpan>
       <PaginatorControl type="next" {...controlProps} isDisabled={isLastDisabled}>
         <span>next</span>
-        <Icon.ChevronsRight size="11" />
+        <Icon name="ChevronRight" size={11} />
       </PaginatorControl>
       <PaginatorControl type="last" {...controlProps} isDisabled={isLastDisabled}>
         last

--- a/src/Paginator/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/src/Paginator/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -19,21 +19,14 @@ exports[`Paginator Component Should initialize properly 1`] = `
       class="css-1tb3crw-button"
     >
       <svg
-        fill="none"
+        class="css-1uz51xv"
+        fill="currentColor"
         height="11"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
+        viewBox="0 0 360 360"
         width="11"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <polyline
-          points="11 17 6 12 11 7"
-        />
-        <polyline
-          points="18 17 13 12 18 7"
+        <path
+          d="M264.142,54.33l-125.858,125.858l125.858,125.857l-28.284,28.285l-154.142,-154.142l154.142,-154.143c9.428,9.428 18.856,18.857 28.284,28.285Z"
         />
       </svg>
       <span>
@@ -55,21 +48,14 @@ exports[`Paginator Component Should initialize properly 1`] = `
         next
       </span>
       <svg
-        fill="none"
+        class="css-1uz51xv"
+        fill="currentColor"
         height="11"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
+        viewBox="0 0 360 360"
         width="11"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <polyline
-          points="13 17 18 12 13 7"
-        />
-        <polyline
-          points="6 17 11 12 6 7"
+        <path
+          d="M278.284,180.187l-154.142,154.143l-28.284,-28.285l125.858,-125.858l-125.858,-125.857l28.284,-28.285c51.381,51.381 102.762,102.762 154.142,154.142Z"
         />
       </svg>
     </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6096,10 +6096,6 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
-react-feather@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-1.1.1.tgz#dd59143af457601e68f2cd3bf32c0d94d30f89e7"
-
 react-group@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-group/-/react-group-1.0.6.tgz#8dd7c00c3b35d05ce164021458bb07d580e3001a"


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

## Summary

Removing `react-feather` as a dependency, and use our own icons inside `Paginator`.

<img width="382" alt="screen shot 2018-08-22 at 12 05 54 pm" src="https://user-images.githubusercontent.com/6738398/44457532-bfeea180-a603-11e8-9ead-b62d515b82c9.png">

## To be tested

Me
- [x] No error/warning in the console
- [x] `Paginator` looks good and works as expected

Tester 1

- [x] The netlify build is working
- [x] `Paginator` looks good and works as expected

Tester 2

- [ ] The netlify build is working
- [ ] `Paginator` looks good and works as expected
