### PR TITLE
 **Breaking:** Making page prop non-optional.

### DIFF
--- a/src/Paginator/Paginator.tsx
+++ b/src/Paginator/Paginator.tsx
@@ -1,5 +1,3 @@
-let isUserWarnedAboutDeprecation = false
-
 import * as React from "react"
 
 import Button from "../Button/Button"
@@ -11,7 +9,7 @@ export interface PaginatorProps extends DefaultProps {
   /** Function to be executed after changing page */
   onChange?: (page: PaginatorProps["page"]) => void
   /** Index of the current selected page */
-  page?: number
+  page: number
   /** Total number of items */
   itemCount: number
   /** Number of items per page */
@@ -76,7 +74,7 @@ const PaginatorControl = ({ children, itemCount, itemsPerPage, page, onChange, t
   )
 }
 
-const getRange = ({ itemCount, itemsPerPage, page }: PaginatorProps & { page: number }) => {
+const getRange = ({ page, itemCount, itemsPerPage }: PaginatorProps) => {
   const start = 1 + (page - 1) * itemsPerPage
   const end = Math.min(itemCount, page * itemsPerPage)
   return `${start}-${end}`
@@ -89,23 +87,7 @@ const Container = styled("div")(({ theme }) => ({
   alignItems: "center",
 }))
 
-const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page: explicitPage, onChange, ...props }) => {
-  const page: number = explicitPage || 1
-
-  if (!explicitPage && !isUserWarnedAboutDeprecation && process.env.NODE_ENV !== "production") {
-    isUserWarnedAboutDeprecation = true
-    /**
-     * @todo remove this in v12.
-     */
-    console.warn(`[operational-ui]: Deprecation Warning
--------------------------------------
-
-<Paginator />'s page prop is now _mandatory_, meaning in the next major
-release, your code (if TypeScript) will not compile. Please add an explicit
-\`page\` prop to your Paginator if you'd like to stay up to date.
-
-Issue: https://github.com/contiamo/operational-ui/pull/820`)
-  }
+const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page, onChange, ...props }) => {
 
   const controlProps = {
     itemCount,


### PR DESCRIPTION
# Summary
   making "page" parameter non-optional in PaginatorProps

<!-- Some context about this PR: screenshots and links to the docs are appreciated -->
The motivation for this change is the decrease in the cognitive load  for :
the users:
  In case if the page was not specified user had to read the source code or the doc of the component 
  to be sure that it takes page 1 by default

and maintainers:
  removed Paginator.defaultProps
  removed unsafe '!' operators from the code

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
