### PR TITLE
**Feature:** Allow configuration of Button's text color

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -16,6 +16,8 @@ export interface ButtonProps extends DefaultProps {
   to?: string
   /** Button color theme (hex or named color from `theme.color`) */
   color?: string
+  /** Button color theme (hex or named color from `theme.color`) */
+  textColor?: keyof OperationalStyleConstants["color"] | string
   /** Icon to display on right or left of button (optional) */
   icon?: IconName
   /** Icon position */
@@ -57,16 +59,13 @@ const makeColors = (theme: OperationalStyleConstants, color: string) => {
 
 const containerStyles: Interpolation<
   Themed<
-    {
-      color_?: ButtonProps["color"]
-      disabled?: boolean
-      condensed?: ButtonProps["condensed"]
-      loading?: ButtonProps["loading"]
-      fullWidth?: ButtonProps["fullWidth"]
+    Pick<ButtonProps, "disabled" | "condensed" | "fullWidth" | "textColor" | "loading"> & {
+      onClick: (ev: React.SyntheticEvent<React.ReactNode>) => void
+      color_?: string
     },
     OperationalStyleConstants
   >
-> = ({ theme, color_, disabled, condensed, loading, fullWidth }) => {
+> = ({ theme, color_, disabled, condensed, loading, fullWidth, textColor }) => {
   const { background: backgroundColor, foreground: foregroundColor } = makeColors(theme, color_ || "")
   return {
     backgroundColor,
@@ -90,7 +89,7 @@ const containerStyles: Interpolation<
     // Apply styles with increased specificity to override defaults
     "&, a:link&, a:visited&": {
       textDecoration: "none",
-      color: loading ? "transparent" : foregroundColor,
+      color: loading ? "transparent" : expandColor(theme, textColor) || foregroundColor,
     },
     ...(!disabled
       ? {
@@ -123,6 +122,10 @@ const Button: React.SFC<ButtonProps> = ({
   color,
   onClick,
   loading,
+  disabled,
+  condensed,
+  fullWidth,
+  textColor,
   ...props
 }) => {
   const ContainerComponent = to ? ContainerLink : Container
@@ -135,9 +138,13 @@ const Button: React.SFC<ButtonProps> = ({
           {...props}
           color_={color}
           loading={loading}
+          disabled={disabled}
+          condensed={condensed}
+          fullWidth={fullWidth}
+          textColor={textColor}
           href={to}
           onClick={(ev: React.SyntheticEvent<React.ReactNode>) => {
-            if (props.disabled) {
+            if (disabled) {
               ev.preventDefault()
               return
             }

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -113,21 +113,7 @@ const ButtonSpinner = styled(Spinner)<{ containerColor?: ButtonProps["color"] }>
   color: makeColors(theme, containerColor || "").foreground,
 }))
 
-const Button: React.SFC<ButtonProps> = ({
-  to,
-  children,
-  icon,
-  iconPosition,
-  iconColor,
-  color,
-  onClick,
-  loading,
-  disabled,
-  condensed,
-  fullWidth,
-  textColor,
-  ...props
-}) => {
+const Button: React.SFC<ButtonProps> = ({ to, children, icon, iconPosition, iconColor, color, onClick, ...props }) => {
   const ContainerComponent = to ? ContainerLink : Container
   const iconProps = { name: icon!, size: 18, color: iconColor }
 
@@ -137,14 +123,9 @@ const Button: React.SFC<ButtonProps> = ({
         <ContainerComponent
           {...props}
           color_={color}
-          loading={loading}
-          disabled={disabled}
-          condensed={condensed}
-          fullWidth={fullWidth}
-          textColor={textColor}
           href={to}
           onClick={(ev: React.SyntheticEvent<React.ReactNode>) => {
-            if (disabled) {
+            if (props.disabled) {
               ev.preventDefault()
               return
             }
@@ -158,12 +139,12 @@ const Button: React.SFC<ButtonProps> = ({
               ctx.pushState(to)
             }
           }}
-          title={loading && children === String(children) ? String(children) : undefined}
+          title={props.loading && children === String(children) ? String(children) : undefined}
         >
           {icon && iconPosition === "start" && <Icon left {...iconProps} />}
           {children}
           {icon && iconPosition === "end" && <Icon right {...iconProps} />}
-          {loading && <ButtonSpinner containerColor={color} />}
+          {props.loading && <ButtonSpinner containerColor={color} />}
         </ContainerComponent>
       )}
     </OperationalContext>

--- a/src/Button/README.md
+++ b/src/Button/README.md
@@ -14,6 +14,7 @@ Using buttons is as simple as including the component with a text node as a chil
   <Button color="error">Error</Button>
   <Button color="warning">Warning</Button>
   <Button color="#ff0000">Custom color</Button>
+  <Button textColor="#300" color="#ff0000">Custom text color</Button>
 </div>
 <div style={{ marginBottom: 10 }}>
   <Button disabled>Default</Button>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
It's a little hard to extend buttons currently by adding a text color. This PR fixes that.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#759 
<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
- [x] Messing with the `textColor` prop renders expected Button.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
- [ ] Messing with the `textColor` prop renders expected Button.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
