### PR TITLE
**Fix:** Header menu

### DIFF
--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -62,9 +62,13 @@ const Container = styled("div")<Props>(({ align, theme, onClick, condensed, widt
   },
 }))
 
-const Title = styled("span")`
+const Title = styled("p")`
   font-weight: bold;
   color: ${({ theme }) => theme.color.text.dark};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+  width: 100%;
 `
 
 const Description = styled("p")`

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -52,10 +52,11 @@ const Container = styled("div")<{ align: ContextMenuProps["align"]; isOpen: bool
 
 const MenuContainer = styled("div")<{
   embedChildrenInMenu?: ContextMenuProps["embedChildrenInMenu"]
-}>(({ theme, embedChildrenInMenu }) => ({
+  align: ContextMenuProps["align"]
+}>(({ theme, align, embedChildrenInMenu }) => ({
   position: "absolute",
   top: embedChildrenInMenu ? 0 : "100%",
-  left: 0,
+  left: align === "left" ? 0 : "auto",
   maxHeight: 360,
   overflow: "auto",
   boxShadow: theme.shadows.popup,
@@ -156,7 +157,11 @@ class ContextMenu extends React.Component<ContextMenuProps, Readonly<State>> {
         <Container isOpen={isOpen} {...props} align={align} onClick={this.toggle} onKeyUp={this.handleKeyPress}>
           {renderedChildren}
           {isOpen && (
-            <MenuContainer innerRef={node => (this.menu = node)} embedChildrenInMenu={this.props.embedChildrenInMenu}>
+            <MenuContainer
+              align={this.props.align}
+              innerRef={node => (this.menu = node)}
+              embedChildrenInMenu={this.props.embedChildrenInMenu}
+            >
               {embedChildrenInMenu && renderedChildren}
               {props.items.map((itemFromProps, index: number) => {
                 const item = this.makeItem(itemFromProps)

--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -16,8 +16,16 @@ export interface HeaderMenuProps extends DefaultProps {
   align?: ContextMenuProps["align"]
 }
 
+interface HeaderMenuState {
+  menuWidth: number
+}
+
 const backgroundColor = "hsla(0, 0%, 100%, 0.1)"
 const boxShadow = "0 3px 6px rgba(0, 0%, 0%, 0.3)"
+
+const HeaderContextMenu = styled(ContextMenu)`
+  height: 100%;
+`
 
 const Container = styled("div")<{
   align: HeaderMenuProps["align"]
@@ -68,21 +76,40 @@ const Container = styled("div")<{
     : {}),
 }))
 
-const HeaderMenu: React.SFC<HeaderMenuProps> = props => {
-  return (
-    <ContextMenu {...props}>
-      {isOpen => (
-        <Container isOpen={isOpen} align={props.align} withCaret={Boolean(props.withCaret)}>
-          {props.children}
-        </Container>
-      )}
-    </ContextMenu>
-  )
-}
+class HeaderMenu extends React.PureComponent<HeaderMenuProps, Readonly<HeaderMenuState>> {
+  private menuNode = React.createRef<HTMLDivElement>()
 
-HeaderMenu.defaultProps = {
-  align: "left",
-  withCaret: false,
+  public readonly state: HeaderMenuState = {
+    menuWidth: 0,
+  }
+
+  public static defaultProps = {
+    align: "left",
+    withCaret: false,
+  }
+
+  public componentDidMount() {
+    if (this.menuNode === null) {
+      return
+    }
+    if (this.menuNode.current === null) {
+      return
+    }
+    this.setState(() => ({ menuWidth: this.menuNode.current!.clientWidth }))
+  }
+
+  public render() {
+    const props = this.props
+    return (
+      <HeaderContextMenu width={this.state.menuWidth} {...props}>
+        {isOpen => (
+          <Container innerRef={this.menuNode} isOpen={isOpen} align={props.align} withCaret={Boolean(props.withCaret)}>
+            {props.children}
+          </Container>
+        )}
+      </HeaderContextMenu>
+    )
+  }
 }
 
 export default HeaderMenu

--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -17,7 +17,7 @@ export interface HeaderMenuProps extends DefaultProps {
 }
 
 interface HeaderMenuState {
-  menuWidth: number
+  renderedMenuWidth: number
 }
 
 const backgroundColor = "hsla(0, 0%, 100%, 0.1)"
@@ -77,10 +77,8 @@ const Container = styled("div")<{
 }))
 
 class HeaderMenu extends React.PureComponent<HeaderMenuProps, Readonly<HeaderMenuState>> {
-  private menuNode = React.createRef<HTMLDivElement>()
-
   public readonly state: HeaderMenuState = {
-    menuWidth: 0,
+    renderedMenuWidth: 0,
   }
 
   public static defaultProps = {
@@ -88,22 +86,35 @@ class HeaderMenu extends React.PureComponent<HeaderMenuProps, Readonly<HeaderMen
     withCaret: false,
   }
 
+  private menuRef = React.createRef<HTMLDivElement>()
+
   public componentDidMount() {
-    if (this.menuNode === null) {
+    this.updateRenderedWidth()
+  }
+
+  public componentDidUpdate() {
+    this.updateRenderedWidth()
+  }
+
+  private updateRenderedWidth() {
+    if (!this.menuRef || this.menuRef.current === null) {
       return
     }
-    if (this.menuNode.current === null) {
-      return
+    const node = this.menuRef.current
+    const renderedMenuWidth = node.clientWidth
+    if (renderedMenuWidth !== this.state.renderedMenuWidth) {
+      this.setState(() => ({
+        renderedMenuWidth,
+      }))
     }
-    this.setState(() => ({ menuWidth: this.menuNode.current!.clientWidth }))
   }
 
   public render() {
     const props = this.props
     return (
-      <HeaderContextMenu width={this.state.menuWidth} {...props}>
+      <HeaderContextMenu width={this.state.renderedMenuWidth} {...props}>
         {isOpen => (
-          <Container innerRef={this.menuNode} isOpen={isOpen} align={props.align} withCaret={Boolean(props.withCaret)}>
+          <Container innerRef={this.menuRef} isOpen={isOpen} align={props.align} withCaret={Boolean(props.withCaret)}>
             {props.children}
           </Container>
         )}

--- a/src/TopbarSelect/TopbarSelect.tsx
+++ b/src/TopbarSelect/TopbarSelect.tsx
@@ -66,7 +66,7 @@ class TopbarSelect extends React.Component<TopbarSelectProps, Readonly<State>> {
     renderedWidth: undefined,
   }
 
-  private containerRef = React.createRef()
+  private containerRef = React.createRef<HTMLDivElement>()
 
   public componentDidMount() {
     this.updateRenderedWidth()
@@ -77,10 +77,10 @@ class TopbarSelect extends React.Component<TopbarSelectProps, Readonly<State>> {
   }
 
   private updateRenderedWidth() {
-    const node = this.containerRef.current as HTMLElement
-    if (!node) {
+    if (!this.containerRef || this.containerRef.current === null) {
       return
     }
+    const node = this.containerRef.current
     const renderedWidth = node.clientWidth
     if (renderedWidth !== this.state.renderedWidth) {
       this.setState(() => ({


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
We currently have a regression on `HeaderMenu` throughout our platform: 
![image](https://user-images.githubusercontent.com/9947422/49864688-550be500-fe03-11e8-8fcd-745c14781048.png)

This PR learns from #860 and implements identical behavior to correctly size and position `HeaderMenu`s context menu.


<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#860 

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
