### PR TITLE
**Breaking:** opinionated table actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@types/react-copy-to-clipboard": "^4.2.5",
     "@types/react-dom": "^16.0.6",
     "@types/react-router": "^4.0.28",
-    "@types/tinycolor2": "^1.4.0",
+    "@types/tinycolor2": "^1.4.1",
     "@types/url-regex": "^4.1.0",
     "auto-changelog": "^1.8.0",
     "danger": "^4.0.1",

--- a/src/ActionMenu/ActionMenu.tsx
+++ b/src/ActionMenu/ActionMenu.tsx
@@ -19,6 +19,11 @@ export interface ActionMenuProps extends DefaultProps {
 const Container = styled("div")(({ theme }) => ({
   width,
   height: 35,
+  /**
+   * `textAlign` is set explicitly for when a parent sets a text-align to right-position this container,
+   * leaving its content left-aligned.
+   */
+  textAlign: "left",
   padding: `0 ${theme.space.content}px`,
   backgroundColor: theme.color.white,
   color: theme.color.primary,

--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -1,12 +1,23 @@
 Tables simply render a semantic HTML table structure based on raw data.
 
-### Usage
+### Simple usage
+
+You can render a simple use-case of the table by specifying a list of records and supplying the columns as a list of strings which would serve both as column heading and access keys for fields.
 
 ```js
-<Table columns={["Name", "Title"]} rows={[["Max", "Carpenter"], ["Moritz", "Baker"]]} />
+<Table
+  data={[{ name: "Max", profession: "Carpenter" }, { name: "Moritz", profession: "Baker" }]}
+  columns={["name", "profession"]}
+/>
 ```
 
-### With external data to format
+While this approach is convenient, it is not recommended because it makes it too easy to re-use record keys as table headings, and adds a strong coupling between data and view concerns.
+
+We suggest taking the time to think about the best way to describe the data fields and then specifying it explicitly as column headers. The following, slightly more verbose version of the API demonstrates how this can be achieved:
+
+### With explicit data formatting
+
+In this case, simple functions taking an individual record as an argument specify how cells should be rendered in a given column:
 
 ```jsx
 const data = [
@@ -45,21 +56,90 @@ const data = [
   },
 ]
 ;<Table
-  columns={["", "Name", "Last updated", "Tags", "Collaborators"]}
-  rows={data.map(item => [
-    <Icon name="Box" color="info" />,
-    item.name,
-    item.lastUpdated,
-    item.tags.map((tag, i) => <Chip key={i}>{tag}</Chip>),
-    <AvatarGroup avatars={item.collaborators} />,
-  ])}
-  onRowClick={(row, i) => console.log({ row, i })}
-  rowActionName="view details"
+  data={data}
+  columns={[
+    { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
+    { heading: "Name", cell: dataEntry => dataEntry.name },
+    { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
+    { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
+    { heading: "Collaborators", cell: dataEntry => <AvatarGroup avatars={dataEntry.collaborators} /> },
+  ]}
+  onRowClick={(dataEntry, i) => console.log({ dataEntry, i })}
+/>
+```
+
+### With icons
+
+```jsx
+const data = [
+  {
+    name: "Mega Deal Dev",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+  },
+  {
+    name: "Mega Deal Dev",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+  },
+  {
+    name: "Toy Bundle",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+  },
+]
+;<Table
+  data={data}
+  icon={dataEntry => "Building"}
+  columns={[
+    { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
+    { heading: "Name", cell: dataEntry => dataEntry.name },
+    { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
+    { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
+  ]}
+  onRowClick={(dataEntry, i) => console.log({ dataEntry, i })}
+/>
+```
+
+### With default row action
+
+```jsx
+const data = [
+  {
+    name: "Mega Deal Dev",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+  },
+  {
+    name: "Mega Deal Dev",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+  },
+  {
+    name: "Toy Bundle",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+  },
+]
+;<Table
+  data={data}
+  icon={dataEntry => "Building"}
+  iconColor={dataEntry => (dataEntry.name.indexOf("Mega") > -1 ? "primary" : "gray")}
+  columns={[
+    { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
+    { heading: "Name", cell: dataEntry => dataEntry.name },
+    { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
+    { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
+  ]}
+  onRowClick={(dataEntry, i) => console.log({ dataEntry, i })}
+  rowActionName="View Details"
 />
 ```
 
 ### With row actions
 
+Row actions are specified as a function of an individual record, returning action items conforming to the [ContextMenu](/#ContextMenu) API:
+
 ```jsx
 const data = [
   {
@@ -97,34 +177,36 @@ const data = [
   },
 ]
 ;<Table
-  columns={["", "Name", "Last updated", "Tags", "Collaborators"]}
-  rows={data.map(item => [
-    <Icon name="Box" color="info" />,
-    item.name,
-    item.lastUpdated,
-    item.tags.map((tag, i) => <Chip key={i}>{tag}</Chip>),
-    <AvatarGroup avatars={item.collaborators} />,
-  ])}
-  onRowClick={(row, i) => console.log({ row, i })}
-  rowActions={data.map(item => [
+  data={data}
+  columns={[
+    { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
+    { heading: "Name", cell: dataEntry => dataEntry.name },
+    { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
+    { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
+    { heading: "Collaborators", cell: dataEntry => <AvatarGroup avatars={dataEntry.collaborators} /> },
+  ]}
+  onRowClick={(dataEntry, dataEntryIndex) => console.log({ dataEntry, dataEntryIndex })}
+  rowActions={dataEntry => [
     {
       label: "Details",
       onClick: () => {
-        console.log("Clicked details")
+        console.log("Details on ", dataEntry)
       },
     },
     {
-      label: "Details",
+      label: "Delete",
       onClick: () => {
-        console.log("Clicked delete")
+        console.log("Deleting ", dataEntry)
       },
     },
-  ])}
+  ]}
 />
 ```
 
 ### Without data
 
+Tables render a default empty view if no records are specified.
+
 ```jsx
-<Table columns={["", "Name", "Last updated", "Tags", "Collaborators"]} rows={[]} />
+<Table columns={["", "Name", "Last updated", "Tags", "Collaborators"]} data={[]} />
 ```

--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -58,7 +58,7 @@ const data = [
 />
 ```
 
-### With \_\_experimentalRowActions
+### With row actions
 
 ```jsx
 const data = [
@@ -106,12 +106,20 @@ const data = [
     <AvatarGroup avatars={item.collaborators} />,
   ])}
   onRowClick={(row, i) => console.log({ row, i })}
-  __experimentalRowActions={data.map(item => (
-    <>
-      <Button color="info">details</Button>
-      <Button color="error">delete</Button>
-    </>
-  ))}
+  rowActions={data.map(item => [
+    {
+      label: "Details",
+      onClick: () => {
+        console.log("Clicked details")
+      },
+    },
+    {
+      label: "Details",
+      onClick: () => {
+        console.log("Clicked delete")
+      },
+    },
+  ])}
 />
 ```
 

--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -138,7 +138,7 @@ const data = [
 
 ### With row actions
 
-Row actions are specified as a function of an individual record, returning action items conforming to the [ContextMenu](/#ContextMenu) API:
+Row actions are specified as a function of an individual record, returning action items conforming to the [ContextMenu](/#ContextMenu) API. The function in the `rowActions` prop can return either the action items as an array or the `ActionMenu` node itself.
 
 ```jsx
 const data = [
@@ -176,31 +176,62 @@ const data = [
     ],
   },
 ]
-;<Table
-  data={data}
-  columns={[
-    { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
-    { heading: "Name", cell: dataEntry => dataEntry.name },
-    { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
-    { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
-    { heading: "Collaborators", cell: dataEntry => <AvatarGroup avatars={dataEntry.collaborators} /> },
-  ]}
-  onRowClick={(dataEntry, dataEntryIndex) => console.log({ dataEntry, dataEntryIndex })}
-  rowActions={dataEntry => [
-    {
-      label: "Details",
-      onClick: () => {
-        console.log("Details on ", dataEntry)
+;<>
+  <Table
+    data={data}
+    columns={[
+      { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
+      { heading: "Name", cell: dataEntry => dataEntry.name },
+      { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
+      { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
+      { heading: "Collaborators", cell: dataEntry => <AvatarGroup avatars={dataEntry.collaborators} /> },
+    ]}
+    onRowClick={(dataEntry, dataEntryIndex) => console.log({ dataEntry, dataEntryIndex })}
+    rowActions={dataEntry => [
+      {
+        label: "Details",
+        onClick: () => {
+          console.log("Details on ", dataEntry)
+        },
       },
-    },
-    {
-      label: "Delete",
-      onClick: () => {
-        console.log("Deleting ", dataEntry)
+      {
+        label: "Delete",
+        onClick: () => {
+          console.log("Deleting ", dataEntry)
+        },
       },
-    },
-  ]}
-/>
+    ]}
+  />
+  <Table
+    data={data}
+    columns={[
+      { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
+      { heading: "Name", cell: dataEntry => dataEntry.name },
+      { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
+      { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
+      { heading: "Collaborators", cell: dataEntry => <AvatarGroup avatars={dataEntry.collaborators} /> },
+    ]}
+    onRowClick={(dataEntry, dataEntryIndex) => console.log({ dataEntry, dataEntryIndex })}
+    rowActions={dataEntry => (
+      <ActionMenu
+        items={[
+          {
+            label: "Details",
+            onClick: () => {
+              console.log("Details on ", dataEntry)
+            },
+          },
+          {
+            label: "Delete",
+            onClick: () => {
+              console.log("Deleting ", dataEntry)
+            },
+          },
+        ]}
+      />
+    )}
+  />
+</>
 ```
 
 ### Without data

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -86,6 +86,7 @@ const Actions = styled(Td)(({ theme }) => ({
 const IconCell = styled(Td)`
   width: 40px;
   padding: ${props => props.theme.space.base}px;
+  color: ${props => props.theme.color.text.lightest};
 `
 
 const ActionLabel = styled(Small)`
@@ -105,7 +106,16 @@ const EmptyView = styled(Td)(({ theme }) => ({
   textAlign: "center",
 }))
 
-function Table<T>({ data, columns, onRowClick, rowActionName, rowActions, icon, iconColor, ...props }: TableProps<T>) {
+function Table<T>({
+  data = [],
+  columns,
+  onRowClick,
+  rowActionName,
+  rowActions,
+  icon,
+  iconColor,
+  ...props
+}: TableProps<T>) {
   const standardizedColumns: Array<Column<T>> =
     Boolean(columns[0]) && typeof columns[0] === "string"
       ? (columns as Array<Extract<keyof T, string>>).map(columnName => ({

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import ActionMenu, { ActionMenuProps } from "../ActionMenu/ActionMenu"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
@@ -16,7 +17,7 @@ export interface TableProps extends DefaultProps {
   /**
    * Add actions on the end of each row
    */
-  __experimentalRowActions?: React.ReactNode[]
+  rowActions?: Array<ActionMenuProps["items"]>
 }
 
 const Container = styled("table")(({ theme }) => ({
@@ -83,6 +84,10 @@ const Actions = styled(Td)(({ theme }) => ({
   },
 }))
 
+const InlineActionMenu = styled(ActionMenu)`
+  display: inline-flex;
+`
+
 const EmptyView = styled(Td)(({ theme }) => ({
   color: theme.color.text.default,
   height: 50,
@@ -90,14 +95,7 @@ const EmptyView = styled(Td)(({ theme }) => ({
   textAlign: "center",
 }))
 
-const Table: React.SFC<TableProps> = ({
-  rows,
-  columns,
-  onRowClick,
-  rowActionName,
-  __experimentalRowActions,
-  ...props
-}) => {
+const Table: React.SFC<TableProps> = ({ rows, columns, onRowClick, rowActionName, rowActions, ...props }) => {
   return (
     <Container {...props}>
       <thead>
@@ -105,7 +103,7 @@ const Table: React.SFC<TableProps> = ({
           {columns.map((title, i) => (
             <Th key={i}>{title}</Th>
           ))}
-          {Boolean(__experimentalRowActions || rowActionName) && <Th />}
+          {Boolean(rowActions || rowActionName) && <Th />}
         </Tr>
       </thead>
       <tbody>
@@ -124,7 +122,16 @@ const Table: React.SFC<TableProps> = ({
                 <Td key={j}>{data}</Td>
               ))}
               {rowActionName && <Action>{rowActionName}</Action>}
-              {__experimentalRowActions && <Actions>{__experimentalRowActions[i]}</Actions>}
+              {rowActions && (
+                <Actions
+                  onClick={(ev: React.SyntheticEvent<Node>) => {
+                    // Table row click should not trigger if this action menu is manipulated
+                    ev.stopPropagation()
+                  }}
+                >
+                  <InlineActionMenu items={rowActions[i]} />
+                </Actions>
+              )}
             </Tr>
           ))
         ) : (

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,19 +1,31 @@
 import * as React from "react"
 import ActionMenu, { ActionMenuProps } from "../ActionMenu/ActionMenu"
+import Icon, { IconName } from "../Icon/Icon"
 import { DefaultProps } from "../types"
+import Small from "../Typography/Small"
 import styled from "../utils/styled"
 
-export interface TableProps extends DefaultProps {
+export interface TableProps<T> extends DefaultProps {
+  data: T[]
   /** Table columns headings */
-  columns: React.ReactNode[]
-  /** Table rows as an array of cells */
-  rows: Array<Array<string | React.ReactNode>>
+  columns: Array<Column<T>> | Array<Extract<keyof T, string>>
   /** Called on row click */
-  onRowClick?: (row: Array<string | React.ReactNode>, index: number) => void
+  onRowClick?: (dataEntry: T, index: number) => void
+  /** Label to show on row hover */
+  rowActionName?: string
   /**
    * Add actions on the end of each row
    */
-  rowActions?: Array<ActionMenuProps["items"]>
+  rowActions?: (dataEntry: T) => ActionMenuProps["items"]
+  /** Icon name for row */
+  icon?: (dataEntry: T) => IconName
+  /** Icon color for row */
+  iconColor?: (dataEntry: T) => string
+}
+
+export interface Column<T> {
+  heading: React.ReactNode
+  cell: (dataEntry: T, index: number) => React.ReactNode
 }
 
 const Container = styled("table")(({ theme }) => ({
@@ -71,6 +83,17 @@ const Actions = styled(Td)(({ theme }) => ({
   },
 }))
 
+const IconCell = styled(Td)`
+  width: 40px;
+  padding: ${props => props.theme.space.base}px;
+`
+
+const ActionLabel = styled(Small)`
+  color: ${props => props.theme.color.primary};
+  margin: 0;
+  display: block;
+`
+
 const InlineActionMenu = styled(ActionMenu)`
   display: inline-flex;
 `
@@ -82,31 +105,46 @@ const EmptyView = styled(Td)(({ theme }) => ({
   textAlign: "center",
 }))
 
-const Table: React.SFC<TableProps> = ({ rows, columns, onRowClick, rowActions, ...props }) => {
+function Table<T>({ data, columns, onRowClick, rowActionName, rowActions, icon, iconColor, ...props }: TableProps<T>) {
+  const standardizedColumns: Array<Column<T>> =
+    Boolean(columns[0]) && typeof columns[0] === "string"
+      ? (columns as Array<Extract<keyof T, string>>).map(columnName => ({
+          heading: columnName,
+          cell: (dataEntry: T) => dataEntry[columnName],
+        }))
+      : (columns as Array<Column<T>>)
+
+  const hasIcons: boolean = Boolean(data[0]) && Boolean(icon) && Boolean(icon!(data[0]))
+
   return (
     <Container {...props}>
       <thead>
         <Tr>
-          {columns.map((title, i) => (
-            <Th key={i}>{title}</Th>
-          ))}
-          {Boolean(rowActions) && <Th />}
+          {hasIcons && <Th key="-1" />}
+          {standardizedColumns.map((column, columnIndex) => <Th key={columnIndex}>{column.heading}</Th>)}
+          {Boolean(rowActions || (onRowClick && rowActionName)) && <Th key="infinity" />}
         </Tr>
       </thead>
       <tbody>
-        {rows.length ? (
-          rows.map((row, i) => (
+        {data.length ? (
+          data.map((dataEntry, dataEntryIndex) => (
             <Tr
-              hover={Boolean(onRowClick)}
-              key={i}
+              hover={Boolean(data)}
+              key={dataEntryIndex}
               onClick={() => {
                 if (onRowClick) {
-                  onRowClick(row, i)
+                  onRowClick(dataEntry, dataEntryIndex)
                 }
               }}
             >
-              {row.map((data, j) => (
-                <Td key={j}>{data}</Td>
+              {hasIcons && (
+                <IconCell>
+                  {/** Because has `hasIcon`, it is guaranteed that the `icon` function exists */}
+                  <Icon name={icon!(dataEntry)} color={iconColor && iconColor(dataEntry)} />
+                </IconCell>
+              )}
+              {standardizedColumns.map((column, columnIndex) => (
+                <Td key={columnIndex}>{column.cell(dataEntry, dataEntryIndex)}</Td>
               ))}
               {rowActions && (
                 <Actions
@@ -115,9 +153,15 @@ const Table: React.SFC<TableProps> = ({ rows, columns, onRowClick, rowActions, .
                     ev.stopPropagation()
                   }}
                 >
-                  <InlineActionMenu items={rowActions[i]} />
+                  <InlineActionMenu items={rowActions(dataEntry)} />
                 </Actions>
               )}
+              {onRowClick &&
+                rowActionName && (
+                  <Actions>
+                    <ActionLabel>{rowActionName}</ActionLabel>
+                  </Actions>
+                )}
             </Tr>
           ))
         ) : (

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -11,10 +11,6 @@ export interface TableProps extends DefaultProps {
   /** Called on row click */
   onRowClick?: (row: Array<string | React.ReactNode>, index: number) => void
   /**
-   * Text to display on right on row hover
-   */
-  rowActionName?: string
-  /**
    * Add actions on the end of each row
    */
   rowActions?: Array<ActionMenuProps["items"]>
@@ -60,15 +56,6 @@ const Td = styled("td")(({ theme }) => ({
   },
 }))
 
-const Action = styled(Td)(({ theme }) => ({
-  textAlign: "right",
-  paddingRight: theme.space.content,
-  color: "transparent",
-  "tr:hover &, :hover": {
-    color: theme.color.text.action,
-  },
-}))
-
 const Actions = styled(Td)(({ theme }) => ({
   textAlign: "right",
   paddingRight: theme.space.small,
@@ -95,7 +82,7 @@ const EmptyView = styled(Td)(({ theme }) => ({
   textAlign: "center",
 }))
 
-const Table: React.SFC<TableProps> = ({ rows, columns, onRowClick, rowActionName, rowActions, ...props }) => {
+const Table: React.SFC<TableProps> = ({ rows, columns, onRowClick, rowActions, ...props }) => {
   return (
     <Container {...props}>
       <thead>
@@ -103,7 +90,7 @@ const Table: React.SFC<TableProps> = ({ rows, columns, onRowClick, rowActionName
           {columns.map((title, i) => (
             <Th key={i}>{title}</Th>
           ))}
-          {Boolean(rowActions || rowActionName) && <Th />}
+          {Boolean(rowActions) && <Th />}
         </Tr>
       </thead>
       <tbody>
@@ -121,7 +108,6 @@ const Table: React.SFC<TableProps> = ({ rows, columns, onRowClick, rowActionName
               {row.map((data, j) => (
                 <Td key={j}>{data}</Td>
               ))}
-              {rowActionName && <Action>{rowActionName}</Action>}
               {rowActions && (
                 <Actions
                   onClick={(ev: React.SyntheticEvent<Node>) => {

--- a/src/Table/__tests__/Table.test.tsx
+++ b/src/Table/__tests__/Table.test.tsx
@@ -7,7 +7,7 @@ const Table = wrapDefaultTheme(ThemelessTable)
 
 describe("Table Component", () => {
   it("Should render", () => {
-    const renderedComponent = render(<Table rows={[]} columns={[]} />)
+    const renderedComponent = render(<Table data={[]} columns={[]} />)
     expect(renderedComponent).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Adds an opinionated, `ActionMenu `-based table row actions solution, replacing `__experimentalRowActions` with `rowActions`. The API is the same as the `items` prop of `ActionMenu` so it should be familiar both on an API level and visually.

<img width="1093" alt="screen shot 2018-10-10 at 10 04 31 am" src="https://user-images.githubusercontent.com/6738398/46721950-a3223200-cc74-11e8-9678-33c7bcbe500a.png">

# Related issue

Fixes #766.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] Table actions work
- [x] Click propagation is stopped so that default row click events are not triggered 

Tester 1

- [x] Things look good on the demo.
- [x] No regressions on tables.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
- [ ] No regressions on tables.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
