### PR TITLE
**Enhance:** context menu child sizes on window resize

### DIFF
--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -1,4 +1,7 @@
+import { Cancelable } from "lodash"
+import debounce from "lodash/debounce"
 import * as React from "react"
+
 import ContextMenu, { ContextMenuProps } from "../ContextMenu/ContextMenu"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
@@ -91,11 +94,25 @@ class HeaderMenu extends React.PureComponent<HeaderMenuProps, Readonly<HeaderMen
 
   public componentDidMount() {
     this.updateRenderedWidth()
+    window.addEventListener("resize", this.handleResize)
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener("resize", this.handleResize)
   }
 
   public componentDidUpdate() {
     this.updateRenderedWidth()
   }
+
+  /**
+   * Explicit typing is required here in order to give the typescript compiler access to typings
+   * used to work out type definitions for the debounce method.
+   * @todo look into making this unnecessary.
+   */
+  public handleResize: (() => void) & Cancelable = debounce(() => {
+    this.updateRenderedWidth()
+  }, 200)
 
   private updateRenderedWidth() {
     if (!this.menuRef || this.menuRef.current === null) {

--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -183,14 +183,14 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
       injectGlobal(baseStylesheet(constants))
     }
     this.onSetWindowSize()
-    document.body.addEventListener("resize", this.handleResize)
+    window.addEventListener("resize", this.handleResize)
   }
 
   public componentWillUnmount() {
     if (this.messageTimerInterval) {
       clearInterval(this.messageTimerInterval)
     }
-    document.body.removeEventListener("resize", this.handleResize)
+    window.removeEventListener("resize", this.handleResize)
   }
 
   public render() {

--- a/src/TopbarSelect/TopbarSelect.tsx
+++ b/src/TopbarSelect/TopbarSelect.tsx
@@ -1,4 +1,7 @@
+import { Cancelable } from "lodash"
+import debounce from "lodash/debounce"
 import * as React from "react"
+
 import ContextMenu, { ContextMenuProps } from "../ContextMenu/ContextMenu"
 import Icon from "../Icon/Icon"
 import styled from "../utils/styled"
@@ -70,11 +73,25 @@ class TopbarSelect extends React.Component<TopbarSelectProps, Readonly<State>> {
 
   public componentDidMount() {
     this.updateRenderedWidth()
+    window.addEventListener("resize", this.handleResize)
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener("resize", this.handleResize)
   }
 
   public componentDidUpdate() {
     this.updateRenderedWidth()
   }
+
+  /**
+   * Explicit typing is required here in order to give the typescript compiler access to typings
+   * used to work out type definitions for the debounce method.
+   * @todo look into making this unnecessary.
+   */
+  public handleResize: (() => void) & Cancelable = debounce(() => {
+    this.updateRenderedWidth()
+  }, 200)
 
   private updateRenderedWidth() {
     if (!this.containerRef || this.containerRef.current === null) {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Updating menu widths on resize for `TopbarSelect` and `HeaderMenu`. Also fixing a bug where `window.addEventListener("resize")` got replaced with `document.body.addEventListener("resize")`, which doesn't fire normally.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
