### PR TITLE
**Feature:** LabelText Block Level El

### DIFF
--- a/src/utils/mixins.ts
+++ b/src/utils/mixins.ts
@@ -25,7 +25,7 @@ export const inputFocus = ({ theme, isError }: { theme: OperationalStyleConstant
 })
 
 export const Label = styled("label")<{ fullWidth?: boolean; left?: boolean }>(({ fullWidth, theme, left }) => ({
-  display: "block",
+  display: "inline-block",
   position: "relative",
   width: "100%",
   maxWidth: fullWidth ? "none" : "360px",
@@ -36,7 +36,7 @@ export const labelTextHeight = 15
 
 export const LabelText = styled("span")(({ theme }) => ({
   fontSize: theme.font.size.fineprint,
-  display: "inline-block",
+  display: "block",
   verticalAlign: "middle",
   marginBottom: theme.space.base,
   fontWeight: theme.font.weight.bold,

--- a/src/utils/mixins.ts
+++ b/src/utils/mixins.ts
@@ -25,7 +25,7 @@ export const inputFocus = ({ theme, isError }: { theme: OperationalStyleConstant
 })
 
 export const Label = styled("label")<{ fullWidth?: boolean; left?: boolean }>(({ fullWidth, theme, left }) => ({
-  display: "inline-block",
+  display: "block",
   position: "relative",
   width: "100%",
   maxWidth: fullWidth ? "none" : "360px",


### PR DESCRIPTION
# Summary

Changed `LabelText` from `inline-block` to `block`

https://github.com/adeelibr/operational-ui/blob/d711e8fd55a03afcc5c886711f7bd88affdbda1a/src/utils/mixins.ts#L39

For issue https://github.com/contiamo/operational-ui/issues/727#issuecomment-423629252

# Related issue
https://github.com/contiamo/operational-ui/issues/727#issuecomment-423629252

Me
- [x] No error or warning in the console on `localhost:6060`

Fabien
- [x] Things look good on the demo.
