### PR TITLE
**Fix:** Set Select height to Input height

### DIFF
--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
+import { inputHeight } from "../Input/Input"
 import { LabelText } from "../LabelText/LabelText"
 import { floatIn, keyCodes, readableTextColor, resetTransform } from "../utils"
 import { expandColor } from "../utils/constants"
@@ -64,7 +65,7 @@ const Container = styled("div")<Partial<SelectProps>>(({ theme, color, disabled,
     borderRadius: 4,
     width: "fit-content",
     minWidth: !naked ? 240 : "none",
-    minHeight: 20,
+    minHeight: inputHeight,
     border: naked ? 0 : "1px solid",
     borderColor: theme.color.border.default,
     opacity: disabled ? 0.5 : 1,

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
-import { inputHeight } from "../Input/Input"
+import { height as inputHeight } from "../Input/Input.constants"
 import { LabelText } from "../LabelText/LabelText"
 import { floatIn, keyCodes, readableTextColor, resetTransform } from "../utils"
 import { expandColor } from "../utils/constants"

--- a/src/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Select Should render correctly 1`] = `
     class="css-ar73w8-Messages"
   />
   <div
-    class="css-2xp493-select"
+    class="css-ttbq55-select"
     placeholder="Select me"
     role="listbox"
     tabindex="-2"


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
There is a bit of a height deviation on `Select` where it is _not_ currently uniform with `Input` and `DatePicker`. This PR fixes this.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
