### PR TITLE
**Feature:** Add spinner feature to card tabs

### DIFF
--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -136,7 +136,7 @@ initialState = {
         </Button>
       ),
       loading: state.isTab1Loading,
-      // Icon name is not taken into consideration when loading
+      // The icon is replaced by a spinner when loading.
       icon: "Yes",
       iconColor: "success",
     },

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -102,11 +102,14 @@ const myData = {
 
 ### With `tabs`
 
-Cards support tabs the same way (and with the exact same API) that `Page` components do. These tabs work both as stateful and controlled components, with a controlled one presented below:
+Cards support tabs the same way (and with the exact same API) that `Page` components do. These tabs work both as stateful and controlled components.
+
+These features are shown in the example below:
 
 ```jsx
 initialState = {
   activeTab: "Tab 1",
+  isTab1Loading: false,
 }
 ;<Card
   activeTabName={state.activeTab}
@@ -116,8 +119,26 @@ initialState = {
   tabs={[
     {
       name: "Tab 1",
-      children: <Button>One kind of button</Button>,
-      icon: "User",
+      children: (
+        <Button
+          onClick={() => {
+            setState(() => ({
+              isTab1Loading: true,
+            }))
+            setTimeout(() => {
+              setState(() => ({
+                isTab1Loading: false,
+              }))
+            }, 1500)
+          }}
+        >
+          Refresh
+        </Button>
+      ),
+      loading: state.isTab1Loading,
+      // Icon name is not taken into consideration when loading
+      icon: "Yes",
+      iconColor: "success",
     },
     {
       name: "Tab 2",

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import Icon, { IconName } from "../Icon/Icon"
+import Spinner from "../Spinner/Spinner"
 import styled from "../utils/styled"
 
 export interface Tab {
@@ -8,6 +9,7 @@ export interface Tab {
   hidden?: boolean
   icon?: IconName
   iconColor?: string
+  loading?: boolean
 }
 
 export interface Props {
@@ -87,7 +89,11 @@ class Tabs extends React.Component<Props, State> {
               active={activeTab === index}
               onClick={() => this.onTabClick(index)}
             >
-              {tab.icon && <Icon name={tab.icon} size={14} color={tab.iconColor} left />}
+              {tab.loading ? (
+                <Spinner left size={14} />
+              ) : (
+                tab.icon && <Icon name={tab.icon} size={14} color={tab.iconColor} left />
+              )}
               {tab.name}
             </Tab>
           ))}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Card header tabs supported colored icons up to this point - with this PR, they also support spinners:

![card-spinner](https://user-images.githubusercontent.com/6738398/50158803-622e4580-02d5-11e9-9f72-cb8d0a1f0bdb.gif)

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
