### PR TITLE
**Feature:** Page loading prop

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import Tabs, { Tab, tabsBarHeight } from "../Internals/Tabs"
 import PageArea from "../PageArea/PageArea"
 import PageContent, { PageContentProps } from "../PageContent/PageContent"
+import Progress from "../Progress/Progress"
 import { DefaultProps } from "../types"
 import { Title } from "../Typography/Title"
 import { readableTextColor } from "../utils"
@@ -20,6 +21,8 @@ export interface BaseProps extends DefaultProps {
   actionsPosition?: "start" | "main" | "end"
   /** A custom color for the page header color? */
   color?: keyof OperationalStyleConstants["color"] | string
+  /** Toggles a top progress bar to indicate loading state */
+  loading?: boolean
 }
 
 export interface PropsWithSimplePage extends BaseProps {
@@ -118,6 +121,13 @@ const ActionsContainer = styled("div")<{ actionPosition: PageProps["actionsPosit
   }),
 )
 
+const FixedProgress = styled(Progress)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+`
+
 const initialState = {}
 
 class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
@@ -187,9 +197,14 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
   }
 
   public render() {
-    const { tabs, fill, onTabChange, ...props } = this.props
+    const { tabs, fill, onTabChange, loading, ...props } = this.props
 
-    return <Container {...props}>{tabs ? this.renderPageWithTabs() : this.renderPageWithoutTabs()}</Container>
+    return (
+      <Container {...props}>
+        {loading && <FixedProgress />}
+        {tabs ? this.renderPageWithTabs() : this.renderPageWithoutTabs()}
+      </Container>
+    )
   }
 }
 


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Adding a `<Page loading />` prop that renders a progress bar going across the top of the page, removing the need for confusing and hard-to-distinguish progress bars that render right below the blue title area. Growing out of https://github.com/contiamo/pantheon-ui/blob/4eedff5bb2e8287fad7aa6c5f776f2ca82a68600/src/PantheonUI/components/Page.tsx.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
