### PR TITLE
Focus and blur handlers for Textarea

### DIFF
--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -26,9 +26,9 @@ export interface BaseProps extends DefaultProps {
    */
   onChange?: (newVal: string) => void
   /** Focus handler */
-  onFocus?: (ev: any) => void
+  onFocus?: (ev: React.FormEvent<HTMLInputElement>) => void
   /** Blur handler */
-  onBlur?: (ev: any) => void
+  onBlur?: (ev: React.FormEvent<HTMLInputElement>) => void
   type?: string
   children?: string
   autoComplete?: string

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -39,6 +39,10 @@ export interface TextareaProps extends DefaultProps {
   copy?: boolean
   /** cmd+enter submit handler */
   onSubmit?: () => void
+  /** Focus handler */
+  onFocus?: (ev: React.FocusEvent<HTMLTextAreaElement>) => void
+  /** Blur handler */
+  onBlur?: (ev: React.FocusEvent<HTMLTextAreaElement>) => void
 }
 
 export interface State {
@@ -174,6 +178,8 @@ class Textarea extends React.Component<TextareaProps, State> {
       copy,
       onChange,
       onSubmit,
+      onFocus,
+      onBlur,
       ...props
     } = this.props
     return (
@@ -192,6 +198,8 @@ class Textarea extends React.Component<TextareaProps, State> {
           isAction={Boolean(action || copy)}
           resize={resize!}
           height={height}
+          onFocus={onFocus}
+          onBlur={onBlur}
           onKeyDown={(ev: React.KeyboardEvent<HTMLTextAreaElement>) => {
             if (isCmdEnter(ev) && onSubmit) {
               onSubmit()


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Adding `onFocus` and `onBlur` handler support to `Textarea`. This is not included in the props spread because the handlers need to go on the wrapped `textarea` node as opposed to the label.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
