### PR TITLE
**Fix:** Update react-styleguidist.

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "parcel-bundler": "^1.9.7",
     "prettier": "^1.13.7",
     "react-docgen-typescript": "^1.6.2",
-    "react-styleguidist": "^7.1.0",
+    "react-styleguidist": "^8.0.6",
     "rimraf": "^2.6.2",
     "ts-jest": "^23.0.0",
     "ts-loader": "^4.4.2",


### PR DESCRIPTION
# Summary

This updated `react-styleguidist` to `^8.0.6` to fix an `npm audit warning`:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Missing Origin Validation                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ webpack-dev-server                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-styleguidist [dev]                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-styleguidist > webpack-dev-server                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/725                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

I checked the release notes of styleguidist (https://github.com/styleguidist/react-styleguidist/releases/tag/v8.0.0). There are no breaking changes that affect us.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.

Tester 2

- [ ] Things look good on the demo.