### PR TITLE
**Fix:** regression on master with unterminated JSX

### DIFF
--- a/src/LabelText/LabelText.tsx
+++ b/src/LabelText/LabelText.tsx
@@ -1,7 +1,6 @@
-import * as React from "react"
 import styled from "../utils/styled"
 
-const StyledLabelText = styled("label")(({ theme }) => ({
+export const LabelText = styled("label")(({ theme }) => ({
   fontSize: theme.font.size.fineprint,
   display: "block",
   verticalAlign: "middle",
@@ -10,8 +9,6 @@ const StyledLabelText = styled("label")(({ theme }) => ({
   color: theme.color.text.lightest,
   height: labelTextHeight,
 }))
-
-export const LabelText: React.SFC = props => <StyledLabelText {...props} />
 
 export const labelTextHeight = 15
 

--- a/src/LabelText/LabelText.tsx
+++ b/src/LabelText/LabelText.tsx
@@ -1,8 +1,7 @@
-import styled from "react-emotion"
+import * as React from "react"
+import styled from "../utils/styled"
 
-export const labelTextHeight = 15
-
-export const LabelText = styled("label")(({ theme }) => ({
+const StyledLabelText = styled("label")(({ theme }) => ({
   fontSize: theme.font.size.fineprint,
   display: "block",
   verticalAlign: "middle",
@@ -11,3 +10,9 @@ export const LabelText = styled("label")(({ theme }) => ({
   color: theme.color.text.lightest,
   height: labelTextHeight,
 }))
+
+export const LabelText: React.SFC = props => <StyledLabelText {...props} />
+
+export const labelTextHeight = 15
+
+export default LabelText

--- a/src/LabelText/README.md
+++ b/src/LabelText/README.md
@@ -10,8 +10,12 @@ This component renders a semantic label tag. This is used internally in the foll
 ## Usage
 
 ```jsx
-<LabelText for="male">Male</LabelText>
-<input type="radio" name="gender" id="male" value="male"><br>
-<LabelText for="female">Female</LabelText>
-<input type="radio" name="gender" id="female" value="female"><br>
+<div>
+  <LabelText htmlFor="male">Male</LabelText>
+  <input type="radio" readOnly name="gender" id="male" value="male" />
+  <br />
+
+  <LabelText for="female">Female</LabelText>
+  <input checked type="radio" readOnly name="gender" id="female" value="female" />
+</div>
 ```


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
#777 came with a [less-than correct implementation](https://github.com/contiamo/operational-ui/pull/777/files#diff-a56badcb9c75fba223b860d0ade86398R14) that led to `LabelText` being unusable and broken examples on master. This PR fixes this.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#777

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
