### PR TITLE
**Fix:** Improve display of long words in `Tree` component

### DIFF
--- a/src/CardSection/CardSection.tsx
+++ b/src/CardSection/CardSection.tsx
@@ -12,6 +12,12 @@ export interface CardSectionProps extends DefaultProps, DragProps {
   disabled?: boolean
   /** Feedback during drag and drop interaction */
   dragAndDropFeedback?: DragAndDropFeedback
+  /**
+   * Disable horizontal padding. Useful for usage with e.g. the `Tree` component, which
+   * has visually weak and often hidden toggle button on the left, and would produce
+   * disproportionate horizontal space in small sections.
+   */
+  noHorizontalPadding?: boolean
   /** Actions */
   actions?: ContextMenuProps["items"]
   /** Action click handler */
@@ -72,10 +78,10 @@ const Overlay = styled("div")<{ overlayType: OverlayType }>`
   }};
 `
 
-const Content = styled("div")`
+const Content = styled("div")<{ noHorizontalPadding?: boolean }>`
   display: block;
-  ${({ theme }) => `
-    padding: ${theme.space.element}px;
+  ${({ theme, noHorizontalPadding }) => `
+    padding: ${noHorizontalPadding ? `${theme.space.element}px 0` : theme.space.element}px;
   `};
 `
 
@@ -119,6 +125,7 @@ const CardSection: React.SFC<CardSectionProps> = ({
   disabled,
   dragAndDropFeedback,
   actions,
+  noHorizontalPadding,
   onActionClick,
   ...props
 }) => (
@@ -130,7 +137,7 @@ const CardSection: React.SFC<CardSectionProps> = ({
         {actions && <StyledActionMenu items={actions} onClick={onActionClick} />}
       </Title>
     )}
-    <Content>{children}</Content>
+    <Content noHorizontalPadding={noHorizontalPadding}>{children}</Content>
   </Container>
 )
 

--- a/src/Internals/SmallNameTag.tsx
+++ b/src/Internals/SmallNameTag.tsx
@@ -40,6 +40,7 @@ const Container = styled("div")<{
     fontWeight: theme.font.weight.bold,
     width: 18,
     height: 18,
+    flexShrink: 0,
     borderRadius: theme.borderRadius,
     display: "inline-flex",
     alignItems: "center",

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -33,7 +33,7 @@ The tree component renders a tree structure with collapsable nodes in a filetree
       initiallyOpen: true,
       childNodes: [
         {
-          label: "LLC",
+          label: "Limited Liability Company",
           tag: "D",
           childNodes: [],
           draggable: true,

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -39,10 +39,9 @@ const TreeItem = styled("div")<{
 }>`
   display: flex;
   align-items: center;
-  padding: 4px 8px;
-  width: fit-content;
-  min-width: 160px;
+  max-width: 200px;
   ${({ theme, hasChildren, hasTag, isTopLevel, isDisabled, isRemovable }) => `
+    padding: ${theme.space.base}px;
     font-size: ${hasTag ? theme.font.size.fineprint : theme.font.size.small}px;
     font-weight: ${hasTag || isTopLevel ? theme.font.weight.bold : theme.font.weight.regular};
     font-family: ${hasTag ? theme.font.family.code : theme.font.family.main};
@@ -63,27 +62,40 @@ const TreeItem = styled("div")<{
       color: ${theme.color.text.lightest};
     }
     & > svg:first-child {
+      margin-right: ${theme.space.base}px;
+      flex-shrink: 0;
       visibility: ${hasChildren ? "visible" : "hidden"};
     }
   `};
 `
 
 const TreeLabel = styled("span")`
-  display: block;
+  display: inline-block;
+  word-wrap: break-word;
   flex: 1;
+  /**
+   * Explicit width assignment is required here because flex positioning works unpredictably with word-wrapping:
+   * in some cases, content to the right of the tree label is pushed past the width of the container
+   * rather than the word being broken. 
+   */
+  max-width: calc(100% - 70px);
 `
 
 /**
  * This is a single-use close button with hard-coded padding to ensure the close icon inside stays readable.
  * @todo look into re-using and formalizing this element.
  */
-const CloseButton = styled("div")`
+const IconButton = styled("div")<{ hidden_?: boolean }>`
   cursor: pointer;
   width: 20px;
   height: 20px;
-  padding: 4px;
-  ${({ theme }) => `border-radius: ${theme.borderRadius}px`};
-  :hover {
+  ${({ hidden_ }) => (hidden_ ? "visibility: hidden;" : "")} ${({ theme }) => `
+    border-radius: ${theme.borderRadius}px;
+    padding: ${theme.space.base}px;
+    :not(:last-child) {
+      margin-right: ${theme.space.base}px;
+    }
+  `} :hover {
     ${({ theme }) => `background-color: ${theme.color.background.light};`};
   }
 `
@@ -113,7 +125,9 @@ const TreeRecursive: React.SFC<{
           recursiveTogglePath(path)
         }}
       >
-        <Icon left name={isOpen ? "ChevronDown" : "Add"} size={12} />
+        <IconButton hidden_={childNodes.length === 0}>
+          <Icon name={isOpen ? "ChevronDown" : "Add"} size={12} />
+        </IconButton>
         {tree.tag && (
           <SmallNameTag color={tagColor} left>
             {tree.tag}
@@ -121,14 +135,14 @@ const TreeRecursive: React.SFC<{
         )}
         <TreeLabel>{tree.label}</TreeLabel>
         {onRemove && (
-          <CloseButton
+          <IconButton
             onClick={ev => {
               ev.stopPropagation()
               onRemove()
             }}
           >
             <Icon name="No" size={12} />
-          </CloseButton>
+          </IconButton>
         )}
       </TreeItem>
       {isOpen &&


### PR DESCRIPTION
<!-- IMPORTANT: If this is a breaking change or a backwards compatible feature, please prefix the title of this PR with **Breaking:** or **Feature:** -->

## Summary

This PR handles long words inside the Tree component

<img width="202" alt="screen shot 2018-08-27 at 12 35 59 pm" src="https://user-images.githubusercontent.com/6738398/44655774-a334de00-a9f6-11e8-815a-e8282ba3a758.png">

## To be tested

Me
- [x] No error/warning in the console on `localhost:6060`
- [x] Tree component works as expected
- [x] Long labels break over to the next line

Tester 1

- [ ] The netlify build is working
- [ ] Tree component works as expected
- [ ] Long labels break over to the next line

Tester 2

- [ ] The netlify build is working
- [ ] Tree component works as expected
- [ ] Long labels break over to the next line
