### PR TITLE
*Feature:* Improve the pushMessage stacking

### DIFF
--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -234,15 +234,16 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
   }
 
   private pushMessage = (message: IMessage) => {
-    this.setState(prevState => {
-      const previousMessageWithSamePayload = prevState.messages.find(
-        m => m.message.body === message.body && m.message.type === message.type,
-      )
+    const hasSamePayload = (m: { message: IMessage }) =>
+      m.message.body === message.body && m.message.type === message.type
 
-      if (previousMessageWithSamePayload) {
+    this.setState(prevState => {
+      const hasPreviousMessageWithSamePayload = Boolean(prevState.messages.find(hasSamePayload))
+
+      if (hasPreviousMessageWithSamePayload) {
         return {
           messages: prevState.messages.map(m => {
-            if (m.message.body === message.body && m.message.type === message.type) {
+            if (hasSamePayload(m)) {
               return { ...m, addedAt: new Date().getTime(), count: m.count + 1 }
             } else {
               return m


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

In operational-ui, we have a nice pushMessage that stacks our errors in the corner of the screen.

Actually, if we have a lot of errors (as 500 on polling) it's not really userfriendly and quite paintful to dismiss the stack.

The idea is to introduce a `count`, so if we have the same error, again and again, we will have `(20) Error - oh no` instead of a stack of 20 messages

## Demo
![a59fc615-bec5-4cff-9988-da941df43821](https://user-images.githubusercontent.com/1761469/48061505-77d12b00-e1bf-11e8-85c5-1ea56aebf8e8.gif)

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->


# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
