### PR TITLE
**Fix:** Add correct type annotation to Form

### DIFF
--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -21,7 +21,7 @@ const Container = styled("form")(({ theme }) => ({
  * to be re-used across different node types (both `HTMLFormElement` and `HTMLElement`
  * cause issues here).
  */
-const Form: React.SFC = (props: React.HTMLProps<any>) => (
+const Form: React.SFC<typeof Container> = (props: React.HTMLProps<any>) => (
   <Container
     {...props}
     onKeyDown={(ev: React.KeyboardEvent<any>) => {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR fixes a regression in #736 that breaks the `Form` component's public interface.

## Regression
![image](https://user-images.githubusercontent.com/9947422/45518035-6e9e8180-b76d-11e8-92e1-fcbbb506636e.png)

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
- [ ] An app that uses `Form` from `@operational/components@canary` compiles.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->
