### PR TITLE
Fix collapsed card section

### DIFF
--- a/src/CardSection/CardSection.tsx
+++ b/src/CardSection/CardSection.tsx
@@ -137,7 +137,7 @@ const CardSection: React.SFC<CardSectionProps> = ({
         {actions && <StyledActionMenu items={actions} onClick={onActionClick} />}
       </Title>
     )}
-    {collapsed === false && <Content noHorizontalPadding={noHorizontalPadding}>{children}</Content>}
+    {!collapsed && <Content noHorizontalPadding={noHorizontalPadding}>{children}</Content>}
   </Container>
 )
 


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fixing `CardSection`'s which are collapsed when the `collapsed` prop isn't explicitly set to `false`. They are now expanded if the `collapsed` prop is ommitted.

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
