### PR TITLE
**Fix:** Refactor Input component

### DIFF
--- a/src/Input/Input.Button.tsx
+++ b/src/Input/Input.Button.tsx
@@ -1,0 +1,73 @@
+import * as React from "react"
+import CopyToClipboard from "react-copy-to-clipboard"
+
+import Icon, { IconName } from "../Icon/Icon"
+import OperationalContext from "../OperationalContext/OperationalContext.init"
+import styled from "../utils/styled"
+import { height } from "./Input.constants"
+
+interface InputButtonBaseProps {
+  onIconClick?: () => void
+}
+
+interface InputButtonPropsWithoutCopy extends InputButtonBaseProps {
+  copy: false
+  icon: React.ReactNode | IconName
+  value?: never
+}
+
+interface InputButtonPropsWithCopy extends InputButtonBaseProps {
+  copy: true
+  icon?: never
+  value: string
+}
+
+export type InputButtonProps = InputButtonPropsWithoutCopy | InputButtonPropsWithCopy
+
+const Button = styled("div")`
+  width: ${height}px;
+  /** Makes sure the button doesn't shrink when inside a flex container */
+  flex: 0 0 ${height}px;
+  height: ${height}px;
+  top: 0px;
+  left: 0px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  ${({ theme }) => `
+    background-color: ${theme.color.background.lighter};
+    border-top-left-radius: ${theme.borderRadius}px;
+    border-bottom-left-radius: ${theme.borderRadius}px;
+    border: 1px solid;
+    border-color: ${theme.color.border.default};
+    color: ${theme.color.text.light};
+    &:hover {
+      background-color: ${theme.color.background.light};
+    }
+  `};
+`
+
+const InputButton: React.SFC<InputButtonProps> = ({ icon, copy, value, onIconClick }) => {
+  if (!icon && !copy) {
+    return null
+  }
+
+  return copy === true ? (
+    <OperationalContext>
+      {({ pushMessage }) => (
+        <CopyToClipboard text={value || ""} onCopy={() => pushMessage({ body: "Copied to clipboard", type: "info" })}>
+          <Button>
+            <Icon name="Copy" size={16} />
+          </Button>
+        </CopyToClipboard>
+      )}
+    </OperationalContext>
+  ) : (
+    <Button onClick={onIconClick}>
+      {typeof icon === "string" ? <Icon name={icon as IconName} size={16} /> : icon}
+    </Button>
+  )
+}
+
+export default InputButton

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -1,0 +1,169 @@
+import * as React from "react"
+
+import Icon from "../Icon/Icon"
+import { FormFieldError, inputFocus, setAlpha } from "../utils"
+import styled from "../utils/styled"
+import { InputProps } from "./Input"
+import InputButton from "./Input.Button"
+import { height } from "./Input.constants"
+
+const width = 360
+
+const Container = styled("div")<{
+  fullWidth: InputProps["fullWidth"]
+  withLabel?: boolean
+}>`
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  ${({ fullWidth, withLabel, theme }) => `
+      margin-right: ${withLabel ? 0 : theme.space.small}px;
+      display: ${withLabel ? "flex" : "inline-flex"};
+      width: 100%;
+      max-width: ${fullWidth ? "none" : `${width}px`};
+    `};
+`
+
+const Field = styled("input")<{
+  isError: boolean
+  withIconButton: boolean
+  preset: InputProps["preset"]
+  disabled: InputProps["disabled"]
+  clear: InputProps["clear"]
+}>(({ theme, disabled, isError, withIconButton, preset, clear }) => {
+  const makeBackgroundColor = () => {
+    if (disabled) {
+      return theme.color.disabled
+    }
+
+    if (preset) {
+      return setAlpha(0.1)(theme.color.primary)
+    }
+
+    return theme.color.white
+  }
+
+  return {
+    ...(withIconButton
+      ? { borderTopRightRadius: theme.borderRadius, borderBottomRightRadius: theme.borderRadius, marginLeft: -1 }
+      : { borderRadius: theme.borderRadius }),
+    fontSize: theme.font.size.body,
+    width: "100%",
+    height,
+    label: "input",
+    flexGrow: 1,
+    padding: `${theme.space.small}px ${theme.space.medium}px`,
+    opacity: disabled ? 0.6 : 1.0,
+    font: "inherit",
+    border: "1px solid",
+    borderColor: isError ? theme.color.error : theme.color.border.default,
+    appearance: "none",
+    fontWeight: preset ? theme.font.weight.medium : theme.font.weight.regular,
+    color: preset ? theme.color.text.dark : theme.color.text.default,
+    backgroundColor: makeBackgroundColor(),
+    "::placeholder": {
+      color: theme.color.text.disabled,
+    },
+    ...(clear ? { paddingRight: 40 } : {}),
+    "&:focus": inputFocus({
+      theme,
+      isError,
+    }),
+  }
+})
+
+const ClearButton = styled("div")`
+  position: absolute;
+  top: 0; /* anchor the position to the top so the browser doesn't guess */
+  right: 0; /* not 12px but 0 because we want a _box_ to attach to the end of Input and not just an X pushed in from the right */
+
+  /* We also probably should specify the dimensions of this box */
+  width: ${height}px;
+  height: ${height}px;
+
+  /* Also, let's center the contents of this box */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer; /* Let the user know this is clickable */
+
+  /* We want the user to click on thix _box_, not the icon inside it */
+  > svg {
+    pointer-events: none;
+  }
+`
+
+const InputField: React.SFC<InputProps> = ({
+  fullWidth,
+  inputRef,
+  autoFocus,
+  name,
+  autoComplete,
+  disabled,
+  value,
+  type,
+  onFocus,
+  onBlur,
+  placeholder,
+  error,
+  onChange,
+  preset,
+  label,
+  labelId,
+  clear,
+  icon,
+  copy,
+  onIconClick,
+}) => {
+  const shouldShowIconButton = Boolean(icon) || Boolean(copy)
+  const forAttributeId = label && labelId
+
+  const renderButton = () => {
+    if (copy === true) {
+      return <InputButton value={value || ""} copy={copy} />
+    } else {
+      return <InputButton onIconClick={onIconClick} icon={icon} copy={false} />
+    }
+  }
+
+  return (
+    <>
+      <Container fullWidth={fullWidth} withLabel>
+        {shouldShowIconButton && renderButton()}
+        <Field
+          innerRef={inputRef}
+          autoFocus={autoFocus}
+          name={name}
+          disabled={Boolean(disabled)}
+          value={value || ""}
+          type={type}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          isError={Boolean(error)}
+          onChange={(ev: React.FormEvent<HTMLInputElement>) => {
+            if (onChange) {
+              onChange(ev.currentTarget.value)
+            }
+          }}
+          clear={clear}
+          preset={Boolean(preset)}
+          id={forAttributeId}
+          withIconButton={shouldShowIconButton}
+          autoComplete={autoComplete}
+        />
+        {clear &&
+          value && (
+            <ClearButton onClick={clear}>
+              <Icon color="color.text.lightest" name="No" />
+            </ClearButton>
+          )}
+      </Container>
+      {error ? <FormFieldError>{error}</FormFieldError> : null}
+    </>
+  )
+}
+
+export default InputField

--- a/src/Input/Input.constants.ts
+++ b/src/Input/Input.constants.ts
@@ -1,0 +1,2 @@
+// Rendered height taking into account paddings, font-sizes and line-height
+export const height = 36

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -65,7 +65,7 @@ export type InputProps = BasePropsWithCopy | BasePropsWithoutCopy
 
 const Input: React.SFC<InputProps> = ({ fullWidth, label, labelId, hint, onToggle, disabled, ...props }) => {
   const forAttributeId = label && labelId
-  const Field = <InputField fullWidth={fullWidth} {...props} />
+  const Field = <InputField fullWidth={fullWidth} disabled={disabled} {...props} />
 
   if (label) {
     return (

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -93,8 +93,6 @@ You can have a field with a "copy to clipboard" button with the `copy` prop.
 
 ### Full Width
 
-#### With Label
-
 ```jsx
 <Input fullWidth value="Dave the Sheep" label="Hi, my name is" />
 ```


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
The `Input` component implementation is a little hard to read and follow on `master`. This PR refactors the component and adjust what happens on click of the copy button if `copy={true}`: it uses `pushMessage` instead of relying on a tooltip.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
