### PR TITLE
Website performance

### DIFF
--- a/styleguide/ReactComponentRenderer.tsx
+++ b/styleguide/ReactComponentRenderer.tsx
@@ -20,10 +20,10 @@ const ReactComponentRenderer: React.SFC<ReactComponentRendererProps> = ({
   tabBody,
 }) => (
   <Consumer>
-    {({ updateActiveComponent }) => (
+    {({ activeComponent, updateActiveComponent }) => (
       <Waypoint
-        topOffset="0"
-        bottomOffset="95%"
+        topOffset="20%"
+        bottomOffset="80%"
         onPositionChange={({ currentPosition }: { currentPosition: "inside" | "outside" }) => {
           if (currentPosition !== "inside") {
             return
@@ -35,7 +35,16 @@ const ReactComponentRenderer: React.SFC<ReactComponentRendererProps> = ({
           {heading} {/* See ./SectionHeadingRenderer.tsx */}
           {tabButtons}
           <div style={{ marginTop: 16 }}>{tabBody}</div>
-          {examples}
+          <div
+            style={{
+              border: "2px solid #F5F5F5",
+              padding: 20,
+              height: 400,
+              overflow: activeComponent === name ? "auto" : "hidden",
+            }}
+          >
+            {activeComponent === name && examples}
+          </div>
         </Card>
       </Waypoint>
     )}

--- a/styleguide/StyleGuideRenderer.tsx
+++ b/styleguide/StyleGuideRenderer.tsx
@@ -30,6 +30,10 @@ const { version } = require("../package.json")
 injectGlobal({
   "#rsg-root": {
     height: "100vh",
+    overflow: "hidden",
+  },
+  "#rsg-root > div": {
+    overflow: "hidden",
   },
   // buttons style override
   [`[class^="rsg--controls-"]`]: {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fixes the 3s reload an the jumpiness of the website by not rendering examples if sections are out of view. Comes with the tradeoff of fixing the height of the examples section, but at least the navigation is sane and the fix is quick. We can build on top of this in the future.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
