### PR TITLE
**Fix:** outside click in `ContextMenu`

### DIFF
--- a/src/Topbar/README.md
+++ b/src/Topbar/README.md
@@ -3,13 +3,22 @@ Top bars are used as lower-level navigation elements for widgets inside applicat
 ### Usage
 
 ```
-<Topbar
+initialState = {
+  selectedFruit: "apples"
+}
+
+;<Topbar
   left={
     <>
       <TopbarSelect
         label="Fruit"
-        selected={"apples"}
+        selected={state.selectedFruit}
         items={["apples", "oranges"].map(name => ({ label: name }))}
+        onChange={newSelectedFruit => {
+          setState(() => ({
+            selectedFruit: newSelectedFruit
+          }))
+        }}
       />
       <TopbarButton
         icon="No"


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fix close-on-outside-click feature on `ContextMenu`, fixing the `TopbarSelect` bug where multiple can be open at the same time. The implementation removes the `InvisibleOverlay` component and manages document click listeners instead (the way `DatePicker` does it currently).

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
