### PR TITLE
**Feature: ** Change actionsPosition options to start, main and end.

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -15,7 +15,7 @@ export interface BaseProps extends DefaultProps {
   /** Page actions, typically `condensed button` component inside a fragment */
   actions?: React.ReactNode
   /** Actions position */
-  actionsPosition?: "start" | "end"
+  actionsPosition?: "start" | "main" | "end"
 }
 
 export interface PropsWithSimplePage extends BaseProps {
@@ -71,19 +71,13 @@ const Container = styled("div")(({ theme }) => ({
   backgroundColor: theme.color.background.lighter,
 }))
 
-const TitleBar = styled("div")<{ actionPosition: PageProps["actionsPosition"] }>(({ theme, actionPosition }) => ({
+const TitleBar = styled("div")(({ theme }) => ({
   backgroundColor: theme.color.primary,
   display: "flex",
   alignItems: "center",
   padding: theme.space.element,
   height: theme.titleHeight,
   fontWeight: theme.font.weight.medium,
-  ...(actionPosition === "start"
-    ? {
-        flexDirection: "row-reverse",
-        justifyContent: "flex-end",
-      }
-    : {}),
 }))
 
 const tabsBarHeight = 43
@@ -121,12 +115,20 @@ const ActionsContainer = styled("div")<{ actionPosition: PageProps["actionsPosit
   ({ theme, actionPosition }) => ({
     ...(actionPosition === "start"
       ? {
+          order: -1,
           // Deal with the button margin (theme.space.small)
           marginRight: theme.space.element - theme.space.small,
         }
       : {
           marginLeft: theme.space.element,
         }),
+    ...(actionPosition === "end"
+      ? {
+          flexGrow: 1,
+          display: "flex",
+          justifyContent: "flex-end",
+        }
+      : {}),
   }),
 )
 
@@ -138,7 +140,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   public static defaultProps: Partial<PageProps> = {
     areas: "main",
     fill: false,
-    actionsPosition: "end",
+    actionsPosition: "main",
   }
 
   public readonly state = initialState
@@ -188,7 +190,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
       <>
         {title && (
           <>
-            <TitleBar actionPosition={actionsPosition}>
+            <TitleBar>
               <Title color="white">{title}</Title>
               {condensedTitle && this.renderTabsBar()}
               <ActionsContainer actionPosition={actionsPosition}>{actions}</ActionsContainer>
@@ -207,7 +209,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
     return (
       <>
         {title && (
-          <TitleBar actionPosition={actionsPosition}>
+          <TitleBar>
             <Title color="white">{title}</Title>
             <ActionsContainer actionPosition={actionsPosition}>{actions}</ActionsContainer>
           </TitleBar>

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -68,6 +68,20 @@ const actions = (
 </Page>
 ```
 
+### With actions on end
+
+```jsx
+/* Always use condensed buttons in page actions */
+const actions = (
+  <Button condensed icon="ExternalLink" color="ghost">
+    Go somewhere else
+  </Button>
+)
+;<Page title="Settings Page" actions={actions} actionsPosition="end">
+  <Card>Hello, this is page content</Card>
+</Page>
+```
+
 ### With tabs
 
 ```jsx
@@ -165,6 +179,78 @@ const actions = (
     { name: "sql", children: <Tab title="SQL" /> },
   ]}
   actions={actions}
+/>
+```
+
+### With condensed title bar and actions on start
+
+```jsx
+const Tab = props => (
+  <PageContent>
+    <Card title={props.title}>The tabs are not working because nothing update `activeTabName`!</Card>
+  </PageContent>
+)
+const options = [
+  { label: "Payroll", onClick: () => {} },
+  { label: "All Databases", onClick: () => {} },
+  { label: "Sales - Germany only", onClick: () => {} },
+  { label: "Sales - global", onClick: () => {} },
+  { label: "Reporting", onClick: () => {} },
+  { label: "Logistics", onClick: () => {} },
+]
+const actions = (
+  <HeaderMenu items={options} withCaret>
+    Sales / Foodmart
+  </HeaderMenu>
+)
+;<Page
+  title="Bundle detail"
+  condensedTitle
+  activeTabName="sql"
+  onTabChange={console.log}
+  tabs={[
+    { name: "olap", children: <Tab title="OLAP" /> },
+    { name: "entity", children: <Tab title="Entity" /> },
+    { name: "sql", children: <Tab title="SQL" /> },
+  ]}
+  actions={actions}
+  actionsPosition="start"
+/>
+```
+
+### With condensed title bar and actions on end
+
+```jsx
+const Tab = props => (
+  <PageContent>
+    <Card title={props.title}>The tabs are not working because nothing update `activeTabName`!</Card>
+  </PageContent>
+)
+const options = [
+  { label: "Payroll", onClick: () => {} },
+  { label: "All Databases", onClick: () => {} },
+  { label: "Sales - Germany only", onClick: () => {} },
+  { label: "Sales - global", onClick: () => {} },
+  { label: "Reporting", onClick: () => {} },
+  { label: "Logistics", onClick: () => {} },
+]
+const actions = (
+  <HeaderMenu items={options} withCaret>
+    Sales / Foodmart
+  </HeaderMenu>
+)
+;<Page
+  title="Bundle detail"
+  condensedTitle
+  activeTabName="sql"
+  onTabChange={console.log}
+  tabs={[
+    { name: "olap", children: <Tab title="OLAP" /> },
+    { name: "entity", children: <Tab title="Entity" /> },
+    { name: "sql", children: <Tab title="SQL" /> },
+  ]}
+  actions={actions}
+  actionsPosition="end"
 />
 ```
 


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking: ** or **Feature: ** -->

## Summary

`actionsPosition` can now take 3 values: "start", "main" and "end" (defaults to "main").
This makes it more compatible with the condensed title option. 

## Related issue

<!-- Paste the github issue here -->

## To be tested

Me
- [x] No error/warning in the console

Tester 1

- [x] The netlify build is working
- [x] Every action position works, regardless of whether title is condensed or not.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] The netlify build is working
- [ ] Every action position works, regardless of whether title is condensed or not.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
