### PR TITLE
Add a breaking change warning for Paginator in v12

### DIFF
--- a/src/Paginator/Paginator.tsx
+++ b/src/Paginator/Paginator.tsx
@@ -1,3 +1,15 @@
+/**
+ * @todo remove this in v12.
+ */
+console.warn(`[operational-ui]: Deprecation Warning
+===
+
+<Paginator />'s page prop is now _mandatory_, meaning in the next major
+release, your code (if TypeScript) will not compile. Please add an explicit
+\`page\` prop to your Paginator if you'd like to stay up to date.
+
+Issue: https://github.com/contiamo/operational-ui/pull/820`)
+
 import * as React from "react"
 
 import Button from "../Button/Button"

--- a/src/Paginator/Paginator.tsx
+++ b/src/Paginator/Paginator.tsx
@@ -1,3 +1,5 @@
+let isUserWarnedAboutDeprecation = false
+
 import * as React from "react"
 
 import Button from "../Button/Button"
@@ -90,7 +92,8 @@ const Container = styled("div")(({ theme }) => ({
 const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page: explicitPage, onChange, ...props }) => {
   const page: number = explicitPage || 1
 
-  if (!explicitPage) {
+  if (!explicitPage && !isUserWarnedAboutDeprecation && process.env.NODE_ENV !== "production") {
+    isUserWarnedAboutDeprecation = true
     /**
      * @todo remove this in v12.
      */

--- a/src/Paginator/Paginator.tsx
+++ b/src/Paginator/Paginator.tsx
@@ -1,15 +1,3 @@
-/**
- * @todo remove this in v12.
- */
-console.warn(`[operational-ui]: Deprecation Warning
-===
-
-<Paginator />'s page prop is now _mandatory_, meaning in the next major
-release, your code (if TypeScript) will not compile. Please add an explicit
-\`page\` prop to your Paginator if you'd like to stay up to date.
-
-Issue: https://github.com/contiamo/operational-ui/pull/820`)
-
 import * as React from "react"
 
 import Button from "../Button/Button"
@@ -68,8 +56,8 @@ const NavigationButton = styled(Button)<Partial<ControlProps>>(({ type }) => ({
 const PaginatorControl = ({ children, itemCount, itemsPerPage, page, onChange, type, isDisabled }: ControlProps) => {
   const pageChanges = {
     first: 1,
-    previous: page! - 1,
-    next: page! + 1,
+    previous: page - 1,
+    next: page + 1,
     last: Math.ceil(itemCount / itemsPerPage),
   }
 
@@ -86,9 +74,9 @@ const PaginatorControl = ({ children, itemCount, itemsPerPage, page, onChange, t
   )
 }
 
-const getRange = ({ page, itemCount, itemsPerPage }: PaginatorProps) => {
-  const start = 1 + (page! - 1) * itemsPerPage
-  const end = Math.min(itemCount, page! * itemsPerPage)
+const getRange = ({ itemCount, itemsPerPage, page }: PaginatorProps & { page: number }) => {
+  const start = 1 + (page - 1) * itemsPerPage
+  const end = Math.min(itemCount, page * itemsPerPage)
   return `${start}-${end}`
 }
 
@@ -99,15 +87,32 @@ const Container = styled("div")(({ theme }) => ({
   alignItems: "center",
 }))
 
-const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page, onChange, ...props }) => {
+const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page: explicitPage, onChange, ...props }) => {
+  const page: number = explicitPage || 1
+
+  if (!explicitPage) {
+    /**
+     * @todo remove this in v12.
+     */
+    console.warn(`[operational-ui]: Deprecation Warning
+-------------------------------------
+
+<Paginator />'s page prop is now _mandatory_, meaning in the next major
+release, your code (if TypeScript) will not compile. Please add an explicit
+\`page\` prop to your Paginator if you'd like to stay up to date.
+
+Issue: https://github.com/contiamo/operational-ui/pull/820`)
+  }
+
   const controlProps = {
     itemCount,
     itemsPerPage,
-    page: page!,
+    page,
     onChange,
   }
+
   const isFirstDisabled = page === 1
-  const isLastDisabled = itemsPerPage * page! >= itemCount
+  const isLastDisabled = itemsPerPage * page >= itemCount
   return (
     <Container {...props}>
       <PaginatorControl type="first" {...controlProps} isDisabled={isFirstDisabled}>
@@ -129,10 +134,6 @@ const Paginator: React.SFC<PaginatorProps> = ({ itemCount, itemsPerPage, page, o
       </PaginatorControl>
     </Container>
   )
-}
-
-Paginator.defaultProps = {
-  page: 1,
 }
 
 export default Paginator

--- a/src/Paginator/README.md
+++ b/src/Paginator/README.md
@@ -3,22 +3,8 @@ Pagination is a predictable and expressive way to handle datasets that don't fit
 ### Usage
 
 ```jsx
-class ComponentWithPaginator extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {}
-  }
-
-  handleChange(page) {
-    this.setState(() => ({ page }))
-  }
-
-  render() {
-    return (
-      <Paginator itemCount={258} itemsPerPage={50} page={this.state.page} onChange={page => this.handleChange(page)} />
-    )
-  }
+initialState = {
+  page: 1,
 }
-
-;<ComponentWithPaginator />
+;<Paginator itemCount={258} itemsPerPage={50} page={state.page} onChange={page => setState({ page })} />
 ```


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Before we do our next minor release, let's add a deprecation warning to warn about the breaking change in v12.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#820 

<!-- Paste the github issue here -->

# To be tested

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
