### PR TITLE
**Feature:** Add `Contact` component to for user metadata

### DIFF
--- a/src/Contact/Contact.tsx
+++ b/src/Contact/Contact.tsx
@@ -12,7 +12,7 @@ const Container = styled("div")`
   flex-direction: column;
   justify-content: center;
   width: 100%;
-  overflow: auto;
+  overflow: auto hidden;
 `
 
 const Heading = styled("h6")<{ hasMeta: boolean }>`

--- a/src/Contact/Contact.tsx
+++ b/src/Contact/Contact.tsx
@@ -11,10 +11,8 @@ const Container = styled("div")`
   display: flex;
   flex-direction: column;
   justify-content: center;
-
-  :not(:last-child) {
-    margin-bottom: ${({ theme }) => theme.space.content}px;
-  }
+  width: 100%;
+  overflow: auto;
 `
 
 const Heading = styled("h6")<{ hasMeta: boolean }>`
@@ -22,16 +20,18 @@ const Heading = styled("h6")<{ hasMeta: boolean }>`
   font-size: ${({ theme }) => theme.font.size.small}px;
   font-weight: ${({ theme }) => theme.font.weight.medium};
   color: ${({ theme }) => theme.color.text.dark};
+  line-height: 1;
 `
 
 const Meta = styled("p")`
   margin: 0;
   font-size: ${({ theme }) => theme.font.size.fineprint}px;
   color: ${({ theme }) => theme.color.text.lightest};
+  line-height: 1;
 `
 
-const Contact: React.SFC<ContactProps> = ({ name, meta }) => (
-  <Container>
+const Contact: React.SFC<ContactProps> = ({ name, meta, ...props }) => (
+  <Container {...props}>
     <Heading hasMeta={Boolean(meta)}>{name}</Heading>
     <Meta>{meta}</Meta>
   </Container>

--- a/src/Contact/Contact.tsx
+++ b/src/Contact/Contact.tsx
@@ -17,8 +17,8 @@ const Container = styled("div")`
   }
 `
 
-const Heading = styled("h6")`
-  margin: 0 0 ${({ theme }) => theme.space.base}px 0;
+const Heading = styled("h6")<{ hasMeta: boolean }>`
+  margin: 0 0 ${({ theme, hasMeta }) => (hasMeta ? theme.space.base : 0)}px 0;
   font-size: ${({ theme }) => theme.font.size.small}px;
   font-weight: ${({ theme }) => theme.font.weight.medium};
   color: ${({ theme }) => theme.color.text.dark};
@@ -32,7 +32,7 @@ const Meta = styled("p")`
 
 const Contact: React.SFC<ContactProps> = ({ name, meta }) => (
   <Container>
-    <Heading>{name}</Heading>
+    <Heading hasMeta={Boolean(meta)}>{name}</Heading>
     <Meta>{meta}</Meta>
   </Container>
 )

--- a/src/Contact/Contact.tsx
+++ b/src/Contact/Contact.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+
+import styled from "../utils/styled"
+
+export interface ContactProps {
+  name: string
+  meta?: string
+}
+
+const Container = styled("div")`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  :not(:last-child) {
+    margin-bottom: ${({ theme }) => theme.space.content}px;
+  }
+`
+
+const Heading = styled("h6")`
+  margin: 0 0 ${({ theme }) => theme.space.base}px 0;
+  font-size: ${({ theme }) => theme.font.size.small}px;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.color.text.dark};
+`
+
+const Meta = styled("p")`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.fineprint}px;
+  color: ${({ theme }) => theme.color.text.lightest};
+`
+
+const Contact: React.SFC<ContactProps> = ({ name, meta }) => (
+  <Container>
+    <Heading>{name}</Heading>
+    <Meta>{meta}</Meta>
+  </Container>
+)
+
+export default Contact

--- a/src/Contact/README.md
+++ b/src/Contact/README.md
@@ -5,7 +5,9 @@ Sometimes, we'd like to show someone's name and email address. This component le
 ```jsx
 <>
   <Contact name="Luke Cage" meta="harlems.hero@gmail.com" />
+  <br />
   <Contact name="Danny Rand" />
+  <br />
   <Contact name="Matt Murdock" meta="+1 173 712 9124" />
 </>
 ```

--- a/src/Contact/README.md
+++ b/src/Contact/README.md
@@ -1,15 +1,18 @@
-Sometimes, we'd like to show someone's name and email address. This component lets us show a contact in a consistent way. It pairs will with an `Avatar`.
+Sometimes, we'd like to show someone's name and email address. This component lets us show a contact in a consistent way.
 
 ## Basic Usage
 
 ```jsx
 <>
-  <Contact name="Paul Heigl" meta="heigl.paul@gmail.com" />
-  <Contact name="Paul Heigl" meta="+49 173 712 9124" />
+  <Contact name="Luke Cage" meta="harlems.hero@gmail.com" />
+  <Contact name="Danny Rand" />
+  <Contact name="Matt Murdock" meta="+1 173 712 9124" />
 </>
 ```
 
 ## With Avatar
+
+In some cases, this component will be required to pair with an `Avatar`. Consider,
 
 ```jsx
 initialState = { name: "Kenye Wheelest", email: "kweezy@notformidablelabs.com" }

--- a/src/Contact/README.md
+++ b/src/Contact/README.md
@@ -1,0 +1,20 @@
+Sometimes, we'd like to show someone's name and email address. This component lets us show a contact in a consistent way. It pairs will with an `Avatar`.
+
+## Basic Usage
+
+```jsx
+<>
+  <Contact name="Paul Heigl" meta="heigl.paul@gmail.com" />
+  <Contact name="Paul Heigl" meta="+49 173 712 9124" />
+</>
+```
+
+## With Avatar
+
+```jsx
+initialState = { name: "Kenye Wheelest", email: "kweezy@notformidablelabs.com" }
+;<div style={{ display: "flex" }}>
+  <Avatar style={{ marginRight: 8 }} name={state.name} />
+  <Contact name={state.name} meta={state.email} />
+</div>
+```

--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -106,10 +106,10 @@ const Content: React.SFC<{ value: StringOrItem }> = ({ value }) => {
   )
 }
 
-const icon = (props: Props) => {
+const ContextMenuItemIcon: React.SFC<Pick<Props, "item" | "iconLocation">> = props => {
   // If item is just a string,
   if (typeof props.item === "string") {
-    return null
+    return <></>
   }
 
   // If it's an object with an icon property
@@ -125,14 +125,16 @@ const icon = (props: Props) => {
   }
 
   // If it's an object with a React Element as a property
-  return props.item.icon
+  return <>{props.item.icon}</>
 }
 
 const ContextMenuItem: React.SFC<Props> = props => (
   <Container {...props} condensed={props.condensed}>
-    {(!props.iconLocation || props.iconLocation === "left") && icon(props)}
+    {(!props.iconLocation || props.iconLocation === "left") && (
+      <ContextMenuItemIcon iconLocation={props.iconLocation} item={props.item} />
+    )}
     <Content value={props.item} />
-    {props.iconLocation === "right" && icon(props)}
+    {props.iconLocation === "right" && <ContextMenuItemIcon iconLocation={props.iconLocation} item={props.item} />}
   </Container>
 )
 

--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -18,9 +18,9 @@ export interface Props {
 }
 
 export interface IContextMenuItem<TValue = any> {
-  label: string
+  label: string | React.ReactElement<any>
   description?: string
-  icon?: IconProps["name"]
+  icon?: IconProps["name"] | React.ReactElement<any>
   iconColor?: keyof OperationalStyleConstants["color"]
   onClick?: ContextMenuProps["onClick"]
   value?: TValue
@@ -106,21 +106,33 @@ const Content: React.SFC<{ value: StringOrItem }> = ({ value }) => {
   )
 }
 
-const InPlaceIcon = (props: Props) =>
-  typeof props.item !== "string" ? (
-    <ContextMenuIcon
-      iconlocation_={props.iconLocation}
-      color={props.item.iconColor}
-      left={props.iconLocation === "left" || !props.iconLocation}
-      name={props.item.icon as IconName}
-    />
-  ) : null
+const icon = (props: Props) => {
+  // If item is just a string,
+  if (typeof props.item === "string") {
+    return null
+  }
+
+  // If it's an object with an icon property
+  if (typeof props.item.icon === "string") {
+    return (
+      <ContextMenuIcon
+        iconlocation_={props.iconLocation}
+        color={props.item.iconColor}
+        left={props.iconLocation === "left" || !props.iconLocation}
+        name={props.item.icon as IconName}
+      />
+    )
+  }
+
+  // If it's an object with a React Element as a property
+  return props.item.icon
+}
 
 const ContextMenuItem: React.SFC<Props> = props => (
   <Container {...props} condensed={props.condensed}>
-    {(!props.iconLocation || props.iconLocation === "left") && <InPlaceIcon {...props} />}
+    {(!props.iconLocation || props.iconLocation === "left") && icon(props)}
     <Content value={props.item} />
-    {props.iconLocation === "right" && <InPlaceIcon {...props} />}
+    {props.iconLocation === "right" && icon(props)}
   </Container>
 )
 

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -41,6 +41,60 @@ const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
 </ContextMenu>
 ```
 
+#### Usage with React Nodes as Labels
+
+In some cases, you might want your `label` to be a little bit more clever than just a string. This example shows a `ContextMenu` with a JSX element as its `label`.
+
+```jsx
+const MyLabelContainer = ({ children, style }) => <div style={{ padding: "8px 0", ...style }}>{children}</div>
+const menuItems = [
+  {
+    label: (
+      <MyLabelContainer>
+        <Contact name="Tejas Kumar" meta="youare@cool.com" />
+      </MyLabelContainer>
+    ),
+    icon: "Add",
+  },
+  {
+    label: (
+      <MyLabelContainer>
+        <Contact name="Peter Szerzo" meta="peter@norway.com" />
+      </MyLabelContainer>
+    ),
+    icon: (
+      <div style={{ marginLeft: "auto" }}>
+        <Hint right>User already exists</Hint>
+      </div>
+    ),
+  },
+  {
+    label: (
+      <MyLabelContainer>
+        <Contact name="Sibelius Seraphini" meta="sibelius@seraphini.com" />
+      </MyLabelContainer>
+    ),
+    icon: "Add",
+  },
+  {
+    label: (
+      <MyLabelContainer>
+        <Contact
+          name={`Arnold "Governator" Schwarzennegger`}
+          meta="arnoldgovernatorschwarzennegger@thegovernmentofcalifornia.usa🇺🇸"
+        />
+      </MyLabelContainer>
+    ),
+    icon: "Add",
+  },
+]
+;<>
+  <ContextMenu iconLocation="right" items={menuItems} onClick={item => alert(`clicked ${item}`)}>
+    <Button>See Users</Button>
+  </ContextMenu>
+</>
+```
+
 #### Large number of items
 
 The context menu doesn't grow past a certain maximum height, but scrolls in its container instead.

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -89,7 +89,7 @@ const menuItems = [
   },
 ]
 ;<>
-  <ContextMenu iconLocation="right" items={menuItems} onClick={item => alert(`clicked ${item}`)}>
+  <ContextMenu iconLocation="right" items={menuItems} onClick={item => alert(`clicked`)}>
     <Button>See Users</Button>
   </ContextMenu>
 </>

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -46,7 +46,11 @@ const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
 In some cases, you might want your `label` to be a little bit more clever than just a string. This example shows a `ContextMenu` with a JSX element as its `label`.
 
 ```jsx
-const MyLabelContainer = ({ children, style }) => <div style={{ padding: "8px 0", ...style }}>{children}</div>
+/* Anything can be a label now, even some DIV you style yourself */
+const MyLabelContainer = ({ children, style }) => (
+  <div style={{ marginRight: 8, padding: "8px 0", ...style }}>{children}</div>
+)
+
 const menuItems = [
   {
     label: (

--- a/src/Hint/Hint.tsx
+++ b/src/Hint/Hint.tsx
@@ -3,7 +3,7 @@ import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import Icon from "../Icon/Icon"
-import DiscriminatedTooltip from "../Tooltip/Tooltip"
+import Tooltip from "../Tooltip/Tooltip"
 import { hoverTooltip } from "../utils/mixins"
 
 export interface HintProps extends DefaultProps {
@@ -31,18 +31,18 @@ const Container = styled("div")<{ left?: HintProps["left"]; right?: HintProps["r
   ...hoverTooltip,
 }))
 
-const Tooltip: React.SFC<{ position: HintProps["tooltipPosition"] }> = props => {
+const HintTooltip: React.SFC<{ position: HintProps["tooltipPosition"] }> = props => {
   switch (props.position) {
     case "right":
-      return <DiscriminatedTooltip right {...props} />
+      return <Tooltip right {...props} />
     case "top":
-      return <DiscriminatedTooltip top {...props} />
+      return <Tooltip top {...props} />
     case "bottom":
-      return <DiscriminatedTooltip bottom {...props} />
+      return <Tooltip bottom {...props} />
     case "left":
-      return <DiscriminatedTooltip left {...props} />
+      return <Tooltip left {...props} />
     case "smart":
-      return <DiscriminatedTooltip smart {...props} />
+      return <Tooltip smart {...props} />
     default:
       return null
   }
@@ -51,7 +51,7 @@ const Tooltip: React.SFC<{ position: HintProps["tooltipPosition"] }> = props => 
 const Hint: React.SFC<HintProps> = props => (
   <Container {...props}>
     <Icon name="Question" size={12} />
-    <Tooltip position={props.tooltipPosition!}>{props.children}</Tooltip>
+    <HintTooltip position={props.tooltipPosition!}>{props.children}</HintTooltip>
   </Container>
 )
 

--- a/src/Hint/Hint.tsx
+++ b/src/Hint/Hint.tsx
@@ -3,7 +3,7 @@ import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 
 import Icon from "../Icon/Icon"
-import Tooltip from "../Tooltip/Tooltip"
+import DiscriminatedTooltip from "../Tooltip/Tooltip"
 import { hoverTooltip } from "../utils/mixins"
 
 export interface HintProps extends DefaultProps {
@@ -17,23 +17,46 @@ export interface HintProps extends DefaultProps {
    * Indicates that this component is right of other content, and adds an appropriate left margin.
    */
   right?: boolean
+  tooltipPosition?: "left" | "top" | "right" | "bottom" | "smart"
 }
 
 const Container = styled("div")<{ left?: HintProps["left"]; right?: HintProps["right"] }>(({ left, right, theme }) => ({
   position: "relative",
-  display: "inline-block",
+  display: "inline-flex",
   verticalAlign: "middle",
+  alignItems: "center",
   color: theme.color.text.lightest,
   marginRight: left ? theme.space.base : 0,
   marginLeft: right ? theme.space.base : 0,
   ...hoverTooltip,
 }))
 
+const Tooltip: React.SFC<{ position: HintProps["tooltipPosition"] }> = props => {
+  switch (props.position) {
+    case "right":
+      return <DiscriminatedTooltip right {...props} />
+    case "top":
+      return <DiscriminatedTooltip top {...props} />
+    case "bottom":
+      return <DiscriminatedTooltip bottom {...props} />
+    case "left":
+      return <DiscriminatedTooltip left {...props} />
+    case "smart":
+      return <DiscriminatedTooltip smart {...props} />
+    default:
+      return null
+  }
+}
+
 const Hint: React.SFC<HintProps> = props => (
   <Container {...props}>
     <Icon name="Question" size={12} />
-    <Tooltip right>{props.children}</Tooltip>
+    <Tooltip position={props.tooltipPosition!}>{props.children}</Tooltip>
   </Container>
 )
+
+Hint.defaultProps = {
+  tooltipPosition: "left",
+}
 
 export default Hint

--- a/src/TopbarSelect/TopbarSelect.tsx
+++ b/src/TopbarSelect/TopbarSelect.tsx
@@ -13,7 +13,7 @@ export interface TopbarSelectProps {
   /** Menu items, conforming to the ContextMenu API */
   items: ContextMenuProps["items"]
   /** Change handler */
-  onChange?: (newLabel: string) => void
+  onChange?: (newLabel: string | React.ReactElement<any>) => void
 }
 
 const TopbarSelectContainer = styled("div")`

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { default as CardSection, CardSectionProps, DragAndDropFeedback } from ".
 export { default as Checkbox, CheckboxProps } from "./Checkbox/Checkbox"
 export { default as Chip, ChipProps } from "./Chip/Chip"
 export { default as Code, CodeProps } from "./Code/Code"
+export { default as Contact, ContactProps } from "./Contact/Contact"
 export { default as ContextMenu, ContextMenuProps } from "./ContextMenu/ContextMenu"
 export { default as DatePicker, DatePickerProps } from "./DatePicker/DatePicker"
 export { default as Debug } from "./Debug/Debug"

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -48,12 +48,19 @@ const separatorColors = {
  * A specialized color palette for typography.
  */
 const textColors = {
+  /** `#333` */
   dark: "#333",
+  /** `#545454` */
   default: "#545454",
+  /** `#c0c0c0` */
   disabled: "#c0c0c0",
+  /** `#666` */
   light: "#666",
+  /** `#747474` */
   lighter: "#747474",
+  /** `#909090` */
   lightest: "#909090",
+  /** primary color */
   action: primaryColor,
   white: whiteColor,
 }


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR creates a nice little component that renders a user's name and metadata for placement in various parts of our UI.
![image](https://user-images.githubusercontent.com/9947422/49382205-18aafb80-f716-11e8-96f1-3403fe766e3d.png)

It is _not_ tightly coupled to `Avatar` and just shows contacts.



<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
