### PR TITLE
**Feature:** Allow image to be a react node on List

### DIFF
--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -4,10 +4,12 @@ import Icon from "../Icon/Icon"
 import Body from "../Typography/Body"
 import styled from "../utils/styled"
 
+export type ImageURL = string
+
 export interface ListProps {
   items: Array<{
     title?: string
-    photo: string | React.ReactNode
+    photo: ImageURL | React.ReactNode
     description: string
     onClick?: () => void
   }>
@@ -21,6 +23,7 @@ const Container = styled("div")<{ fullWidth: ListProps["fullWidth"]; onClick: Li
   border: 1px solid ${({ theme }) => theme.color.border.disabled};
   width: ${({ fullWidth }) => (fullWidth ? "100%" : "640px")};
   cursor: ${({ onClick }) => (onClick ? "pointer" : "initial")};
+  background-color: ${({ theme }) => theme.color.white};
 
   :hover {
     background-color: ${({ theme }) => theme.color.background.lighter};
@@ -49,6 +52,11 @@ const StyledIcon = styled(Icon)`
   justify-self: flex-end;
 `
 
+const BodyText = styled(Body)`
+  margin: 0;
+  margin-right: ${({ theme }) => theme.space.content}px;
+`
+
 const List: React.SFC<ListProps> = ({ items, fullWidth }) => (
   <>
     {items.map(({ title, photo, description, onClick }, index) => (
@@ -58,7 +66,7 @@ const List: React.SFC<ListProps> = ({ items, fullWidth }) => (
             {typeof photo === "string" ? <img alt={title || description} src={photo} /> : photo}
           </ImageContainer>
         )}
-        <Body style={{ margin: 0 }}>{description}</Body>
+        <BodyText>{description}</BodyText>
         {onClick && <StyledIcon right size={21} name="ChevronRight" />}
       </Container>
     ))}

--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -7,7 +7,7 @@ import styled from "../utils/styled"
 export interface ListProps {
   items: Array<{
     title?: string
-    photo: string
+    photo: string | React.ReactNode
     description: string
     onClick?: () => void
   }>
@@ -55,7 +55,7 @@ const List: React.SFC<ListProps> = ({ items, fullWidth }) => (
       <Container onClick={onClick} fullWidth={fullWidth} key={index}>
         {photo && (
           <ImageContainer>
-            <img alt={title || description} src={photo} />
+            {typeof photo === "string" ? <img alt={title || description} src={photo} /> : photo}
           </ImageContainer>
         )}
         <Body style={{ margin: 0 }}>{description}</Body>

--- a/src/List/README.md
+++ b/src/List/README.md
@@ -24,3 +24,24 @@ This component renders a navigable list.
   ]}
 />
 ```
+
+## With Icon
+
+```jsx
+<List
+  items={[
+    {
+      photo: <Logo color="black" name="Pantheon" />,
+      description:
+        "Pantheon is a data hub that integrates with your existing data landscape and provides a central point of access for business, data science and operational use.",
+      onClick: () => goToStep("next"),
+    },
+    {
+      photo: <Logo color="black" name="Labs" />,
+      description:
+        "Labs is a flexible, consistent, and simple data science environment enabling data scientists to seamlessly explore data and deploy models.",
+      onClick: () => alert("You chose the second item!"),
+    },
+  ]}
+/>
+```


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
It would be nicer to be able to pass an `<img />` into `List`. This PR proposes an update to the props to allow either a string (an image URL), or a ReactNode.

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
