### PR TITLE
**Feature:** Add headless property to Table

### DIFF
--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -11,6 +11,16 @@ You can render a simple use-case of the table by specifying a list of records an
 />
 ```
 
+### Simple Usage without Header
+
+```js
+<Table
+  headless
+  data={[{ name: "Max", profession: "Carpenter" }, { name: "Moritz", profession: "Baker" }]}
+  columns={["name", "profession"]}
+/>
+```
+
 While this approach is convenient, it is not recommended because it makes it too easy to re-use record keys as table headings, and adds a strong coupling between data and view concerns.
 
 We suggest taking the time to think about the best way to describe the data fields and then specifying it explicitly as column headers. The following, slightly more verbose version of the API demonstrates how this can be achieved:

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -21,6 +21,8 @@ export interface TableProps<T> extends DefaultProps {
   icon?: (dataEntry: T) => IconName
   /** Icon color for row */
   iconColor?: (dataEntry: T) => string
+  /** Remove the header? */
+  headless?: boolean
 }
 
 export interface Column<T> {
@@ -120,6 +122,7 @@ function Table<T>({
   rowActions,
   icon,
   iconColor,
+  headless,
   ...props
 }: TableProps<T>) {
   const standardizedColumns: Array<Column<T>> =
@@ -134,15 +137,17 @@ function Table<T>({
 
   return (
     <Container {...props}>
-      <Thead>
-        <Tr>
-          {hasIcons && <Th key="-1" />}
-          {standardizedColumns.map((column, columnIndex) => (
-            <Th key={columnIndex}>{column.heading}</Th>
-          ))}
-          {Boolean(rowActions || (onRowClick && rowActionName)) && <Th key="infinity" />}
-        </Tr>
-      </Thead>
+      {!headless && (
+        <Thead>
+          <Tr>
+            {hasIcons && <Th key="-1" />}
+            {standardizedColumns.map((column, columnIndex) => (
+              <Th key={columnIndex}>{column.heading}</Th>
+            ))}
+            {Boolean(rowActions || (onRowClick && rowActionName)) && <Th key="infinity" />}
+          </Tr>
+        </Thead>
+      )}
       <tbody>
         {data.length ? (
           data.map((dataEntry, dataEntryIndex) => {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR allows a `Table` to be rendered without a heading for each column. It helps fulfill our design requirements a bit more.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->
# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
