### PR TITLE
**Fix:** full screen modal height

### DIFF
--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -35,13 +35,13 @@ export interface Props {
 
 const actionsBarSize = 36
 
-const Actions = styled("div")`
+export const Actions = styled("div")`
   margin-top: ${({ theme }) => theme.space.element}px;
   align-self: flex-end;
   height: ${actionsBarSize}px;
 `
 
-const ControlledModalContent = styled("div")<{ fullSize: boolean }>(
+export const ControlledModalContent = styled("div")<{ fullSize: boolean }>(
   ({ fullSize }) =>
     fullSize
       ? {

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -51,7 +51,7 @@ const Container = styled(Card)<Partial<ControlledModalProps>>(({ theme, fullSize
         width: 1110,
         display: "grid",
         gridTemplateRows: "40px 100%",
-        maxHeight: `calc(100% - ${theme.space.element * 2}px)`,
+        maxHeight: `calc(100% - ${theme.space.element * 3}px)`,
       }
     : // Regular size rules
       {
@@ -71,7 +71,7 @@ const Content = styled("div")<ControlledModalProps>(({ theme, fullSize }) => ({
   // Ensure scrollability if content is too long
   ...(fullSize
     ? {
-        height: "100%", // height + padding top + padding bottom
+        height: "100%",
         overflow: "auto",
       }
     : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export { default as Title } from "./Typography/Title"
 export { default as Small } from "./Typography/Small"
 
 // Internals components
-export { ConfirmBodyProps, ConfirmOptions } from "./Internals/Confirm"
+export { Actions, ControlledModalContent, ConfirmBodyProps, ConfirmOptions } from "./Internals/Confirm"
 export { Tab } from "./Internals/Tabs"
 
 // Utils


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

The full screen modal is 20px to big, so we can scroll! (and I don't like that ^^)

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
