### PR TITLE
**Breaking:** Remove tab name lowercasing in Page component

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -150,14 +150,14 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   private onTabClick(index: number, tabs: Tabs) {
     this.setState({ activeTab: index })
     if (this.props.onTabChange) {
-      this.props.onTabChange(tabs[index].name.toLowerCase())
+      this.props.onTabChange(tabs[index].name)
     }
   }
 
   private getActiveTab(tabs: Tabs): number {
     let activeTab: number
     if (this.props.activeTabName) {
-      const index = tabs.findIndex(({ name }) => name.toLowerCase() === this.props.activeTabName!.toLowerCase())
+      const index = tabs.findIndex(({ name }) => name === this.props.activeTabName)
       activeTab = index === -1 ? 0 : index
     } else {
       activeTab = this.state.activeTab


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking:** or **Feature:** -->

## Summary

This PR removes tab name lowercasing to make sure that tab name identifiers in `activeTabName`, `tabs[i].name` and `onTabChange(tabName => ...)` always match up. This fixes an issue when in the following markup:

```
initialState = {
  activeTabName: "Tab1"
}

<Page
  activeTabName={state.tabName}
  tabs={[
    {
      name: "Tab1",
      children: <div>Tab 1 content</div>
    },
    {
      name: "Tab2",
      children: <div>Tab 2 content</div>
    }
  ]}
  onTabChange={newTab => {
    setState(() => ({ activeTabName: newTab }))
  }
/>
```
the `newTab` variable will start assuming values "tab1" and "tab2", inconsistent with both the set tab names and the tab name in the initial state.

## Related issue

<!-- Paste the github issue here -->

## To be tested

Me
- [ ] No error/warning in the console
- [ ] No regressions on `Page` tabs

Tester 1

- [ ] The netlify build is working
- [ ] No regressions on `Page` tabs

Tester 2

- [x] The netlify build is working
- [x] No regressions on `Page` tabs
