### PR TITLE
**Feature:** Update Modal to be full page

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -119,6 +119,7 @@ const Content = styled("div")`
 
   /* Allow dynamic height */
   display: flex;
+  align-items: flex-start;
   flex-direction: column;
   flex: 1;
 `

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -115,9 +115,12 @@ const Container = styled("div")(({ theme }) => ({
 }))
 
 const Content = styled("div")`
-  ${({ theme }) => `
-    padding: ${theme.space.element}px;
-  `};
+  padding: ${({ theme }) => theme.space.element}px;
+
+  /* Allow dynamic height */
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 `
 
 const SectionsContainer = styled("div")<{ stackHorizontal: boolean }>`

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -116,12 +116,6 @@ const Container = styled("div")(({ theme }) => ({
 
 const Content = styled("div")`
   padding: ${({ theme }) => theme.space.element}px;
-
-  /* Allow dynamic height */
-  display: flex;
-  align-items: flex-start;
-  flex-direction: column;
-  flex: 1;
 `
 
 const SectionsContainer = styled("div")<{ stackHorizontal: boolean }>`

--- a/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Card Should render 1`] = `
     class="css-13aykpc"
   >
     <div
-      class="css-90kvr8"
+      class="css-hj9g46"
     >
       hi
     </div>

--- a/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Card Should render 1`] = `
     class="css-13aykpc"
   >
     <div
-      class="css-hj9g46"
+      class="css-gz8dae"
     >
       hi
     </div>

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -5,6 +5,7 @@ export const CardColumns = styled("div")<React.Props<{}>>(({ children, theme }) 
   display: "flex",
   flexWrap: "wrap",
   margin: -(theme.space.element / 2),
+  maxWidth: "100%",
   "& > *": {
     flexBasis: `${React.Children.count(children)}%`,
   },

--- a/src/Internals/CardHeader.tsx
+++ b/src/Internals/CardHeader.tsx
@@ -20,6 +20,8 @@ const Container = styled("div")(({ theme }) => ({
   alignItems: "center",
   backgroundColor: theme.color.background.lighter,
   color: theme.color.text.lighter,
+  flex: "0 0 auto", // Make sure it stays the same size if other parts of the card push it
+
   // This ensures that the card header text and card controls are placed in opposite corners.
   justifyContent: "space-between",
   height: theme.space.element * 2,

--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -3,13 +3,6 @@ import Button, { ButtonProps } from "../Button/Button"
 import styled from "../utils/styled"
 import ControlledModal from "./ControlledModal"
 
-const Actions = styled("div")`
-  ${({ theme }) => `
-  margin-top: ${theme.space.element};
-  align-self: flex-end;
-`};
-`
-
 export interface ConfirmBodyProps<T> {
   setConfirmState: (state?: Partial<T>) => void
   confirmState: T
@@ -18,6 +11,7 @@ export interface ConfirmBodyProps<T> {
 export interface ConfirmOptions<T> {
   title: React.ReactNode
   body: React.ReactNode | React.ComponentType<ConfirmBodyProps<T>>
+  fullSize?: boolean
   cancelButton?: React.ReactElement<ButtonProps>
   actionButton?: React.ReactElement<ButtonProps>
   onConfirm?: (confirmState: T) => void
@@ -32,6 +26,19 @@ export interface State<T> {
 export interface Props {
   children: (confirm: <T>(options: ConfirmOptions<T>) => void) => React.ReactNode
 }
+
+const actionsBarSize = 56
+
+const Actions = styled("div")`
+  margin-top: ${({ theme }) => theme.space.element}px;
+  align-self: flex-end;
+  height: ${actionsBarSize}px;
+`
+
+const ControlledModalContent = styled("div")`
+  height: calc(100% - ${actionsBarSize}px);
+  overflow: auto;
+`
 
 export class Confirm<T> extends React.Component<Props, Readonly<State<T>>> {
   public readonly state: State<T> = {
@@ -77,15 +84,19 @@ export class Confirm<T> extends React.Component<Props, Readonly<State<T>>> {
       <>
         {this.props.children(this.openConfirm.bind(this))}
         {isOpen && (
-          <ControlledModal title={this.state.options.title} onClose={this.closeConfirm}>
-            <div>
+          <ControlledModal
+            fullSize={this.state.options.fullSize}
+            title={this.state.options.title}
+            onClose={this.closeConfirm}
+          >
+            <ControlledModalContent>
               {typeof this.state.options.body === "function" && this.state.options.state
                 ? React.createElement(this.state.options.body, {
                     setConfirmState: this.setConfirmState,
                     confirmState: this.state.options.state,
                   })
                 : this.state.options.body}
-            </div>
+            </ControlledModalContent>
             <Actions>
               {React.cloneElement(this.state.options.cancelButton || <Button>Cancel</Button>, {
                 onClick: this.onCancelClick,

--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -27,7 +27,7 @@ export interface Props {
   children: (confirm: <T>(options: ConfirmOptions<T>) => void) => React.ReactNode
 }
 
-const actionsBarSize = 56
+const actionsBarSize = 36
 
 const Actions = styled("div")`
   margin-top: ${({ theme }) => theme.space.element}px;

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -16,13 +16,13 @@ export interface Props {
 }
 
 const fromTop = (fullSize: boolean) => {
-  const left = fullSize ? 0 : "-50%"
+  const translateX = fullSize ? 0 : "-50%"
   return keyframes`
   0% {
-    transform: translate(${left}, -10px)
+    transform: translate(${translateX}, -10px)
   }
   100% {
-    transform: translate(${left}, 0)
+    transform: translate(${translateX}, 0)
   }
 `
 }

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -34,10 +34,9 @@ const Container = styled(Card)<Partial<Props>>(({ theme, fullSize }) => ({
   animation: `${fromTop(Boolean(fullSize))} 0.2s`,
   position: "absolute",
   minWidth: 600,
-  minHeight: 200,
   zIndex: theme.zIndex.modal,
   maxWidth: `calc(100% - ${theme.space.element * 2}px)`, // don't go past the screen!
-  maxHeight: `calc(100% - ${theme.space.element * 2}px)`,
+
   ...(fullSize
     ? // Full-size specific rules
       {
@@ -45,6 +44,7 @@ const Container = styled(Card)<Partial<Props>>(({ theme, fullSize }) => ({
         width: 1110,
         display: "grid",
         gridTemplateRows: "40px 100%",
+        maxHeight: `calc(100% - ${theme.space.element * 2}px)`,
       }
     : // Regular size rules
       {

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -12,46 +12,64 @@ export interface Props {
   onClose?: () => void
   title?: CardProps["title"]
   action?: CardProps["action"]
+  fullSize?: boolean
 }
 
-const fromTop = keyframes`
+const fromTop = (fullSize: boolean) => {
+  const left = fullSize ? 0 : "-50%"
+  return keyframes`
   0% {
-    transform: translate(-50%, -10px)
+    transform: translate(${left}, -10px)
   }
   100% {
-    transform: translate(-50%, 0)
+    transform: translate(${left}, 0)
   }
 `
+}
 
-const Container = styled(Card)(({ theme }) => ({
+const Container = styled(Card)<Partial<Props>>(({ theme, fullSize }) => ({
+  top: fullSize ? theme.space.content : theme.space.element,
+  left: fullSize ? 20 : "50%",
+  height: fullSize ? `calc(100% - ${theme.space.element + theme.space.content}px)` : "fit-content",
+  animation: `${fromTop(Boolean(fullSize))} 0.2s`,
   position: "absolute",
-  top: theme.space.element,
-  left: "50%",
-  transform: "translate(-50%, 0)",
-  animation: `${fromTop} 0.2s`,
   minWidth: 600,
   minHeight: 200,
   zIndex: theme.zIndex.modal,
   display: "flex",
   flexDirection: "column",
+  maxWidth: `calc(100% - ${theme.space.element * 2}px)`, // don't go past the screen!
+
+  ...(fullSize
+    ? // Full-size specific rules
+      {
+        border: 0,
+        width: 1110,
+      }
+    : // Regular size rules
+      {
+        transform: "translate(-50%, 0)",
+      }),
 }))
 
-const Content = styled("div")({
+const Content = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   justifyContent: "space-between",
-  /**
-   * Moved the min-height from the container to be driven by
-   * the content. Accounting for the padding of the Card Content
-   * which is what is restricting the dynamic growth.
-   */
-  minHeight: 120,
-})
+
+  // Invert control of spacing from Card to Modal
+  margin: theme.space.element * -1,
+  padding: theme.space.element,
+
+  // Ensure scrollability if content is too long
+  height: `calc(100% + ${theme.space.element * 2}px)`, // height + padding top + padding bottom
+  overflow: "auto",
+}))
 
 const ControlledModal: React.SFC<Props> = (props: Props) => (
   <>
     <Overlay id={props.id} className={props.className} onClick={props.onClose} />
-    <Container className={props.contentClassName} title={props.title} action={props.action}>
+    <Container className={props.contentClassName} fullSize={props.fullSize} title={props.title} action={props.action}>
       <Content>{props.children}</Content>
     </Container>
   </>

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -29,7 +29,7 @@ const fromTop = (fullSize: boolean) => {
 
 const Container = styled(Card)<Partial<Props>>(({ theme, fullSize }) => ({
   top: fullSize ? theme.space.content : theme.space.element,
-  left: fullSize ? 20 : "50%",
+  left: fullSize ? theme.space.element : "50%",
   height: fullSize ? `calc(100% - ${theme.space.element + theme.space.content}px)` : "fit-content",
   animation: `${fromTop(Boolean(fullSize))} 0.2s`,
   position: "absolute",

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -28,23 +28,23 @@ const fromTop = (fullSize: boolean) => {
 }
 
 const Container = styled(Card)<Partial<Props>>(({ theme, fullSize }) => ({
-  top: fullSize ? theme.space.content : theme.space.element,
+  top: theme.space.element,
   left: fullSize ? theme.space.element : "50%",
-  height: fullSize ? `calc(100% - ${theme.space.element + theme.space.content}px)` : "fit-content",
+  height: fullSize ? "100%" : "fit-content",
   animation: `${fromTop(Boolean(fullSize))} 0.2s`,
   position: "absolute",
   minWidth: 600,
   minHeight: 200,
   zIndex: theme.zIndex.modal,
-  display: "flex",
-  flexDirection: "column",
   maxWidth: `calc(100% - ${theme.space.element * 2}px)`, // don't go past the screen!
-
+  maxHeight: `calc(100% - ${theme.space.element * 2}px)`,
   ...(fullSize
     ? // Full-size specific rules
       {
         border: 0,
         width: 1110,
+        display: "grid",
+        gridTemplateRows: "40px 100%",
       }
     : // Regular size rules
       {
@@ -52,7 +52,7 @@ const Container = styled(Card)<Partial<Props>>(({ theme, fullSize }) => ({
       }),
 }))
 
-const Content = styled("div")(({ theme }) => ({
+const Content = styled("div")<Props>(({ theme, fullSize }) => ({
   display: "flex",
   flexDirection: "column",
   justifyContent: "space-between",
@@ -62,7 +62,7 @@ const Content = styled("div")(({ theme }) => ({
   padding: theme.space.element,
 
   // Ensure scrollability if content is too long
-  height: `calc(100% + ${theme.space.element * 2}px)`, // height + padding top + padding bottom
+  height: fullSize ? `calc(100% - 60px)` : `100%`, // height + padding top + padding bottom
   overflow: "auto",
 }))
 

--- a/src/Internals/Modal.tsx
+++ b/src/Internals/Modal.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import ControlledModal from "./ControlledModal"
 
 export interface ModalOptions {
+  fullSize?: boolean
   title: React.ReactNode
   body: React.ReactNode | ((close: () => void) => React.ReactNode)
 }
@@ -35,7 +36,11 @@ export class Modal extends React.Component<Props, Readonly<State>> {
       <>
         {this.props.children(this.openModal)}
         {isOpen && (
-          <ControlledModal title={this.state.options.title} onClose={this.closeModal}>
+          <ControlledModal
+            fullSize={this.state.options.fullSize}
+            title={this.state.options.title}
+            onClose={this.closeModal}
+          >
             {typeof this.state.options.body === "function"
               ? this.state.options.body(this.closeModal)
               : this.state.options.body}

--- a/src/Layout/README.md
+++ b/src/Layout/README.md
@@ -69,17 +69,138 @@ const sidebar = (
           <>
             {Array(10)
               .fill("Hello!!!!")
-              .map((value, i) => <Card key={i}>{value}</Card>)}
-            <Button
-              onClick={() => {
-                confirm({
-                  title: "Are you sure",
-                  body: "This is a scary operation.",
-                })
-              }}
-            >
-              Open a modal
-            </Button>
+              .map((value, i) => (
+                <Card key={i}>{value}</Card>
+              ))}
+
+            <Card title="Partial Kanye Lyrics">
+              <div>
+                <Button
+                  color="#314865"
+                  textColor="#2bda64"
+                  onClick={() => {
+                    confirm({
+                      title: "Yikes",
+                      body: `Tweakin', tweakin' off that 2CB, huh?
+Is he gon' make it? TBD, huh
+Thought I was gon' run, DMC, huh?
+I done died and lived again on DMT, huh
+See, this a type of high that won't come down
+This the type of high that get you gunned down
+Yeezy, Yeezy trollin' OD, huh?
+Turn TMZ to Smack DVD, huh?
+`
+                        .split("\n")
+                        .map(line => (
+                          <>
+                            {line}
+                            <br />
+                          </>
+                        )),
+                    })
+                  }}
+                >
+                  Open a Confirm
+                </Button>
+                <Button
+                  color="#f89663"
+                  onClick={() => {
+                    confirm({
+                      fullSize: true,
+                      title: "Waves",
+                      body: `Turn it up!
+Waves don't die
+Let me crash here for the moment
+I don't need to own it
+No lie
+Waves don't die
+Let me crash here for a moment
+I don't, I don't need to own...
+Sun don't shine in the shade (turn it up!)
+Bird can't fly in a cage (turn it up!)
+Even when somebody go away (turn it up!)
+The feelings don't really go away
+That's just the wave (yeah)`
+                        .split("\n")
+                        .map(line => (
+                          <>
+                            {line}
+                            <br />
+                          </>
+                        )),
+                    })
+                  }}
+                >
+                  Open a full-size Confirm
+                </Button>
+                <Button
+                  color="#613f90"
+                  textColor="#fb059e"
+                  onClick={() => {
+                    modal({
+                      title: "Stronger",
+                      body: `N-now th-that that don't kill me
+Can only make me stronger
+I need you to hurry up now
+'Cause I can't wait much longer
+I know I got to be right now
+'Cause I can't get much wronger
+Man I've been waiting all night now
+That's how long I been on ya
+I need you right now
+Let's get lost tonight`
+                        .split("\n")
+                        .map(line => (
+                          <>
+                            {line}
+                            <br />
+                          </>
+                        )),
+                    })
+                  }}
+                >
+                  Open a Modal
+                </Button>
+                <Button
+                  color="#f89663"
+                  onClick={() => {
+                    modal({
+                      fullSize: true,
+                      title: "FML",
+                      body: `I been waiting for a minute
+For my lady
+I been living without limits
+As far as my business
+I'm the only one that's in control
+I been feeling all I've given
+For my children
+I will die for those I love
+
+God, I'm willing
+To make this my mission
+Give up the women
+Before I lose half of what I own
+I been thinking
+About my vision
+Pour out my feelings
+Revealing the layers to my soul, my soul
+The layers to my soul
+Revealing the layers to my soul
+`
+                        .split("\n")
+                        .map(line => (
+                          <>
+                            {line}
+                            <br />
+                          </>
+                        )),
+                    })
+                  }}
+                >
+                  Open a full-size Modal
+                </Button>
+              </div>
+            </Card>
           </>
         )}
       </Page>
@@ -146,7 +267,9 @@ const sidebar = (
           <>
             {Array(10)
               .fill("Hello!!!!")
-              .map((value, i) => <Card key={i}>{value}</Card>)}
+              .map((value, i) => (
+                <Card key={i}>{value}</Card>
+              ))}
             <Button
               onClick={() => {
                 confirm({
@@ -223,7 +346,9 @@ const sidebar = (
       >
         {Array(10)
           .fill("Hello!!!!")
-          .map((value, i) => <Card key={i}>{value}</Card>)}
+          .map((value, i) => (
+            <Card key={i}>{value}</Card>
+          ))}
       </Page>
     }
   />


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR adds an option `fullSize` to `Modal` and `Confirm` that allows a user to render a large modal/confirm box.

## How to Test
Go to the first example of `Layout` where there are buttons to trigger modals.

## To Be Tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
- [x] No regression on `Card`.
- [x] No regression on `Modal`.
- [x] No regression on `Confirm`.
- [x] `Modal` and `Confirm` overflow correctly.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
- [ ] No regression on `Card`.
- [ ] No regression on `Modal`.
- [ ] No regression on `Confirm`.
- [ ] `Modal` and `Confirm` overflow correctly.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
