### PR TITLE
**Feature:** Add `onError` handler on operational-ui provider to allow external logs

### DIFF
--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -34,6 +34,11 @@ export interface OperationalUIProps {
    * Dangerous: Disable the error boundary if explicitly set to false
    */
   errorBoundary?: boolean
+
+  /**
+   * Custom error handler on `componentDidCatch`
+   */
+  onError?: (error: Error) => void
   /**
    * Custom theme
    */
@@ -161,6 +166,9 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
 
   public componentDidCatch(error: Error) {
     this.setState({ error })
+    if (this.props.onError) {
+      this.props.onError(error)
+    }
   }
 
   public componentDidMount() {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add `onError` options on `OperationalUI` to be able to connect the error boundary to external tools as sentry

https://docs.sentry.io/clients/javascript/integrations/react/?_ga=2.266374605.2127030996.1535699510-844189471.1535699510#expanded-usage


# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Nothing to report
- [x] This should works ^^

Tester 2

 - [ ] Nothing to report
 - [ ] This should works ^^
