### PR TITLE
**Fix:** splash typings

### DIFF
--- a/src/Splash/Splash.Logo.tsx
+++ b/src/Splash/Splash.Logo.tsx
@@ -3,7 +3,7 @@ import styled from "../utils/styled"
 
 interface Props {
   size: number
-  logo: React.ReactElement<any> | string | null
+  logo?: React.ReactElement<any> | string
   color?: string
 }
 


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fixing broken `Splash` typings where `React.ReactElement<any> | string | null` was conflicting with `React.ReactElement<any> | string | undefined`.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
