### PR TITLE
**Feature:** Recalculate tree open paths when depth changes

### DIFF
--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -6,7 +6,7 @@ import { DefaultProps } from "../types"
 import constants, { expandColor } from "../utils/constants"
 import styled from "../utils/styled"
 import { Tree as ITree } from "./Tree.types"
-import { containsPath, getInitialOpenPaths, togglePath } from "./Tree.utils"
+import { containsPath, getInitialOpenPaths, getMaxDepth, togglePath } from "./Tree.utils"
 
 export interface TreeProps extends DefaultProps {
   /** An array of tree structures */
@@ -165,12 +165,24 @@ const TreeRecursive: React.SFC<{
 
 class Tree extends React.Component<TreeProps, State> {
   public readonly state: State = {
-    openPaths: this.props.trees
-      .map((tree, index) => getInitialOpenPaths([index])(tree))
-      .reduce((current, accumulator) => [...current, ...accumulator], []),
+    openPaths: this.getOpenPaths(),
   }
 
-  public togglePath = (path: number[]) => {
+  private getOpenPaths() {
+    return this.props.trees
+      .map((tree, index) => getInitialOpenPaths([index])(tree))
+      .reduce((current, accumulator) => [...current, ...accumulator], [])
+  }
+
+  public componentDidUpdate(prevProps: TreeProps) {
+    if (getMaxDepth(this.props.trees) !== getMaxDepth(prevProps.trees)) {
+      this.setState(() => ({
+        openPaths: this.getOpenPaths(),
+      }))
+    }
+  }
+
+  private togglePath = (path: number[]) => {
     this.setState(prevState => ({
       openPaths: togglePath(path)(prevState.openPaths),
     }))

--- a/src/Tree/Tree.utils.ts
+++ b/src/Tree/Tree.utils.ts
@@ -1,6 +1,29 @@
 import { Tree } from "./Tree.types"
 
-const pathsEqual = (path1: number[], path2: number[]) => path1.join("-") === path2.join("-")
+const arePathsEqual = (path1: number[], path2: number[]) => path1.join("-") === path2.join("-")
+
+/**
+ * Returns the largest element of an array of numbers, or undefined if the array is empty.
+ */
+const getMaxFromList = (nos: number[]): number | undefined => {
+  if (nos.length === 0) {
+    return undefined
+  }
+  return nos.reduce((accumulator, current) => (accumulator < current ? current : accumulator), -100000)
+}
+
+export const getDepth = (tree: Tree): number => {
+  if (tree.childNodes.length === 0) {
+    return 1
+  }
+  // Type-casting is necessary because at this point in the function there is a guarantee
+  // that tree.childNodes is not empty and therefore it has a maximum value.
+  return 1 + (getMaxFromList(tree.childNodes.map(getDepth)) as number)
+}
+
+export const getMaxDepth = (trees: Tree[]): number | undefined => {
+  return getMaxFromList(trees.map(getDepth))
+}
 
 export const getInitialOpenPaths = (basePath: number[]) => (tree: Tree): number[][] => {
   return [
@@ -24,7 +47,7 @@ export const togglePath = (path: number[]) => (paths: number[][]): number[][] =>
     return [path]
   }
   const [head, ...tail] = paths
-  if (pathsEqual(head, path)) {
+  if (arePathsEqual(head, path)) {
     return tail
   }
   return [head, ...togglePath(path)(tail)]
@@ -35,7 +58,7 @@ export const containsPath = (path: number[]) => (paths: number[][]): boolean => 
     return false
   }
   const [head, ...tail] = paths
-  if (pathsEqual(head, path)) {
+  if (arePathsEqual(head, path)) {
     return true
   }
   return containsPath(path)(tail)

--- a/src/Tree/__tests__/Tree.test.tsx
+++ b/src/Tree/__tests__/Tree.test.tsx
@@ -2,7 +2,7 @@ import { render } from "enzyme"
 import * as React from "react"
 import { Tree as ThemelessTree } from "../../index"
 import wrapDefaultTheme from "../../utils/wrap-default-theme"
-import { getInitialOpenPaths, togglePath } from "../Tree.utils"
+import { getDepth, getInitialOpenPaths, togglePath } from "../Tree.utils"
 
 const Tree = wrapDefaultTheme(ThemelessTree)
 
@@ -42,5 +42,16 @@ describe("Tree Component", () => {
         ],
       }),
     ).toEqual([[], [0, 0], [1]])
+  })
+  it("Calculates depth of a single-node tree", () => {
+    expect(getDepth({ label: "", childNodes: [] })).toEqual(1)
+  })
+  it("Calculates depth of a complex tree", () => {
+    expect(
+      getDepth({
+        label: "",
+        childNodes: [{ label: "", childNodes: [] }, { label: "", childNodes: [{ label: "", childNodes: [] }] }],
+      }),
+    ).toEqual(3)
   })
 })


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

This PR fixes #765 (refer to issue for a detailed description). The chosen solution recalculates initially open paths when the maximum depth of the tree changes.

# Test like so

Replace the tree snippet with the following:

```js
const createTrees = () => [
    {
      label: "Store",
      childNodes: [
        {
          label: "Region",
          initiallyOpen: true,
          childNodes: [
            {
              label: "City",
              tag: "D",
              disabled: true,
              childNodes: [],
            },
            {
              label: "County",
              color: "primary",
              tag: "D",
              childNodes: [],
            },
          ],
        },
      ],
    },
    {
      label: "Legal Entity",
      initiallyOpen: true,
      childNodes: [
        {
          label: "Limited Liability Company",
          tag: "D",
          childNodes: [],
          draggable: true,
          onDragStart: ev => {
            ev.dataTransfer.effectAllowed = "move"
          },
        },
        {
          label: "Inc.",
          tag: "D",
          color: "#2C363F",
          childNodes: [],
        },
      ],
    },
  ]

initialState = { 
  trees: []
}

setTimeout(() => {
  setState(() => ({
    trees: createTrees()
  }))
}, 3000)

;<Tree
  trees={state.trees}
/>
```

This snippet updates the tree from empty to non-empty (the most common use-case when this bug occurs). After the 3s timeout, the new tree appears in the expected open state based on the `initiallyOpen` flags in the individual nodes.

# Related issue

#765

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] No regressions on tree

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
