### PR TITLE
**Fix:** Support Layout cases where Page has no title

### DIFF
--- a/src/Layout/README.md
+++ b/src/Layout/README.md
@@ -210,6 +210,215 @@ Revealing the layers to my soul
 </div>
 ```
 
+### Without a Page Title
+
+This is an example of a basic layout _without_ a page title. Content at the bottom should be correctly visible.
+
+```jsx
+const sidebar = (
+  <Sidenav>
+    <SidenavHeader condensed icon="Home" label="Project Home" />
+    <SidenavHeader label="The Prize" active>
+      <SidenavItem label="The First Prize" icon="Settings" />
+      <SidenavItem label="The Second Prize" icon="Settings" />
+      <SidenavItem label="The Third Prize" icon="Settings" />
+    </SidenavHeader>
+    <SidenavHeader label="Let It Snow" active>
+      <SidenavItem label="The First Prize" icon="Settings" />
+      <SidenavItem label="The Second Prize" icon="Settings" />
+      <SidenavItem label="The Third Prize" icon="Settings" />
+    </SidenavHeader>
+    <SidenavHeader label="Let It Snow" active>
+      <SidenavItem label="The First Prize" icon="Settings" />
+      <SidenavItem label="The Second Prize" icon="Settings" />
+      <SidenavItem label="The Third Prize" icon="Settings" />
+    </SidenavHeader>
+  </Sidenav>
+)
+
+// Container must set the height explicitly.
+// This component will set height to 100%.
+;<div style={{ height: 600 }}>
+  <Layout
+    sidenav={sidebar}
+    header={
+      <HeaderBar
+        logo={<Logo name="Contiamo" />}
+        main={
+          <HeaderMenu
+            withCaret
+            items={[
+              { key: "project1", label: "Project 1" },
+              { key: "project2", label: "Project 2" },
+              { key: "project3", label: "Project 3" },
+            ]}
+          >
+            Project 1
+          </HeaderMenu>
+        }
+        end={
+          <HeaderMenu
+            items={[{ key: "account", label: "My account" }, { key: "log-out", label: "Log out" }]}
+            align="right"
+          >
+            Imogen Mason <Avatar name="Imogen Mason" />
+          </HeaderMenu>
+        }
+      />
+    }
+    main={
+      <Page
+        actions={
+          <Button condensed color="ghost">
+            Help
+          </Button>
+        }
+      >
+        {({ confirm, modal }) => (
+          <>
+            {Array(10)
+              .fill("Hello!!!!")
+              .map((value, i) => (
+                <Card key={i}>{value}</Card>
+              ))}
+
+            <Card title="Partial Kanye Lyrics">
+              <div>
+                <Button
+                  color="#314865"
+                  textColor="#2bda64"
+                  onClick={() => {
+                    confirm({
+                      title: "Yikes",
+                      body: (
+                        <Form>
+                          <Body>You can only add users who are already in your organization.</Body>
+                          <Autocomplete
+                            onResultClick={result => alert("Thanks for choosing " + result.label)}
+                            value="Click me for results..."
+                            results={[
+                              { label: "Tweakin', tweakin' off that 2CB, huh?" },
+                              { label: "Is he gon' make it? TBD, huh" },
+                              { label: "Thought I was gon' run, DMC, huh?" },
+                              { label: "I done died and lived again on DMT, huh" },
+                            ]}
+                            fullWidth
+                            label="Sometimes I scare myself, myself"
+                          />
+                        </Form>
+                      ),
+                    })
+                  }}
+                >
+                  Open a Confirm
+                </Button>
+                <Button
+                  color="#f89663"
+                  onClick={() => {
+                    confirm({
+                      fullSize: true,
+                      title: "Waves",
+                      body: `Turn it up!
+Waves don't die
+Let me crash here for the moment
+I don't need to own it
+No lie
+Waves don't die
+Let me crash here for a moment
+I don't, I don't need to own...
+Sun don't shine in the shade (turn it up!)
+Bird can't fly in a cage (turn it up!)
+Even when somebody go away (turn it up!)
+The feelings don't really go away
+That's just the wave (yeah)`
+                        .split("\n")
+                        .map(line => (
+                          <>
+                            {line}
+                            <br />
+                          </>
+                        )),
+                    })
+                  }}
+                >
+                  Open a full-size Confirm
+                </Button>
+                <Button
+                  color="#613f90"
+                  textColor="#fb059e"
+                  onClick={() => {
+                    modal({
+                      title: "Stronger",
+                      body: `N-now th-that that don't kill me
+Can only make me stronger
+I need you to hurry up now
+'Cause I can't wait much longer
+I know I got to be right now
+'Cause I can't get much wronger
+Man I've been waiting all night now
+That's how long I been on ya
+I need you right now
+Let's get lost tonight`
+                        .split("\n")
+                        .map(line => (
+                          <>
+                            {line}
+                            <br />
+                          </>
+                        )),
+                    })
+                  }}
+                >
+                  Open a Modal
+                </Button>
+                <Button
+                  color="#f89663"
+                  onClick={() => {
+                    modal({
+                      fullSize: true,
+                      title: "FML",
+                      body: `I been waiting for a minute
+For my lady
+I been living without limits
+As far as my business
+I'm the only one that's in control
+I been feeling all I've given
+For my children
+I will die for those I love
+
+God, I'm willing
+To make this my mission
+Give up the women
+Before I lose half of what I own
+I been thinking
+About my vision
+Pour out my feelings
+Revealing the layers to my soul, my soul
+The layers to my soul
+Revealing the layers to my soul
+`
+                        .split("\n")
+                        .map(line => (
+                          <>
+                            {line}
+                            <br />
+                          </>
+                        )),
+                    })
+                  }}
+                >
+                  Open a full-size Modal
+                </Button>
+              </div>
+            </Card>
+          </>
+        )}
+      </Page>
+    }
+  />
+</div>
+```
+
 ### Example with Compact Sidenav
 
 ```jsx

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -92,12 +92,15 @@ const TitleContainer = styled("div")(({ theme }) => ({
   fontWeight: theme.font.weight.medium,
 }))
 
-const ViewContainer = styled("div")<{ isInTab?: boolean; isTitleCondensed?: boolean }>(
-  ({ theme, isInTab, isTitleCondensed }) => ({
-    height: `calc(100% - ${isInTab && !isTitleCondensed ? theme.titleHeight + tabsBarHeight : theme.titleHeight}px)`,
-    overflow: "hidden",
-    position: "relative",
-  }),
+const ViewContainer = styled("div")<{ isInTab?: boolean; isTitleCondensed?: boolean; hasTitle?: boolean }>(
+  ({ theme, isInTab, isTitleCondensed, hasTitle }) => {
+    const calculatedTitleOffset = isInTab && !isTitleCondensed ? theme.titleHeight + tabsBarHeight : theme.titleHeight
+    return {
+      height: hasTitle ? `calc(100% - ${calculatedTitleOffset}px)` : "100%",
+      overflow: "hidden",
+      position: "relative",
+    }
+  },
 )
 
 const ActionsContainer = styled("div")<{ actionPosition: PageProps["actionsPosition"] }>(
@@ -162,7 +165,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
                 {!condensedTitle && tabsBar}
               </TitleBar>
             )}
-            <ViewContainer isInTab isTitleCondensed={condensedTitle}>
+            <ViewContainer isInTab isTitleCondensed={condensedTitle} hasTitle={Boolean(title)}>
               {activeChildren}
             </ViewContainer>
           </>
@@ -184,7 +187,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
             </TitleContainer>
           </TitleBar>
         )}
-        <ViewContainer>
+        <ViewContainer hasTitle={Boolean(title)}>
           <PageContent areas={areas} fill={fill}>
             {modalConfirmContext => {
               const resolvedChildren = typeof children === "function" ? children(modalConfirmContext) : children


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR adds support to `Layout` and `Page` where children are correctly spaced when `Page` has no given `title` prop.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#834 

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
