### PR TITLE
**Fix:** tree component padding

### DIFF
--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -27,7 +27,7 @@ const TreeContainer = styled("div")`
 `
 
 const TreeChildren = styled("div")`
-  margin-left: 28px;
+  margin-left: 16px;
 `
 
 const TreeItem = styled("div")<{


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Reduces the padding on the tree component to the following:

<img width="188" alt="screen shot 2018-09-17 at 3 45 36 pm" src="https://user-images.githubusercontent.com/6738398/45627055-50989000-ba91-11e8-8500-e9c436775dea.png">

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] Tree component looks good

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
