### PR TITLE
**Feature:** Allow function for `Page.Confirm` actions button

### DIFF
--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -12,8 +12,8 @@ export interface ConfirmOptions<T> {
   title: React.ReactNode
   body: React.ReactNode | React.ComponentType<ConfirmBodyProps<T>>
   fullSize?: boolean
-  cancelButton?: React.ReactElement<ButtonProps>
-  actionButton?: React.ReactElement<ButtonProps>
+  cancelButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>)
+  actionButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>)
   onConfirm?: (confirmState: T) => void
   onCancel?: (confirmState: T) => void
   state?: T
@@ -105,12 +105,20 @@ export class Confirm<T> extends React.Component<Props, Readonly<State<T>>> {
               )}
             </ControlledModalContent>
             <Actions>
-              {React.cloneElement(cancelButton || <Button>Cancel</Button>, {
-                onClick: this.onCancelClick,
-              })}
-              {React.cloneElement(actionButton || <Button color="success">Confirm</Button>, {
-                onClick: this.onActionClick,
-              })}
+              {React.cloneElement(
+                typeof cancelButton === "function" ? cancelButton(state as T) : cancelButton || <Button>Cancel</Button>,
+                {
+                  onClick: this.onCancelClick,
+                },
+              )}
+              {React.cloneElement(
+                typeof actionButton === "function"
+                  ? actionButton(state as T)
+                  : actionButton || <Button color="success">Confirm</Button>,
+                {
+                  onClick: this.onActionClick,
+                },
+              )}
             </Actions>
           </ControlledModal>
         )}

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -555,7 +555,11 @@ const Tab = props => (
               </>
             ),
             cancelButton: <Button>Cancel</Button>,
-            actionButton: <Button color="primary">Confirm</Button>,
+            actionButton: state => (
+              <Button color="primary" disabled={state.var1 === "no"}>
+                Confirm
+              </Button>
+            ),
             onConfirm: state => alert(JSON.stringify(state, null, 2)),
           })
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export { default as Title } from "./Typography/Title"
 export { default as Small } from "./Typography/Small"
 
 // Internals components
-export { ConfirmBodyProps } from "./Internals/Confirm"
+export { ConfirmBodyProps, ConfirmOptions } from "./Internals/Confirm"
 export { Tab } from "./Internals/Tabs"
 
 // Utils


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

![image](https://user-images.githubusercontent.com/1761469/47114298-b710f980-d25b-11e8-9d75-91771575762e.png)

In order implement the previous screen, I need a simple way to disable the button regarding the `Confirm` state.

![da97593d-28de-461e-b2ce-427ef84cfdb9](https://user-images.githubusercontent.com/1761469/47114277-a791b080-d25b-11e8-8cfd-d944ac91aaa3.gif)


# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
- [x] I can give a function as `actionButton`
- [x] I can give a function as `cancelButton`
- [x] No breaking change is introduce
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->