### PR TITLE
**Fix:** HeaderMenu line height for long strings

### DIFF
--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -25,8 +25,9 @@ const Container = styled("div")<{
   withCaret: HeaderMenuProps["withCaret"]
 }>(({ theme, align, isOpen, withCaret }) => ({
   width: 250,
-  lineHeight: "50px",
-  padding: `0 ${theme.space.content}px`,
+  lineHeight: 1,
+  padding: theme.space.content,
+  [align === "left" ? "paddingRight" : "paddingLeft"]: theme.space.element * 2, // leave room for the caret
   color: isOpen ? theme.color.white : "#ffffffcc",
   backgroundColor: isOpen ? backgroundColor : "transparent",
   boxShadow: isOpen ? boxShadow : "none",
@@ -48,7 +49,7 @@ const Container = styled("div")<{
           content: "''",
           position: "absolute",
           top: "50%",
-          [align === "left" ? "right" : "left"]: theme.space.content + theme.space.small,
+          [align === "left" ? "right" : "left"]: theme.space.content,
           width: 0,
           height: 0,
           border: "4px solid transparent",

--- a/src/HeaderMenu/README.md
+++ b/src/HeaderMenu/README.md
@@ -23,3 +23,35 @@ initialState = { project: { key: "project1", label: "Project 1", icon: "Building
   </HeaderMenu>
 </div>
 ```
+
+### Behavior with Long Label
+
+```jsx
+const projectOptions = [
+  {
+    key: "project1",
+    icon: "Building",
+    iconColor: "primary",
+    label: "Contiamo is a nice place and they have a nice UI library",
+    description: "Organization-wide content and settings",
+  },
+  { key: "project1", label: "Project 1", icon: "User" },
+  { key: "project2", label: "Project 2", icon: "Project" },
+  { key: "project3", label: "Project 3", icon: "Project" },
+]
+
+initialState = {
+  project: {
+    key: "project1",
+    icon: "Building",
+    iconColor: "primary",
+    label: "Contiamo is a nice place and they have a nice UI library",
+    description: "Organization-wide content and settings",
+  },
+}
+;<div style={{ display: "inline-block", backgroundColor: "#3e3e3e" }}>
+  <HeaderMenu items={projectOptions} onClick={project => setState(() => ({ project }))} withCaret>
+    <Icon left name={state.project.icon} /> {state.project.label}
+  </HeaderMenu>
+</div>
+```


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR cleans up `HeaderMenu` a bit by improving its appearance when rendered with loooooooooooooooooooooooooooooooooooooooooong values.

## Before
![image](https://user-images.githubusercontent.com/9947422/49719257-f0af2100-fc5c-11e8-9778-b45b602e1f4f.png)

## After
![image](https://user-images.githubusercontent.com/9947422/49719244-e4c35f00-fc5c-11e8-8b16-36c8c335066c.png)


<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
