### PR TITLE
**Feature:** Add more flexibility to Confirm

### DIFF
--- a/src/Code/Code.tsx
+++ b/src/Code/Code.tsx
@@ -115,6 +115,7 @@ const defaultCodeTheme = {
 
 const Container = styled("div")`
   display: flex;
+  position: relative;
   pre {
     flex: 1;
     display: flex;

--- a/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
+++ b/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Code Should render 1`] = `
     class="css-ar73w8-Messages"
   />
   <div
-    class="css-cvljpn"
+    class="css-1e9yps6"
   >
     <div
       class="react-json-view"

--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -12,8 +12,8 @@ export interface ConfirmOptions<T> {
   title: React.ReactNode
   body: React.ReactNode | React.ComponentType<ConfirmBodyProps<T>>
   fullSize?: boolean
-  cancelButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>)
-  actionButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>)
+  cancelButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>) | null
+  actionButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>) | null
   onConfirm?: (confirmState: T) => void
   onCancel?: (confirmState: T) => void
   state?: T
@@ -105,20 +105,24 @@ export class Confirm<T> extends React.Component<Props, Readonly<State<T>>> {
               )}
             </ControlledModalContent>
             <Actions>
-              {React.cloneElement(
-                typeof cancelButton === "function" ? cancelButton(state as T) : cancelButton || <Button>Cancel</Button>,
-                {
-                  onClick: this.onCancelClick,
-                },
-              )}
-              {React.cloneElement(
-                typeof actionButton === "function"
-                  ? actionButton(state as T)
-                  : actionButton || <Button color="success">Confirm</Button>,
-                {
-                  onClick: this.onActionClick,
-                },
-              )}
+              {cancelButton !== null &&
+                React.cloneElement(
+                  typeof cancelButton === "function"
+                    ? cancelButton(state as T)
+                    : cancelButton || <Button>Cancel</Button>,
+                  {
+                    onClick: this.onCancelClick,
+                  },
+                )}
+              {actionButton !== null &&
+                React.cloneElement(
+                  typeof actionButton === "function"
+                    ? actionButton(state as T)
+                    : actionButton || <Button color="success">Confirm</Button>,
+                  {
+                    onClick: this.onActionClick,
+                  },
+                )}
             </Actions>
           </ControlledModal>
         )}

--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -17,6 +17,12 @@ export interface ConfirmOptions<T> {
   onConfirm?: (confirmState: T) => void
   onCancel?: (confirmState: T) => void
   state?: T
+  /**
+   * Prevent closing the modal on overlay click if it's specify to `false`
+   *
+   * @default true
+   */
+  closeOnOverlayClick?: boolean
 }
 
 export interface State<T> {
@@ -89,14 +95,19 @@ export class Confirm<T> extends React.Component<Props, Readonly<State<T>>> {
   }
 
   public render() {
-    const { actionButton, fullSize, title, cancelButton, state, body: Body } = this.state.options
+    const { actionButton, fullSize, title, cancelButton, state, body: Body, closeOnOverlayClick } = this.state.options
     const isOpen = Boolean(Body)
 
     return (
       <>
         {this.props.children(this.openConfirm.bind(this))}
         {isOpen && (
-          <ControlledModal fullSize={fullSize} title={title} onClose={this.closeConfirm}>
+          <ControlledModal
+            fullSize={fullSize}
+            title={title}
+            onClose={this.closeConfirm}
+            closeOnOverlayClick={closeOnOverlayClick}
+          >
             <ControlledModalContent fullSize={Boolean(fullSize)}>
               {typeof Body === "function" && state ? (
                 <Body setConfirmState={this.setConfirmState} confirmState={state} />

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -13,6 +13,12 @@ export interface Props {
   title?: CardProps["title"]
   action?: CardProps["action"]
   fullSize?: boolean
+  /**
+   * Prevent closing the modal on overlay click if it's specify to `false`
+   *
+   * @default true
+   */
+  closeOnOverlayClick?: boolean
 }
 
 const fromTop = (fullSize: boolean) => {
@@ -79,9 +85,18 @@ const ControlledModal: React.SFC<Props> = ({
   title,
   action,
   children,
+  closeOnOverlayClick,
 }: Props) => (
   <>
-    <Overlay id={id} className={className} onClick={onClose} />
+    <Overlay
+      id={id}
+      className={className}
+      onClick={() => {
+        if (closeOnOverlayClick !== false && onClose) {
+          onClose()
+        }
+      }}
+    />
     <Container className={contentClassName} fullSize={fullSize} title={title} action={action}>
       <Content fullSize={fullSize}>{children}</Content>
     </Container>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add some useful behaviour to Confirm:
- we can remove action or cancel button if we pass `null` as `actionButton` or `cancelButton`
- we can disable the closing action on overlay click.

# Related issue

We need this for idp that have some custom confirm modal.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
