### PR TITLE
**Feature:** Tree reordering

### DIFF
--- a/dev-server/index.tsx
+++ b/dev-server/index.tsx
@@ -8,12 +8,47 @@ import * as React from "react"
 import { render } from "react-dom"
 import OperationalUI, { Card, CardSection, Tree, TreeProps } from "../src"
 
-class Example extends React.Component<{}, {}> {
+export interface State {
+  courses: string[]
+}
+
+const remove = i => list => list.filter((_, j) => i !== j)
+
+class Example extends React.Component<{}, State> {
+  public readonly state: State = {
+    courses: ["apples", "oranges", "grapefruit"],
+  }
+
   public render() {
     return (
       <OperationalUI>
         <div style={{ width: 600, height: 300, margin: 20 }}>
-          <Card title="A simple card" />
+          <Card>
+            <Tree
+              trees={this.state.courses.map(course => ({
+                label: course,
+                tag: "X",
+                childNodes: [],
+              }))}
+              onReorder={(source, target) => {
+                const sourceIndex = source[0]
+                const targetIndex = target[0]
+
+                let newCourses
+
+                if (targetIndex === this.state.courses.length) {
+                  newCourses = [...remove(sourceIndex)(this.state.courses), this.state.courses[sourceIndex]]
+                } else {
+                  newCourses = [...this.state.courses]
+                  const swap = newCourses[sourceIndex]
+                  newCourses[sourceIndex] = newCourses[targetIndex]
+                  newCourses[targetIndex] = swap
+                }
+
+                this.setState(() => ({ courses: newCourses }))
+              }}
+            />
+          </Card>
         </div>
       </OperationalUI>
     )

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -53,3 +53,48 @@ The tree component renders a tree structure with collapsable nodes in a filetree
   ]}
 />
 ```
+
+### Reordering
+
+Tree items can be reordered using drag-and-drop. The API for this feature is low-level and assumes that the tree nodes are generated from data available in a different shape in state, making it dangerous and error-prone to update based on a readily reordered set of nodes.
+
+Instead, it provides the paths of the source and target where the nodes are inserted. The client would have to do the actual state update themselves, which is fairly straightforward for a simple flat list, and doable for more complicated use-cases (beware of edge cases).
+
+In the future, this library may provide helpers or sample code to deal with reordering with less boilerplate.
+
+```jsx
+initialState = {
+  courses: ["Appetizer", "Soup", "Spaghetti", "Cake"],
+}
+
+const remove = i => list => list.filter((_, j) => i !== j)
+;<Tree
+  trees={state.courses.map(course => ({
+    tag: "C",
+    label: course,
+    childNodes: [],
+  }))}
+  onReorder={(source, target) => {
+    const sourceIndex = source[0]
+    const targetIndex = target[0]
+
+    /**
+     * The following logic swaps the entries at source and target, catering to an edge case where the element is dragged
+     * to the end of the list. This logic is for illustration purposes only, and needs a bit more work in order to replicate
+     * similar behavior in tools like Photoshop.
+     */
+    let newCourses
+
+    if (targetIndex === state.courses.length) {
+      newCourses = [...remove(sourceIndex)(state.courses), state.courses[sourceIndex]]
+    } else {
+      newCourses = [...state.courses]
+      const swap = newCourses[sourceIndex]
+      newCourses[sourceIndex] = newCourses[targetIndex]
+      newCourses[targetIndex] = swap
+    }
+
+    setState(() => ({ courses: newCourses }))
+  }}
+/>
+```

--- a/src/Tree/Tree.utils.ts
+++ b/src/Tree/Tree.utils.ts
@@ -1,6 +1,6 @@
 import { Tree } from "./Tree.types"
 
-const arePathsEqual = (path1: number[], path2: number[]) => path1.join("-") === path2.join("-")
+export const arePathsEqual = (path1: number[], path2: number[]) => path1.join("-") === path2.join("-")
 
 /**
  * Returns the largest element of an array of numbers, or undefined if the array is empty.


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Adds reordering capabilities to trees:

![swap](https://user-images.githubusercontent.com/6738398/47505367-517dc800-d86e-11e8-923c-03a8ea27a4be.gif)

READ THIS FIRST - the implementation is a bit dense, might be helpful to read this example first:

```js
<Tree
  trees={[
    {
      label: "apples",
      childNodes: []
    },
    {
      label: "oranges",
      childNodes: []
    },
  ]}
  onReorder={(source, target) => console.log(source, target)}
/>
```

What will happen when I play with this?
- if I move "apples" over "oranges", it logs `[ 0 ]` and `[ 1 ]`, indicating that I dragged the 0th child onto the 1st, which would add apples on top of oranges, hence it would stay in place. This is a bit lame for a 2-member list, but for any realistic situation is very predictable, and there is a large wiggle room in which the node can move around and find a destination easily. This is an attempt to improve on the behavior in tools like sketch or adobe XD, although we should stress-test it to make sure it's not too off-the-beaten-path.
- if I move "apples" to the end of the list, it logs `[ 0 ]` and `[ 2 ]`, indicating that I dragged over a fictitious 3rd node above which the node shall be inserted, the result of which would be that apples and oranges will reverse.

Reordering itself has to be done by the client based on these indices, I outlined why I went with this behavior in the component's readme.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
