### PR TITLE
**Fix:** Remove lodash uuid from Checkbox.tsx #789

### DIFF
--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -94,9 +94,10 @@ export interface CheckboxProps {
 }
 
 const Checkbox: React.SFC<CheckboxProps> = ({ value, onChange, label, disabled }) => {
-  const uuid = Math.random()
+  const uuid = `checkbox_${Math.random()
     .toString(36)
-    .slice(2)
+    .slice(2)}`
+
   return (
     <div style={disabled ? { opacity: 0.6 } : {}}>
       <Input id={uuid} type="checkbox" checked={Boolean(value)} onChange={() => onChange(!value)} disabled={disabled} />

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,4 +1,3 @@
-import uniqueId from "lodash/uniqueId"
 import * as React from "react"
 import { keyframes } from "react-emotion"
 
@@ -94,25 +93,16 @@ export interface CheckboxProps {
   disabled?: boolean
 }
 
-class Checkbox extends React.Component<CheckboxProps> {
-  private uuid = uniqueId("checkbox_")
-
-  public render() {
-    const { value, onChange, label, disabled } = this.props
-
-    return (
-      <div style={disabled ? { opacity: 0.6 } : {}}>
-        <Input
-          id={this.uuid}
-          type="checkbox"
-          checked={Boolean(value)}
-          onChange={() => onChange(!value)}
-          disabled={disabled}
-        />
-        <Label htmlFor={this.uuid}>{label}</Label>
-      </div>
-    )
-  }
+const Checkbox: React.SFC<CheckboxProps> = ({ value, onChange, label, disabled }) => {
+  const uuid = Math.random()
+    .toString(36)
+    .slice(2)
+  return (
+    <div style={disabled ? { opacity: 0.6 } : {}}>
+      <Input id={uuid} type="checkbox" checked={Boolean(value)} onChange={() => onChange(!value)} disabled={disabled} />
+      <Label htmlFor={uuid}>{label}</Label>
+    </div>
+  )
 }
 
 export default Checkbox


### PR DESCRIPTION
Summary

1.  Remove lodash/uuid from Checkbox.tsx
2.  Convert Checkbox.tsx to dumb component

After this PR remove lodash from:

https://github.com/contiamo/operational-ui/blob/8c0d472a09a8f56d5fa57e1add31a299e0e341a5/src/utils/constants.ts#L217

https://github.com/contiamo/operational-ui/blob/8c0d472a09a8f56d5fa57e1add31a299e0e341a5/src/ContextMenu/ContextMenu.tsx#L131

And from `OperationalUI`

https://github.com/contiamo/operational-ui/blob/8c0d472a09a8f56d5fa57e1add31a299e0e341a5/src/OperationalUI/OperationalUI.tsx#L3

https://github.com/contiamo/operational-ui/blob/8c0d472a09a8f56d5fa57e1add31a299e0e341a5/src/OperationalUI/OperationalUI.tsx#L4

https://github.com/contiamo/operational-ui/blob/8c0d472a09a8f56d5fa57e1add31a299e0e341a5/src/OperationalUI/OperationalUI.tsx#L5

