### PR TITLE
**Feature:** Allow conditional rendering of Sidenav Header Items

### DIFF
--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-
 import Icon, { IconName } from "../Icon/Icon"
 import OperationalContext from "../OperationalContext/OperationalContext"
 import { SidenavProps } from "../Sidenav/Sidenav"
@@ -194,6 +193,10 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, co
             {isActive && (
               <ItemsContainer>
                 {React.Children.map(props.children, child => {
+                  if (!child) {
+                    return child
+                  }
+
                   const typedChild = child as React.ReactElement<SidenavItemProps>
                   return { ...typedChild, props: { ...typedChild.props, compact } }
                 })}

--- a/src/SidenavHeader/SidenavHeader.tsx
+++ b/src/SidenavHeader/SidenavHeader.tsx
@@ -193,6 +193,12 @@ const SidenavHeader: React.SFC<SidenavHeaderProps> = ({ onToggle, active, to, co
             {isActive && (
               <ItemsContainer>
                 {React.Children.map(props.children, child => {
+                  /**
+                   * If a child manages to get here but does not exist
+                   * it will have a value of `null` or `false`, then we
+                   * should not attempt to extend it but rather forward it on
+                   * as is.
+                   */
                   if (!child) {
                     return child
                   }


### PR DESCRIPTION
Check existance of children before rendering Sidenav Header

Closes #703

# Summary

Allow conditional rendering of Sidenav Items
![kapture 2018-09-04 at 7 37 17](https://user-images.githubusercontent.com/6516758/45029056-692a9400-b015-11e8-9a9a-08263dda63a7.gif)


<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->

# Related issue

#703 

# To be tested
From the PR build:
![screen shot 2018-09-04 at 7 44 06 am](https://user-images.githubusercontent.com/6516758/45029352-5e243380-b016-11e8-889a-2ccc419e804e.png)

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
