### PR TITLE
**Fix:** Adjust page width in extreme overflow cases

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -121,7 +121,9 @@ const Container = styled("div")(({ theme }) => ({
 const Content = styled("div")<{ fullSize?: boolean }>`
   padding: ${({ theme }) => theme.space.element}px;
   height: ${props => (props.fullSize ? "100%" : "auto")};
-  overflow: auto;
+  white-space: pre-wrap;
+  word-wrap: break-all;
+  hyphens: auto;
 `
 
 const SectionsContainer = styled("div")<{ stackHorizontal: boolean }>`

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -106,6 +106,7 @@ const Container = styled("div")(({ theme }) => ({
   boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.16)",
   backgroundColor: theme.color.white,
   wordWrap: "break-word",
+  wordBreak: "break-all",
   "& > img": {
     maxWidth: "100%",
   },

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -120,7 +120,8 @@ const Container = styled("div")(({ theme }) => ({
 
 const Content = styled("div")<{ fullSize?: boolean }>`
   padding: ${({ theme }) => theme.space.element}px;
-  ${props => (props.fullSize ? "height: 100%" : "")};
+  height: ${props => (props.fullSize ? "100%" : "auto")};
+  overflow: auto;
 `
 
 const SectionsContainer = styled("div")<{ stackHorizontal: boolean }>`

--- a/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Card Should render 1`] = `
     class="css-ar73w8-Messages"
   />
   <div
-    class="css-13aykpc"
+    class="css-1wstrtr"
   >
     <div
       class="css-dj0vfm"

--- a/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Card Should render 1`] = `
     class="css-13aykpc"
   >
     <div
-      class="css-11kcwvm"
+      class="css-oc0wil"
     >
       hi
     </div>

--- a/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Card Should render 1`] = `
     class="css-13aykpc"
   >
     <div
-      class="css-oc0wil"
+      class="css-dj0vfm"
     >
       hi
     </div>

--- a/src/Code/Code.tsx
+++ b/src/Code/Code.tsx
@@ -114,6 +114,9 @@ const Container = styled("div")`
     flex: 1;
     display: flex;
     margin: 0;
+    word-break: break-all;
+    hyphens: auto;
+    white-space: initial;
   }
 
   code {

--- a/src/Code/Code.tsx
+++ b/src/Code/Code.tsx
@@ -116,7 +116,7 @@ const Container = styled("div")`
     margin: 0;
     word-break: break-all;
     hyphens: auto;
-    white-space: initial;
+    white-space: pre-wrap;
   }
 
   code {

--- a/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
+++ b/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Code Should render 1`] = `
     class="css-ar73w8-Messages"
   />
   <div
-    class="css-b8lpfz"
+    class="css-z3yyzs"
   >
     <div
       class="react-json-view"

--- a/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
+++ b/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Code Should render 1`] = `
     class="css-ar73w8-Messages"
   />
   <div
-    class="css-pnm2qv"
+    class="css-b8lpfz"
   >
     <div
       class="react-json-view"

--- a/src/LabelText/README.md
+++ b/src/LabelText/README.md
@@ -15,7 +15,7 @@ This component renders a semantic label tag. This is used internally in the foll
   <input type="radio" readOnly name="gender" id="male" value="male" />
   <br />
 
-  <LabelText for="female">Female</LabelText>
+  <LabelText htmlFor="female">Female</LabelText>
   <input checked type="radio" readOnly name="gender" id="female" value="female" />
 </div>
 ```

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -41,9 +41,20 @@ Here's a case where children are too long. The card has a _hard_ max-width set t
 ```jsx
 <Page title="My Page">
   <Card title="Hello">
-    <Code>
-      HelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHello
-    </Code>
+    <CardColumns>
+      <CardColumn title="Really Friendly Code">
+        <Code>
+          HelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHello
+        </Code>
+      </CardColumn>
+    </CardColumns>
+    <CardColumns>
+      <CardColumn title="Kinda funny">
+        {Array(1000)
+          .fill("LOL")
+          .join("")}
+      </CardColumn>
+    </CardColumns>
   </Card>
 </Page>
 ```

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -34,7 +34,21 @@ Here's a page with a different color:
 </Page>
 ```
 
-### Properly handles grid rows
+### Long Children
+
+Here's a case where children are too long. The card has a _hard_ max-width set to its grid area, and any text children are hyphenated.
+
+```jsx
+<Page title="My Page">
+  <Card title="Hello">
+    <Code>
+      HelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHello
+    </Code>
+  </Card>
+</Page>
+```
+
+### Properly handled grid rows
 
 Here is a simple usage example:
 

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -21,12 +21,10 @@ export interface PageContentProps extends DefaultProps {
 const sideSize = 280
 
 const StyledPageContent = styled("div")<{ areas?: PageContentProps["areas"]; fill_?: boolean }>(props => {
-  const longColumnWidth = props.fill_ ? "auto" : `calc(100% - ${sideSize - props.theme.space.element}px)`
-
   const gridTemplateColumns = {
-    main: props.fill_ ? "100%" : "1150px",
-    "main side": `${longColumnWidth} ${sideSize}px`,
-    "side main": `${sideSize}px ${longColumnWidth}`,
+    main: props.fill_ ? "100%" : "auto",
+    "main side": `auto ${sideSize}px`,
+    "side main": `${sideSize}px auto`,
   }[props.areas || "main"]
 
   return {

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -20,9 +20,9 @@ export interface PageContentProps extends DefaultProps {
 
 const StyledPageContent = styled("div")<{ areas?: PageContentProps["areas"]; fill_?: boolean }>(props => {
   const gridTemplateColumns = {
-    main: "auto",
-    "main side": "auto 280px",
-    "side main": "280px auto",
+    main: "100%",
+    "main side": "100% 280px",
+    "side main": "280px 100%",
   }[props.areas || "main"]
 
   return {

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -18,18 +18,22 @@ export interface PageContentProps extends DefaultProps {
   fill?: boolean
 }
 
+const sideSize = 280
+
 const StyledPageContent = styled("div")<{ areas?: PageContentProps["areas"]; fill_?: boolean }>(props => {
+  const longColumnWidth = props.fill_ ? "auto" : `calc(100% - ${sideSize - props.theme.space.element}px)`
+
   const gridTemplateColumns = {
-    main: "100%",
-    "main side": "100% 280px",
-    "side main": "280px 100%",
+    main: props.fill_ ? "100%" : "1150px",
+    "main side": `${longColumnWidth} ${sideSize}px`,
+    "side main": `${sideSize}px ${longColumnWidth}`,
   }[props.areas || "main"]
 
   return {
     gridTemplateColumns,
     display: "grid",
     alignItems: "start",
-    gridTemplateAreas: `"${props.areas}"`,
+    gridTemplateAreas: `"${props.areas || "main"}"`,
     gridGap: props.theme.space.element,
     width: "100%",
     height: "100%",


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR is a proposed addressal of #810 that correctly deals with long children of a given `Card` on a `Page`.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#810 

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
