### PR TITLE
**Feature:** Add Autocomplete component

### DIFF
--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -12,6 +12,10 @@ export interface AutocompleteProps<TValue> {
    */
   label?: string
   /**
+   * An Icon to append to each result
+   */
+  resultIcon?: Item["icon"]
+  /**
    * Should the input fill its container?
    */
   fullWidth?: boolean
@@ -57,7 +61,7 @@ const initialState = {
 type AutocompleteState = Readonly<typeof initialState>
 
 const Container = styled(ContextMenu)<Partial<AutocompleteProps<any>>>`
-  width: ${({ fullWidth }) => (fullWidth ? "100%" : "initial")};
+  width: ${({ fullWidth }) => (fullWidth ? "100%" : "fit-content")};
   display: flex;
   align-items: center;
 `
@@ -66,6 +70,7 @@ function makeItems<TValue>({
   searchValue,
   minCharacters,
   results,
+  resultIcon,
   noResultsMessage,
 }: Partial<AutocompleteProps<TValue> & AutocompleteState>) {
   if (!searchValue || !(searchValue.length > (minCharacters || 0))) {
@@ -73,7 +78,9 @@ function makeItems<TValue>({
   }
 
   if (results && results.length) {
-    return results
+    return results.map(
+      result => (typeof result === "string" ? { label: result, icon: resultIcon } : { ...result, icon: resultIcon }),
+    )
   }
 
   if (!results || !results.length) {
@@ -95,13 +102,27 @@ class Autocomplete<TValue> extends React.Component<AutocompleteProps<TValue>, Au
   }
 
   public render() {
-    const { fullWidth, label, results, minCharacters, loading, noResultsMessage, onChange, onResultClick } = this.props
+    const {
+      fullWidth,
+      label,
+      results,
+      resultIcon,
+      minCharacters,
+      loading,
+      noResultsMessage,
+      onChange,
+      onResultClick,
+    } = this.props
     const { searchValue } = this.state
     return (
-      <Container items={makeItems({ results, searchValue, minCharacters, noResultsMessage })} onClick={onResultClick}>
+      <Container
+        fullWidth={fullWidth}
+        items={makeItems({ results, searchValue, resultIcon, minCharacters, noResultsMessage })}
+        onClick={item => (item && typeof item === "string" ? onResultClick(item) : onResultClick((item as Item).label))}
+      >
         <Input
           icon={loading ? <Spinner /> : "Search"}
-          fullWidth={fullWidth}
+          fullWidth={true}
           value={searchValue}
           onChange={onChange}
           label={label}

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 
-import ContextMenu, { Item } from "../ContextMenu/ContextMenu"
+import ContextMenu from "../ContextMenu/ContextMenu"
+import { IContextMenuItem, IContextMenuItem as Item } from "../ContextMenu/ContextMenu.Item"
 import Input from "../Input/Input"
-import Spinner from "../Spinner/Spinner"
+import Progress from "../Progress/Progress"
 import styled from "../utils/styled"
 
 export interface AutocompleteProps<TValue> {
@@ -79,7 +80,10 @@ function makeItems<TValue>({
 
   if (results && results.length) {
     return results.map(
-      result => (typeof result === "string" ? { label: result, icon: resultIcon } : { ...result, icon: resultIcon }),
+      (result: string | IContextMenuItem) =>
+        typeof result === "string"
+          ? { label: result, icon: resultIcon } // typescript is so weird
+          : { ...result, icon: resultIcon },
     )
   }
 
@@ -113,20 +117,18 @@ class Autocomplete<TValue> extends React.Component<AutocompleteProps<TValue>, Au
       onChange,
       onResultClick,
     } = this.props
+
     const { searchValue } = this.state
+
     return (
       <Container
+        iconLocation="right"
         fullWidth={fullWidth}
         items={makeItems({ results, searchValue, resultIcon, minCharacters, noResultsMessage })}
         onClick={item => (item && typeof item === "string" ? onResultClick(item) : onResultClick((item as Item).label))}
       >
-        <Input
-          icon={loading ? <Spinner /> : "Search"}
-          fullWidth={true}
-          value={searchValue}
-          onChange={onChange}
-          label={label}
-        />
+        {loading && <Progress bottom />}
+        <Input fullWidth={true} value={searchValue} onChange={onChange} label={label} />
       </Container>
     )
   }

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -64,9 +64,7 @@ function makeItems<TValue>({ value, results, resultIcon, noResultsMessage }: Par
   if (results && results.length) {
     return results.map(
       (result: string | IContextMenuItem) =>
-        typeof result === "string"
-          ? { label: result, icon: resultIcon } // typescript is so weird
-          : { ...result, icon: resultIcon },
+        typeof result === "string" ? { label: result, icon: resultIcon } : { ...result, icon: resultIcon },
     )
   }
 

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -87,11 +87,7 @@ function makeItems<TValue>({
     )
   }
 
-  if (!results || !results.length) {
-    return [noResultsMessage || ""]
-  }
-
-  return []
+  return [noResultsMessage || ""]
 }
 
 class Autocomplete<TValue> extends React.Component<AutocompleteProps<TValue>, AutocompleteState> {

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import ContextMenu, { Item } from "../ContextMenu/ContextMenu"
+import Input from "../Input/Input"
+import Spinner from "../Spinner/Spinner"
+import styled from "../utils/styled"
+
+export interface AutocompleteProps<TValue> {
+  /**
+   * Label text, rendering the input inside a tag if specified.
+   * The `labelId` props is responsible for specifying for and id attributes.
+   */
+  label?: string
+  /**
+   * Should the input fill its container?
+   */
+  fullWidth?: boolean
+  /**
+   * The current value of the input field.
+   * You must always supply this from the parent component, as per https://facebook.github.io/react/docs/forms.html#controlled-components.
+   */
+  value: { label: string; value?: TValue }
+  /**
+   * A search can show a loading indicator.
+   */
+  loading?: boolean
+  /**
+   * Message to display when there are no results.
+   */
+  noResultsMessage?: string | Item
+  /**
+   * Called when a result is selected.
+   */
+  onResultClick: (item?: string | Item) => void
+  /**
+   * Called on search input change.
+   */
+  onChange: (search: string) => void
+  /**
+   * Search results
+   */
+  results?: Array<{ label: string; value: TValue }>
+  /**
+   * Minimum characters to query for results.
+   */
+  minCharacters?: number
+}
+
+const initialState = {
+  /**
+   * `true` if the dropdown result is open
+   */
+  isOpen: false,
+  searchValue: "",
+}
+
+type AutocompleteState = Readonly<typeof initialState>
+
+const Container = styled(ContextMenu)<Partial<AutocompleteProps<any>>>`
+  width: ${({ fullWidth }) => (fullWidth ? "100%" : "initial")};
+  display: flex;
+  align-items: center;
+`
+
+function makeItems<TValue>({
+  searchValue,
+  minCharacters,
+  results,
+  noResultsMessage,
+}: Partial<AutocompleteProps<TValue> & AutocompleteState>) {
+  if (!searchValue || !(searchValue.length > (minCharacters || 0))) {
+    return []
+  }
+
+  if (results && results.length) {
+    return results
+  }
+
+  if (!results || !results.length) {
+    return [noResultsMessage || ""]
+  }
+
+  return []
+}
+
+class Autocomplete<TValue> extends React.Component<AutocompleteProps<TValue>, AutocompleteState> {
+  public readonly state = initialState
+
+  public static defaultProps = {
+    minCharacters: 3,
+  }
+
+  public static getDerivedStateFromProps(props: AutocompleteProps<any>) {
+    return { searchValue: props.value }
+  }
+
+  public render() {
+    const { fullWidth, label, results, minCharacters, loading, noResultsMessage, onChange, onResultClick } = this.props
+    const { searchValue } = this.state
+    return (
+      <Container items={makeItems({ results, searchValue, minCharacters, noResultsMessage })} onClick={onResultClick}>
+        <Input
+          icon={loading ? <Spinner /> : "Search"}
+          fullWidth={fullWidth}
+          value={searchValue}
+          onChange={onChange}
+          label={label}
+        />
+      </Container>
+    )
+  }
+}
+
+export default Autocomplete

--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import ContextMenu from "../ContextMenu/ContextMenu"
 import { IContextMenuItem, IContextMenuItem as Item } from "../ContextMenu/ContextMenu.Item"
-import Input from "../Input/Input"
+import Input, { InputProps } from "../Input/Input"
 import Progress from "../Progress/Progress"
 import styled from "../utils/styled"
 
@@ -17,14 +17,13 @@ export interface AutocompleteProps<TValue> {
    */
   resultIcon?: Item["icon"]
   /**
+   * A hint to the user.
+   */
+  hint?: InputProps["hint"]
+  /**
    * Should the input fill its container?
    */
   fullWidth?: boolean
-  /**
-   * The current value of the input field.
-   * You must always supply this from the parent component, as per https://facebook.github.io/react/docs/forms.html#controlled-components.
-   */
-  value: { label: string; value?: TValue }
   /**
    * A search can show a loading indicator.
    */
@@ -46,20 +45,10 @@ export interface AutocompleteProps<TValue> {
    */
   results?: Array<{ label: string; value: TValue }>
   /**
-   * Minimum characters to query for results.
+   * The value of the Search
    */
-  minCharacters?: number
+  value: ""
 }
-
-const initialState = {
-  /**
-   * `true` if the dropdown result is open
-   */
-  isOpen: false,
-  searchValue: "",
-}
-
-type AutocompleteState = Readonly<typeof initialState>
 
 const Container = styled(ContextMenu)<Partial<AutocompleteProps<any>>>`
   width: ${({ fullWidth }) => (fullWidth ? "100%" : "fit-content")};
@@ -67,14 +56,8 @@ const Container = styled(ContextMenu)<Partial<AutocompleteProps<any>>>`
   align-items: center;
 `
 
-function makeItems<TValue>({
-  searchValue,
-  minCharacters,
-  results,
-  resultIcon,
-  noResultsMessage,
-}: Partial<AutocompleteProps<TValue> & AutocompleteState>) {
-  if (!searchValue || !(searchValue.length > (minCharacters || 0))) {
+function makeItems<TValue>({ value, results, resultIcon, noResultsMessage }: Partial<AutocompleteProps<TValue>>) {
+  if (!results || !value) {
     return []
   }
 
@@ -90,44 +73,29 @@ function makeItems<TValue>({
   return [noResultsMessage || ""]
 }
 
-class Autocomplete<TValue> extends React.Component<AutocompleteProps<TValue>, AutocompleteState> {
-  public readonly state = initialState
-
-  public static defaultProps = {
-    minCharacters: 3,
-  }
-
-  public static getDerivedStateFromProps(props: AutocompleteProps<any>) {
-    return { searchValue: props.value }
-  }
-
-  public render() {
-    const {
-      fullWidth,
-      label,
-      results,
-      resultIcon,
-      minCharacters,
-      loading,
-      noResultsMessage,
-      onChange,
-      onResultClick,
-    } = this.props
-
-    const { searchValue } = this.state
-
-    return (
-      <Container
-        iconLocation="right"
-        fullWidth={fullWidth}
-        items={makeItems({ results, searchValue, resultIcon, minCharacters, noResultsMessage })}
-        onClick={item => (item && typeof item === "string" ? onResultClick(item) : onResultClick((item as Item).label))}
-      >
-        {loading && <Progress bottom />}
-        <Input fullWidth={true} value={searchValue} onChange={onChange} label={label} />
-      </Container>
-    )
-  }
+function Autocomplete<TValue>({
+  fullWidth,
+  label,
+  results,
+  resultIcon,
+  loading,
+  noResultsMessage,
+  onChange,
+  value,
+  onResultClick,
+  hint,
+}: AutocompleteProps<TValue>) {
+  return (
+    <Container
+      iconLocation="right"
+      fullWidth={fullWidth}
+      items={makeItems({ results, value, resultIcon, noResultsMessage })}
+      onClick={onResultClick}
+    >
+      {loading && <Progress bottom />}
+      <Input hint={hint} fullWidth={true} value={value} onChange={onChange} label={label} />
+    </Container>
+  )
 }
 
 export default Autocomplete

--- a/src/Autocomplete/README.md
+++ b/src/Autocomplete/README.md
@@ -1,87 +1,44 @@
 ### Single value search
 
 ```jsx
-const data = [
-  "Homer J. Simpson",
-  "Marge Simpson",
-  "Bart Simpson",
-  "Lisa Simpson",
-  "Maggie Simpson",
-  "Krusty",
-  "Abraham Simpson",
-  "Ned Flanders",
-  "Apu Nahasapeemapetilon Jr",
-  "Barney Gumble",
-  "Moe Szyslak",
-  "Willie",
-  "Charles Montgomery Burns",
-  "Tahiti Mel",
-  "Jeff Albertson",
-  "Martin Prince",
-  "Chef Wiggum",
-  "Lou",
-]
-
-// Fake `restful-react.Get` component
-class Get extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      loading: false,
-      res: null,
-    }
-  }
-
-  componentWillUnmount() {
-    clearTimeout(this.timeoutId)
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.path !== this.props.path) {
-      this.setState({ loading: true })
-
-      clearTimeout(this.timeoutId)
-      this.timeoutId = setTimeout(() => {
-        this.setState({
-          res: data.filter(i => i.toLowerCase().startsWith(this.props.path.slice(8).toLowerCase())),
+updateSearch = text => {
+  // You can even debounce this.
+  setState({ search: text })
+  if (text.length > 3) {
+    setState({ loading: true })
+    fetch("https://dog.ceo/api/breeds/list")
+      .then(results => results.json())
+      .then(results =>
+        setState({
+          data: results.message
+            .filter(name => ~name.indexOf(text))
+            .map(breed => ({ label: breed, value: `https://dog.ceo/api/breed/${breed}/images` })),
           loading: false,
-        })
-      }, 1000)
-    }
-  }
-
-  render() {
-    return this.props.children(this.state.res, { loading: this.state.loading })
+        }),
+      )
+  } else {
+    setState({ data: undefined })
   }
 }
+;<div style={{ display: "flex", alignItems: "flex-start" }}>
+  <Autocomplete
+    value={state.search}
+    loading={state.loading}
+    resultIcon="Add"
+    results={state.data}
+    noResultsMessage="No result Found"
+    onResultClick={result => {
+      fetch(result.value)
+        .then(response => response.json())
+        .then(dogImage => setState({ chosenDog: { ...result, value: dogImage.message[0] } }))
+    }}
+    onChange={updateSearch}
+    label="Find a Good Boye 🐶"
+    hint={`Try "Husky"`}
+  />
 
-class Container extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      search: "",
-      value: { label: "" },
-    }
-  }
-  render() {
-    return (
-      <Get path={`?search=${this.state.search}`}>
-        {(data, { loading }) => (
-          <Autocomplete
-            value={this.state.search}
-            loading={loading}
-            resultIcon="Add"
-            results={data}
-            noResultsMessage="No result Found"
-            onResultClick={result => alert("You chose " + result)}
-            onChange={search => this.setState({ search })}
-            label="Choose your simpson"
-          />
-        )}
-      </Get>
-    )
-  }
-}
-
-;<Container />
+  {state.chosenDog && (
+    <img alt={state.chosenDog.label} src={state.chosenDog.value} style={{ marginLeft: 8, width: 100 }} />
+  )}
+</div>
 ```

--- a/src/Autocomplete/README.md
+++ b/src/Autocomplete/README.md
@@ -70,6 +70,7 @@ class Container extends React.Component {
           <Autocomplete
             value={this.state.search}
             loading={loading}
+            resultIcon="Add"
             results={data}
             noResultsMessage="No result Found"
             onResultClick={result => alert("You chose " + result)}

--- a/src/Autocomplete/README.md
+++ b/src/Autocomplete/README.md
@@ -1,0 +1,86 @@
+### Single value search
+
+```jsx
+const data = [
+  "Homer J. Simpson",
+  "Marge Simpson",
+  "Bart Simpson",
+  "Lisa Simpson",
+  "Maggie Simpson",
+  "Krusty",
+  "Abraham Simpson",
+  "Ned Flanders",
+  "Apu Nahasapeemapetilon Jr",
+  "Barney Gumble",
+  "Moe Szyslak",
+  "Willie",
+  "Charles Montgomery Burns",
+  "Tahiti Mel",
+  "Jeff Albertson",
+  "Martin Prince",
+  "Chef Wiggum",
+  "Lou",
+]
+
+// Fake `restful-react.Get` component
+class Get extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      loading: false,
+      res: null,
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timeoutId)
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.path !== this.props.path) {
+      this.setState({ loading: true })
+
+      clearTimeout(this.timeoutId)
+      this.timeoutId = setTimeout(() => {
+        this.setState({
+          res: data.filter(i => i.toLowerCase().startsWith(this.props.path.slice(8).toLowerCase())),
+          loading: false,
+        })
+      }, 1000)
+    }
+  }
+
+  render() {
+    return this.props.children(this.state.res, { loading: this.state.loading })
+  }
+}
+
+class Container extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      search: "",
+      value: { label: "" },
+    }
+  }
+  render() {
+    return (
+      <Get path={`?search=${this.state.search}`}>
+        {(data, { loading }) => (
+          <Autocomplete
+            value={this.state.search}
+            loading={loading}
+            results={data}
+            noResultsMessage="No result Found"
+            onResultClick={result => alert("You chose " + result)}
+            onChange={search => this.setState({ search })}
+            label="Choose your simpson"
+          />
+        )}
+      </Get>
+    )
+  }
+}
+
+;<Container />
+```

--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import Icon, { IconProps } from "../Icon/Icon"
+import Icon, { IconName, IconProps } from "../Icon/Icon"
 import { darken } from "../utils"
 import { OperationalStyleConstants } from "../utils/constants"
 import styled from "../utils/styled"
@@ -11,6 +11,7 @@ export interface Props {
   width?: string | number
   onClick?: () => void
   align?: "left" | "right"
+  iconLocation?: "left" | "right"
   item: StringOrItem
 }
 
@@ -73,14 +74,15 @@ const Description = styled("p")`
   overflow: hidden;
 `
 
-const ContentContainer = styled("div")`
+const ContentContainer = styled("div")<Partial<Props>>`
   line-height: ${({ theme }) => theme.font.lineHeight};
   padding: ${({ theme }) => theme.space.content}px 0;
   width: calc(100% - ${({ theme }) => theme.space.content}px);
 `
 
-const ContextMenuIcon = styled(Icon)`
+const ContextMenuIcon = styled(Icon)<Partial<Props>>`
   flex: 0 0 auto;
+  margin-left: ${({ iconLocation }) => (iconLocation && iconLocation === "right" ? "auto" : 0)};
 `
 
 const Content: React.SFC<{ value: StringOrItem }> = ({ value }) => {
@@ -101,11 +103,21 @@ const Content: React.SFC<{ value: StringOrItem }> = ({ value }) => {
   )
 }
 
+const InPlaceIcon = (props: Props) =>
+  typeof props.item !== "string" ? (
+    <ContextMenuIcon
+      iconLocation={props.iconLocation}
+      color={props.item.iconColor}
+      left={props.iconLocation === "left" || !props.iconLocation}
+      name={props.item.icon as IconName}
+    />
+  ) : null
+
 const ContextMenuItem: React.SFC<Props> = props => (
   <Container {...props} condensed={props.condensed}>
-    {typeof props.item !== "string" &&
-      props.item.icon && <ContextMenuIcon color={props.item.iconColor} left name={props.item.icon} />}
+    {(!props.iconLocation || props.iconLocation === "left") && <InPlaceIcon {...props} />}
     <Content value={props.item} />
+    {props.iconLocation === "right" && <InPlaceIcon {...props} />}
   </Container>
 )
 

--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -24,8 +24,10 @@ export interface IContextMenuItem {
 
 const Container = styled("div")<Props>(({ align, theme, onClick, condensed, width, item }) => ({
   userSelect: "none",
+  display: "flex",
+  alignItems: "center",
   label: "contextmenuitem",
-  width: width || (condensed ? 160 : 250),
+  width: width || (condensed ? 160 : "100%"),
   whiteSpace: "nowrap",
   overflow: "hidden",
   textOverflow: "ellipsis",

--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -24,8 +24,6 @@ export interface IContextMenuItem {
 
 const Container = styled("div")<Props>(({ align, theme, onClick, condensed, width, item }) => ({
   userSelect: "none",
-  display: "flex",
-  alignItems: "center",
   label: "contextmenuitem",
   width: width || (condensed ? 160 : "100%"),
   whiteSpace: "nowrap",

--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -13,6 +13,7 @@ export interface Props {
   align?: "left" | "right"
   iconLocation?: "left" | "right"
   item: StringOrItem
+  tabIndex: number
 }
 
 export interface IContextMenuItem {

--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -80,9 +80,9 @@ const ContentContainer = styled("div")<Partial<Props>>`
   width: calc(100% - ${({ theme }) => theme.space.content}px);
 `
 
-const ContextMenuIcon = styled(Icon)<Partial<Props>>`
+const ContextMenuIcon = styled(Icon)<{ iconlocation_: Props["iconLocation"] }>`
   flex: 0 0 auto;
-  margin-left: ${({ iconLocation }) => (iconLocation && iconLocation === "right" ? "auto" : 0)};
+  margin-left: ${({ iconlocation_ }) => (iconlocation_ && iconlocation_ === "right" ? "auto" : 0)};
 `
 
 const Content: React.SFC<{ value: StringOrItem }> = ({ value }) => {
@@ -106,7 +106,7 @@ const Content: React.SFC<{ value: StringOrItem }> = ({ value }) => {
 const InPlaceIcon = (props: Props) =>
   typeof props.item !== "string" ? (
     <ContextMenuIcon
-      iconLocation={props.iconLocation}
+      iconlocation_={props.iconLocation}
       color={props.item.iconColor}
       left={props.iconLocation === "left" || !props.iconLocation}
       name={props.item.icon as IconName}

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -54,7 +54,7 @@ const MenuContainer = styled("div")<{
   overflow: "auto",
   boxShadow: theme.shadows.popup,
   zIndex: theme.zIndex.selectOptions,
-  width: "fit-content",
+  width: "100%",
   display: isExpanded ? "block" : "none",
 }))
 

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
+import { keyCodes } from "../utils"
 import ContextMenuItem, { IContextMenuItem } from "./ContextMenu.Item"
 
 export interface ContextMenuProps extends DefaultProps {
@@ -63,13 +64,6 @@ const MenuContainer = styled("div")<{
   minWidth: "fit-content",
   display: isExpanded ? "block" : "none",
 }))
-
-const keyCodes = {
-  up: 38,
-  down: 40,
-  enter: 13,
-  esc: 27,
-}
 
 class ContextMenu extends React.Component<ContextMenuProps, State> {
   public menu: HTMLDivElement | null = null

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -18,6 +18,8 @@ export interface ContextMenuProps extends DefaultProps {
   keepOpenOnItemClick?: boolean
   /** Menu items */
   items: Array<string | IContextMenuItem>
+  /** Where shall we place an icon in rows? */
+  iconLocation?: "left" | "right"
   /** Alignment */
   align?: "left" | "right"
   /** Custom width */
@@ -54,7 +56,8 @@ const MenuContainer = styled("div")<{
   overflow: "auto",
   boxShadow: theme.shadows.popup,
   zIndex: theme.zIndex.selectOptions,
-  width: "100%",
+  width: `calc(100% - ${theme.space.small}px)`,
+  minWidth: "fit-content",
   display: isExpanded ? "block" : "none",
 }))
 
@@ -86,7 +89,7 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
       throw new Error("No array of items has been provided for the ContextMenu.")
     }
 
-    const { items, condensed, children, open, embedChildrenInMenu, align, width, ...props } = this.props
+    const { items, condensed, iconLocation, children, open, embedChildrenInMenu, align, width, ...props } = this.props
 
     const renderedChildren =
       typeof children === "function"
@@ -105,6 +108,7 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
                 key={`contextmenu-${index}`}
                 condensed={condensed}
                 align={align}
+                iconLocation={iconLocation}
                 width={width || "100%"}
                 item={item}
               />

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,6 @@
+import { isEqual } from "lodash"
 import * as React from "react"
+
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
@@ -33,6 +35,7 @@ export interface ContextMenuProps extends DefaultProps {
 
 export interface State {
   isOpen: boolean
+  focusedItemIndex: number
 }
 
 const Container = styled("div")(({ align }: { align: ContextMenuProps["align"] }) => ({
@@ -61,9 +64,19 @@ const MenuContainer = styled("div")<{
   display: isExpanded ? "block" : "none",
 }))
 
+const keyCodes = {
+  up: 38,
+  down: 40,
+  enter: 13,
+  esc: 27,
+}
+
 class ContextMenu extends React.Component<ContextMenuProps, State> {
-  public state = {
+  public menu: HTMLDivElement | null = null
+
+  public state: State = {
     isOpen: false,
+    focusedItemIndex: 0,
   }
 
   public static defaultProps: Partial<ContextMenuProps> = {
@@ -71,11 +84,17 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
     embedChildrenInMenu: false,
   }
 
-  public componentDidUpdate() {
+  public componentDidUpdate(prevProps: ContextMenuProps) {
     if (this.state.isOpen) {
       document.addEventListener("click", this.toggle)
     } else {
       document.removeEventListener("click", this.toggle)
+    }
+
+    // Reset focused item to first if items change.
+    if (!isEqual(this.props.items, prevProps.items)) {
+      this.setState(() => ({ focusedItemIndex: 0 }))
+      this.focusElement()
     }
   }
 
@@ -84,6 +103,37 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
       isOpen: !prevState.isOpen,
     }))
 
+  private focusElement = () => {
+    if (this.menu && this.menu.querySelector('[tabindex="0"]')) {
+      setTimeout(() => (this.menu!.querySelector('[tabindex="0"]') as HTMLDivElement).focus())
+    }
+  }
+
+  private onUpPress = () => ({
+    focusedItemIndex: this.state.focusedItemIndex === 0 ? this.props.items.length - 1 : this.state.focusedItemIndex - 1,
+  })
+
+  private onDownPress = () => ({
+    focusedItemIndex: this.state.focusedItemIndex === this.props.items.length - 1 ? 0 : this.state.focusedItemIndex + 1,
+  })
+
+  private handleKeyPress = ({ keyCode }: React.KeyboardEvent<HTMLDivElement>) => {
+    if (keyCode === keyCodes.enter && this.props.onClick) {
+      this.props.onClick(this.props.items[this.state.focusedItemIndex])
+      this.setState(() => ({ isOpen: false }))
+      return
+    }
+
+    if (keyCode === keyCodes.esc) {
+      this.setState(() => ({ isOpen: false }))
+    }
+
+    if ([keyCodes.up, keyCodes.down].includes(keyCode)) {
+      this.setState(keyCode === keyCodes.up ? this.onUpPress : this.onDownPress)
+      this.focusElement()
+    }
+  }
+
   public render() {
     if (!this.props.items) {
       throw new Error("No array of items has been provided for the ContextMenu.")
@@ -91,30 +141,34 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
 
     const { items, condensed, iconLocation, children, open, embedChildrenInMenu, align, width, ...props } = this.props
 
-    const renderedChildren =
-      typeof children === "function"
-        ? (children as ((isActive: boolean) => React.ReactNode))(this.state.isOpen)
-        : children
+    const renderedChildren = typeof children === "function" ? children(this.state.isOpen) : children
     return (
-      <Container {...props} align={align} onClick={this.toggle}>
+      <Container {...props} align={align} onClick={this.toggle} onKeyUp={this.handleKeyPress}>
         {renderedChildren}
-        <MenuContainer isExpanded={open || this.state.isOpen} embedChildrenInMenu={this.props.embedChildrenInMenu}>
-          {embedChildrenInMenu && renderedChildren}
-          {items.map((item: string | IContextMenuItem, index: number) => {
-            const clickHandler = (typeof item !== "string" && item.onClick) || this.props.onClick
-            return (
-              <ContextMenuItem
-                onClick={clickHandler && (() => clickHandler(item))}
-                key={`contextmenu-${index}`}
-                condensed={condensed}
-                align={align}
-                iconLocation={iconLocation}
-                width={width || "100%"}
-                item={item}
-              />
-            )
-          })}
-        </MenuContainer>
+        {this.state.isOpen && (
+          <MenuContainer
+            innerRef={node => (this.menu = node)}
+            isExpanded={open || this.state.isOpen}
+            embedChildrenInMenu={this.props.embedChildrenInMenu}
+          >
+            {embedChildrenInMenu && renderedChildren}
+            {items.map((item: string | IContextMenuItem, index: number) => {
+              const clickHandler = (typeof item !== "string" && item.onClick) || this.props.onClick
+              return (
+                <ContextMenuItem
+                  tabIndex={this.state.focusedItemIndex === index ? 0 : -1} // ref "tabindex roving": https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex
+                  onClick={clickHandler && (() => clickHandler(item))}
+                  key={`contextmenu-${index}`}
+                  condensed={condensed}
+                  align={align}
+                  iconLocation={iconLocation}
+                  width={width || "100%"}
+                  item={item}
+                />
+              )
+            })}
+          </MenuContainer>
+        )}
       </Container>
     )
   }

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -96,6 +96,7 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
 
     if (keyCode === keyCodes.esc) {
       this.setState(() => ({ isOpen: false }))
+      return
     }
 
     if ([keyCodes.up, keyCodes.down].includes(keyCode)) {

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -50,9 +50,8 @@ const Container = styled("div")(({ align }: { align: ContextMenuProps["align"] }
 }))
 
 const MenuContainer = styled("div")<{
-  isExpanded: boolean
   embedChildrenInMenu?: ContextMenuProps["embedChildrenInMenu"]
-}>(({ theme, isExpanded, embedChildrenInMenu }) => ({
+}>(({ theme, embedChildrenInMenu }) => ({
   position: "absolute",
   top: embedChildrenInMenu ? 0 : "100%",
   left: 0,
@@ -62,7 +61,6 @@ const MenuContainer = styled("div")<{
   zIndex: theme.zIndex.selectOptions,
   width: `calc(100% - ${theme.space.small}px)`,
   minWidth: "fit-content",
-  display: isExpanded ? "block" : "none",
 }))
 
 class ContextMenu extends React.Component<ContextMenuProps, State> {
@@ -124,8 +122,7 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
 
     // Reset focused item to first if items change.
     if (!isEqual(this.props.items, prevProps.items)) {
-      this.setState(() => ({ focusedItemIndex: 0 }))
-      this.focusElement()
+      this.setState(() => ({ focusedItemIndex: this.props.items.length - 1 }))
     }
   }
 
@@ -141,11 +138,7 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
       <Container {...props} align={align} onClick={this.toggle} onKeyUp={this.handleKeyPress}>
         {renderedChildren}
         {this.state.isOpen && (
-          <MenuContainer
-            innerRef={node => (this.menu = node)}
-            isExpanded={open || this.state.isOpen}
-            embedChildrenInMenu={this.props.embedChildrenInMenu}
-          >
+          <MenuContainer innerRef={node => (this.menu = node)} embedChildrenInMenu={this.props.embedChildrenInMenu}>
             {embedChildrenInMenu && renderedChildren}
             {items.map((item: string | IContextMenuItem, index: number) => {
               const clickHandler = (typeof item !== "string" && item.onClick) || this.props.onClick

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -66,33 +66,9 @@ const MenuContainer = styled("div")<{
 }))
 
 class ContextMenu extends React.Component<ContextMenuProps, State> {
-  public menu: HTMLDivElement | null = null
+  private menu: HTMLDivElement | null = null
 
-  public state: State = {
-    isOpen: false,
-    focusedItemIndex: 0,
-  }
-
-  public static defaultProps: Partial<ContextMenuProps> = {
-    align: "left",
-    embedChildrenInMenu: false,
-  }
-
-  public componentDidUpdate(prevProps: ContextMenuProps) {
-    if (this.state.isOpen) {
-      document.addEventListener("click", this.toggle)
-    } else {
-      document.removeEventListener("click", this.toggle)
-    }
-
-    // Reset focused item to first if items change.
-    if (!isEqual(this.props.items, prevProps.items)) {
-      this.setState(() => ({ focusedItemIndex: 0 }))
-      this.focusElement()
-    }
-  }
-
-  public toggle = () =>
+  private toggle = () =>
     this.setState(prevState => ({
       isOpen: !prevState.isOpen,
     }))
@@ -124,6 +100,30 @@ class ContextMenu extends React.Component<ContextMenuProps, State> {
 
     if ([keyCodes.up, keyCodes.down].includes(keyCode)) {
       this.setState(keyCode === keyCodes.up ? this.onUpPress : this.onDownPress)
+      this.focusElement()
+    }
+  }
+
+  public state: State = {
+    isOpen: false,
+    focusedItemIndex: 0,
+  }
+
+  public static defaultProps: Partial<ContextMenuProps> = {
+    align: "left",
+    embedChildrenInMenu: false,
+  }
+
+  public componentDidUpdate(prevProps: ContextMenuProps) {
+    if (this.state.isOpen) {
+      document.addEventListener("click", this.toggle)
+    } else {
+      document.removeEventListener("click", this.toggle)
+    }
+
+    // Reset focused item to first if items change.
+    if (!isEqual(this.props.items, prevProps.items)) {
+      this.setState(() => ({ focusedItemIndex: 0 }))
       this.focusElement()
     }
   }

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -1,9 +1,18 @@
 Context menus are nested menus that can expand from anywhere on a page. Their use is encouraged in the header and in the upper right corner of cards.
 
-### Usage
+### Basic Usage
 
 ```jsx
 const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
+;<ContextMenu items={menuItems} onClick={item => alert(`clicked ${item}`)}>
+  <span>Click here</span>
+</ContextMenu>
+```
+
+### Usage with Icon
+
+```jsx
+const menuItems = [{ label: "Menu 1", icon: "Search" }, "Menu 2", "Menu 3"]
 ;<ContextMenu items={menuItems} onClick={item => alert(`clicked ${item}`)}>
   <span>Click here</span>
 </ContextMenu>

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -13,9 +13,14 @@ const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
 
 ```jsx
 const menuItems = [{ label: "Menu 1", icon: "Search" }, "Menu 2", "Menu 3"]
-;<ContextMenu items={menuItems} onClick={item => alert(`clicked ${item}`)}>
-  <span>Click here</span>
-</ContextMenu>
+;<>
+  <ContextMenu items={menuItems} onClick={item => alert(`clicked ${item}`)}>
+    <Button>Click here for icon on left</Button>
+  </ContextMenu>
+  <ContextMenu iconLocation="right" items={menuItems} onClick={item => alert(`clicked ${item}`)}>
+    <Button color="primary">Click here for icon on right</Button>
+  </ContextMenu>
+</>
 ```
 
 #### Condensed

--- a/src/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ContextMenu Component Should render 1`] = `
       />
     </svg>
     <div
-      class="css-121qqvs"
+      class="css-11z5cfi"
     >
       <div
         class="css-eql6c9-contextmenuitem"

--- a/src/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -21,28 +21,6 @@ exports[`ContextMenu Component Should render 1`] = `
         d="M320,340.187l-280,0l0,-320l280,0l0,320Zm-120,-59.999l0,-40l-120,0l0,40l120,0Zm80,-80l0,-40l-200,0l0,40l200,0Zm0,-80l0,-40l-200,0l0,40l200,0Z"
       />
     </svg>
-    <div
-      class="css-11z5cfi"
-    >
-      <div
-        class="css-eql6c9-contextmenuitem"
-        width="100%"
-      >
-        Item 1
-      </div>
-      <div
-        class="css-eql6c9-contextmenuitem"
-        width="100%"
-      >
-        Item 2
-      </div>
-      <div
-        class="css-eql6c9-contextmenuitem"
-        width="100%"
-      >
-        Item 3
-      </div>
-    </div>
   </div>
 </div>
 `;

--- a/src/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/ContextMenu/__tests__/__snapshots__/ContextMenu.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`ContextMenu Component Should render 1`] = `
       />
     </svg>
     <div
-      class="css-1m1l0js"
+      class="css-121qqvs"
     >
       <div
         class="css-eql6c9-contextmenuitem"

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -3,6 +3,7 @@ import { Icon } from "../"
 import { DefaultProps } from "../types"
 import { Label, LabelText } from "../utils/mixins"
 
+import { keyCodes } from "../utils"
 import Month from "./DatePicker.Month"
 import { Container, DatePickerCard, IconContainer, Input, MonthNav, Toggle } from "./DatePicker.styles"
 import { changeMonth, months, toDate, toYearMonthDay, validateDateString } from "./DatePicker.utils"
@@ -87,7 +88,7 @@ class DatePicker extends React.Component<DatePickerProps, State> {
 
   public componentDidMount() {
     this.keypressHandler = (ev: any) => {
-      if (ev.keyCode !== 27) {
+      if (ev.keyCode !== keyCodes.esc) {
         return
       }
 

--- a/src/Debug/README.md
+++ b/src/Debug/README.md
@@ -3,7 +3,7 @@ A component that displays information intended to convey meaningful information 
 ## Usage
 
 ```jsx
-const { styled } = require("../../")
+const { styled } = require("../")
 const UnfloatedDebug = styled(Debug)({
   /**
    * Remove the following line to see the _actual_

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -47,7 +47,7 @@ export interface BasePropsWithCopy extends BaseProps {
 export interface BasePropsWithoutCopy extends BaseProps {
   copy?: false
   /** Icon to display in an adjacent icon button */
-  icon?: IconName
+  icon?: IconName | React.ReactNode
   /** Click handler on the icon */
   onIconClick?: () => void
 }
@@ -157,7 +157,7 @@ class Input extends React.Component<InputProps, State> {
       </CopyToClipboard>
     ) : (
       <InputButton onClick={this.props.onIconClick}>
-        {typeof this.props.icon === "string" ? <Icon name={this.props.icon} size={16} /> : this.props.icon}
+        {typeof this.props.icon === "string" ? <Icon name={this.props.icon as IconName} size={16} /> : this.props.icon}
       </InputButton>
     )
   }

--- a/src/Progress/Progress.tsx
+++ b/src/Progress/Progress.tsx
@@ -11,21 +11,24 @@ export interface ProgressProps extends DefaultProps {
   onRetry?: () => void
   /** OnClose callback */
   onClose?: () => void
+  /** Show progress bar on the bottom? */
+  bottom?: boolean
 }
 
-const Container = styled("div")(
+const Container = styled("div")<ProgressProps>(
   {
     label: "progress",
     width: "100%",
     overflowX: "hidden",
     textAlign: "center",
-    top: 0,
     left: 0,
     position: "absolute",
-  },
-  ({ theme }) => ({
-    zIndex: theme.deprecated.baseZIndex + 300,
     backgroundColor: "transparent",
+  },
+  ({ theme, bottom }) => ({
+    zIndex: theme.deprecated.baseZIndex + 300,
+    top: bottom ? "auto" : 0,
+    bottom: bottom ? 0 : "auto",
   }),
 )
 

--- a/src/Progress/__tests__/__snapshots__/Progress.test.tsx.snap
+++ b/src/Progress/__tests__/__snapshots__/Progress.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Progress Component Should initialize properly 1`] = `
     class="css-ar73w8-Messages"
   />
   <div
-    class="css-1f8ra8u-progress"
+    class="css-4khk7-progress"
   >
     <div
       class="css-1x11kw8"

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-import { floatIn, readableTextColor, resetTransform } from "../utils"
+import { floatIn, keyCodes, readableTextColor, resetTransform } from "../utils"
 import { expandColor } from "../utils/constants"
 import { inputFocus, Label, LabelText } from "../utils/mixins"
 import SelectFilter from "./Select.Filter"
@@ -157,7 +157,7 @@ class Select extends React.Component<SelectProps, State> {
   }
 
   public handleEsc = (e: KeyboardEvent) => {
-    if (e.keyCode === 27) {
+    if (e.keyCode === keyCodes.esc) {
       this.close()
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import OperationalUI from "./OperationalUI/OperationalUI"
 export { OperationalStyleConstants } from "./utils/constants"
 
 export { default as ActionMenu, ActionMenuProps } from "./ActionMenu/ActionMenu"
+export { default as Autocomplete, AutocompleteProps } from "./Autocomplete/Autocomplete"
 export { default as Avatar, AvatarProps } from "./Avatar/Avatar"
 export { default as AvatarGroup, AvatarGroupProps } from "./AvatarGroup/AvatarGroup"
 export { default as Breadcrumb, BreadcrumbProps } from "./Breadcrumb/Breadcrumb"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,7 @@ export const isOutsideLink = (url: string) => urlRegex({ exact: true }).test(url
 export const isCmdEnter = (ev: React.KeyboardEvent<HTMLElement>) => {
   const crossBrowserSafeKeycode = ev.which || ev.keyCode
   const modifierKey = ev.ctrlKey || ev.metaKey
-  return crossBrowserSafeKeycode === 13 && modifierKey
+  return crossBrowserSafeKeycode === keyCodes.enter && modifierKey
 }
 
 /**
@@ -34,6 +34,20 @@ export const getInitials = (name: string): string => {
 
   const [firstInitial, , lastInitial] = fullInitials
   return fullInitials.length > 2 ? firstInitial + lastInitial : fullInitials
+}
+
+export const keyCodes = {
+  /** 38 */
+  up: 38,
+
+  /** 40 */
+  down: 40,
+
+  /** 13 */
+  enter: 13,
+
+  /** 27 */
+  esc: 27,
 }
 
 /**


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR adds support for an `Autocomplete` component that works in tandem with https://github.com/contiamo/restful-react.


<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#751 

<!-- Paste the github issue here -->

# Open questions
- @fabien0102 do we need debounce on this? I saw [the implementation on your branch](https://github.com/contiamo/operational-ui/blob/feat-autocomplete/src/Autocomplete/Autocomplete.tsx#L75-L80) (this is a fork of your branch). To my understanding, Restful React's `Get` already has a debounce so I'm wondering if this is necessary here?

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
- [ ] No regression on `ContextMenu`
- [ ] No regression on `Input`
- [ ] No regression on `Progress`
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
- [ ] No regression on `ContextMenu`
- [ ] No regression on `Input`
- [ ] No regression on `Progress`
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
