### PR TITLE
**Feature:** Add cmd+enter submit to text area

### DIFF
--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -1,15 +1,9 @@
-/**
- * Having React typings in scope is necessary for styled components not using React directly, otherwise
- * botched module names like `import("eac")` show up in the .d.ts files due to a typescript compiler error.
- * See issue: https://github.com/emotion-js/emotion/issues/788
- * @todo remove this as soon as the issue is fixed.
- */
-// @ts-ignore
 import * as React from "react"
 
+import { isCmdEnter } from "../utils"
 import styled from "../utils/styled"
 
-export const Form = styled("form")(({ theme }) => ({
+const Container = styled("form")(({ theme }) => ({
   // Space between groups
   "> :not(:last-child)": {
     marginBottom: 34 - theme.space.small,
@@ -21,5 +15,21 @@ export const Form = styled("form")(({ theme }) => ({
     marginBottom: theme.space.small,
   },
 }))
+
+/**
+ * The `any` type variable is required to allow the `isCmdEnter` method
+ * to be re-used across different node types (both `HTMLFormElement` and `HTMLElement`
+ * cause issues here).
+ */
+const Form: React.SFC = (props: React.HTMLProps<any>) => (
+  <Container
+    {...props}
+    onKeyDown={(ev: React.KeyboardEvent<any>) => {
+      if (isCmdEnter(ev) && props.onSubmit) {
+        props.onSubmit(ev)
+      }
+    }}
+  />
+)
 
 export default Form

--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -48,14 +48,14 @@ Text areas detect a `cmd+enter` submit through an `onSubmit` prop, like so:
 ```jsx
 initialState = {
   value: "Type something",
-  isSubmitted: false,
+  submittedValue: undefined,
 }
 ;<>
   <Textarea
     value={state.value}
     onChange={newValue => setState(() => ({ value: newValue }))}
-    onSubmit={() => setState(() => ({ isSubmitted: true }))}
+    onSubmit={() => setState(prevState => ({ submittedValue: prevState.value }))}
   />
-  {state.isSubmitted ? <p>Submitted: {state.value}</p> : <p>Submit by hitting cmd+enter</p>}
+  {state.submittedValue ? <p>Submitted: {state.submittedValue}</p> : <p>Submit by hitting cmd+enter</p>}
 </>
 ```

--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -1,51 +1,61 @@
 A textarea field, with optional label, hint and error.
 
+### Simple usage
+
+The following snippet show the text area with various visual additions handling fixed heights, errors and hints.
+
 ```jsx
-class MyForm extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      v1: "",
-      v2: "",
-      v3: "",
-      v4: "",
-      v5: "",
-      v6: "",
-      v7: "",
-      v8: "",
-    }
-    this.handleChange = key => value => {
-      this.setState({ [key]: value })
-    }
-  }
-
-  render() {
-    const { v1, v2, v3, v4, v5, v6, v7, v8 } = this.state
-
-    return (
-      <Form>
-        <Textarea value={v1} onChange={this.handleChange("v1")} label="simple" />
-        <Textarea copy value={v2} onChange={this.handleChange("v2")} label="with copying" />
-        <Textarea
-          value={v3}
-          onChange={this.handleChange("v3")}
-          label="with actions"
-          action={
-            <div>
-              <Icon size={8} name="Open" />
-              <a href="#textarea">More information</a>
-            </div>
-          }
-        />
-        <Textarea value={v4} onChange={this.handleChange("v4")} label="with error" error="oh no!" />
-        <Textarea value={v5} onChange={this.handleChange("v5")} label="with hint" hint="this is a hint" />
-        <Textarea value={v6} onChange={this.handleChange("v6")} label="disabled" disabled />
-        <Textarea value={v7} onChange={this.handleChange("v7")} label="a code" code />
-        <Textarea value={v8} onChange={this.handleChange("v7")} label="fixed height" height={200} />
-      </Form>
-    )
-  }
+initialState = {
+  v1: "",
+  v2: "",
+  v3: "",
+  v4: "",
+  v5: "",
+  v6: "",
+  v7: "",
+  v8: "",
 }
 
-;<MyForm />
+const handleChange = key => value => {
+  setState(() => ({ [key]: value }))
+}
+;<Form>
+  <Textarea value={state.v1} onChange={handleChange("v1")} label="simple" />
+  <Textarea copy value={state.v2} onChange={handleChange("v2")} label="with copying" />
+  <Textarea
+    value={state.v3}
+    onChange={handleChange("v3")}
+    label="with actions"
+    action={
+      <div>
+        <Icon size={8} name="Open" />
+        <a href="#textarea">More information</a>
+      </div>
+    }
+  />
+  <Textarea value={state.v4} onChange={handleChange("v4")} label="with error" error="oh no!" />
+  <Textarea value={state.v5} onChange={handleChange("v5")} label="with hint" hint="this is a hint" />
+  <Textarea value={state.v6} onChange={handleChange("v6")} label="disabled" disabled />
+  <Textarea value={state.v7} onChange={handleChange("v7")} label="a code" code />
+  <Textarea value={state.v8} onChange={handleChange("v8")} label="fixed height" height={200} />
+</Form>
+```
+
+### Submitting
+
+Text areas detect a `cmd+enter` submit through an `onSubmit` prop, like so:
+
+```jsx
+initialState = {
+  value: "Type something",
+  isSubmitted: false,
+}
+;<>
+  <Textarea
+    value={state.value}
+    onChange={newValue => setState(() => ({ value: newValue }))}
+    onSubmit={() => setState(() => ({ isSubmitted: true }))}
+  />
+  {state.isSubmitted ? <p>Submitted: {state.value}</p> : <p>Submit by hitting cmd+enter</p>}
+</>
 ```

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -35,6 +35,8 @@ export interface TextareaProps extends DefaultProps {
   resize?: ResizeOptions
   /** Copy text to clipboard on click */
   copy?: boolean
+  /** cmd+enter submit handler */
+  onSubmit?: () => void
 }
 
 export interface State {
@@ -144,6 +146,7 @@ class Textarea extends React.Component<TextareaProps, State> {
       height,
       copy,
       onChange,
+      onSubmit,
       ...props
     } = this.props
     return (
@@ -162,6 +165,14 @@ class Textarea extends React.Component<TextareaProps, State> {
           isAction={Boolean(action || copy)}
           resize={resize!}
           height={height}
+          onKeyDown={(ev: React.KeyboardEvent<HTMLTextAreaElement>) => {
+            const crossBrowserSafeKeycode = ev.which || ev.keyCode
+            const modifierKey = ev.ctrlKey || ev.metaKey
+            const isCmdPlusEnter = crossBrowserSafeKeycode === 13 && modifierKey
+            if (isCmdPlusEnter && onSubmit) {
+              onSubmit()
+            }
+          }}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             if (!onChange) {
               return

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 import { DefaultProps } from "../types"
+import { isCmdEnter } from "../utils"
 import styled from "../utils/styled"
 
 import Hint from "../Hint/Hint"
@@ -166,10 +167,7 @@ class Textarea extends React.Component<TextareaProps, State> {
           resize={resize!}
           height={height}
           onKeyDown={(ev: React.KeyboardEvent<HTMLTextAreaElement>) => {
-            const crossBrowserSafeKeycode = ev.which || ev.keyCode
-            const modifierKey = ev.ctrlKey || ev.metaKey
-            const isCmdPlusEnter = crossBrowserSafeKeycode === 13 && modifierKey
-            if (isCmdPlusEnter && onSubmit) {
+            if (isCmdEnter(ev) && onSubmit) {
               onSubmit()
             }
           }}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,15 @@ export const isModifiedEvent = (event: any) => !!(event.metaKey || event.altKey 
 export const isOutsideLink = (url: string) => urlRegex({ exact: true }).test(url)
 
 /**
+ * Detect if a key event originated from a cmd+enter
+ */
+export const isCmdEnter = (ev: React.KeyboardEvent<HTMLElement>) => {
+  const crossBrowserSafeKeycode = ev.which || ev.keyCode
+  const modifierKey = ev.ctrlKey || ev.metaKey
+  return crossBrowserSafeKeycode === 13 && modifierKey
+}
+
+/**
  * Return the initials in 2 letters from a full name.
  *
  * @param name


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Text areas will now call a handler provided to their `onSubmit` prop when cmd+enter is pressed inside.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] Textarea component reacts to cmd+enter on Chrome, Safari and Firefox
- [x] No regressions on Textarea

Tester 1

- [x] Netlify looks good
- [x] Textarea component reacts to cmd+enter in my own environment
- [x] No regressions on Textarea

Tester 2

- [ ] No error or warning in the console on `localhost:6060`
- [ ] Textarea component reacts to cmd+enter in my own environment
- [ ] No regressions on Textarea
