### PR TITLE
**Enhance:** foldable card sections

### DIFF
--- a/src/CardSection/CardSection.tsx
+++ b/src/CardSection/CardSection.tsx
@@ -27,6 +27,12 @@ export interface CardSectionProps extends DefaultProps, DragProps {
   collapsed?: boolean
   /** Toggle collapsed state */
   onToggle?: () => void
+  /** Fires when the toggle area is hovered */
+  onToggleMouseEnter?: () => void
+  /** Fires when the mouse leaves the hover area */
+  onToggleMouseLeave?: () => void
+  /** Force the toggle area to have hover styles whether they are hovered or not */
+  forceToggleHoverStyles?: boolean
 }
 
 export type DragAndDropFeedback = "validTarget" | "invalidTarget" | "dropping"
@@ -87,13 +93,13 @@ const Content = styled("div")<{ noHorizontalPadding?: boolean }>`
   `};
 `
 
-const Title = styled("div")<{ withToggle?: boolean }>`
+const Title = styled("div")<{ withToggle: boolean; forceHoverStyles: boolean }>`
   position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
   height: 36px;
-  ${({ theme, withToggle }) => `
+  ${({ theme, withToggle, forceHoverStyles }) => `
     padding: 0px ${theme.space.element}px;
     font-family: ${theme.font.family.main};
     font-weight: ${theme.font.weight.bold};
@@ -104,9 +110,10 @@ const Title = styled("div")<{ withToggle?: boolean }>`
       withToggle
         ? `
     cursor: pointer;
+    background-color: ${forceHoverStyles ? theme.color.background.lightest : "transparent"};
     svg {
       cursor: pointer;
-      color: ${theme.color.separators.default};
+      color: ${forceHoverStyles ? theme.color.separators.dark : theme.color.separators.default};
     }
     :hover {
       background-color: ${theme.color.background.lightest};
@@ -149,12 +156,21 @@ const CardSection: React.SFC<CardSectionProps> = ({
   onActionClick,
   collapsed,
   onToggle,
+  onToggleMouseEnter,
+  onToggleMouseLeave,
+  forceToggleHoverStyles,
   ...props
 }) => (
   <Container {...props}>
     <Overlay overlayType={makeOverlayType(disabled, dragAndDropFeedback)} />
     {title && (
-      <Title withToggle={Boolean(onToggle)} onClick={onToggle}>
+      <Title
+        onMouseEnter={onToggleMouseEnter}
+        onMouseLeave={onToggleMouseLeave}
+        withToggle={Boolean(onToggle)}
+        forceHoverStyles={Boolean(forceToggleHoverStyles)}
+        onClick={onToggle}
+      >
         {title}
         {onToggle && <Icon name={collapsed ? "ChevronDown" : "ChevronUp"} />}
         {actions && <StyledActionMenu items={actions} onClick={onActionClick} />}

--- a/src/CardSection/CardSection.tsx
+++ b/src/CardSection/CardSection.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import ActionMenu from "../ActionMenu/ActionMenu"
 import { ContextMenuProps } from "../ContextMenu/ContextMenu"
+import Icon from "../Icon/Icon"
 import { DefaultProps, DragProps } from "../types"
 import styled from "../utils/styled"
 
@@ -24,6 +25,8 @@ export interface CardSectionProps extends DefaultProps, DragProps {
   onActionClick?: ContextMenuProps["onClick"]
   /** Is this collapsed? */
   collapsed?: boolean
+  /** Toggle collapsed state */
+  onToggle?: () => void
 }
 
 export type DragAndDropFeedback = "validTarget" | "invalidTarget" | "dropping"
@@ -84,18 +87,36 @@ const Content = styled("div")<{ noHorizontalPadding?: boolean }>`
   `};
 `
 
-const Title = styled("div")`
+const Title = styled("div")<{ withToggle?: boolean }>`
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   height: 36px;
-  ${({ theme }) => `
+  ${({ theme, withToggle }) => `
     padding: 0px ${theme.space.element}px;
     font-family: ${theme.font.family.main};
     font-weight: ${theme.font.weight.bold};
     color: ${theme.color.text.lighter};
     font-size: ${theme.font.size.body};
     border-bottom: 1px solid ${theme.color.separators.default};
+    ${
+      withToggle
+        ? `
+    cursor: pointer;
+    svg {
+      cursor: pointer;
+      color: ${theme.color.separators.default};
+    }
+    :hover {
+      background-color: ${theme.color.background.lightest};
+    }
+    :hover svg {
+      color: ${theme.color.separators.dark};
+    }
+    `
+        : ""
+    }
   `};
 `
 
@@ -127,13 +148,15 @@ const CardSection: React.SFC<CardSectionProps> = ({
   noHorizontalPadding,
   onActionClick,
   collapsed,
+  onToggle,
   ...props
 }) => (
   <Container {...props}>
     <Overlay overlayType={makeOverlayType(disabled, dragAndDropFeedback)} />
     {title && (
-      <Title>
+      <Title withToggle={Boolean(onToggle)} onClick={onToggle}>
         {title}
+        {onToggle && <Icon name={collapsed ? "ChevronDown" : "ChevronUp"} />}
         {actions && <StyledActionMenu items={actions} onClick={onActionClick} />}
       </Title>
     )}

--- a/src/CardSection/README.md
+++ b/src/CardSection/README.md
@@ -3,11 +3,24 @@ Card sections are flexibly stacked sub-containers designed to fit within cards. 
 ### Simple usage
 
 ```jsx
-<div style={{ width: 300 }}>
+initialState = {
+  isCollapsed: true,
+}
+;<div style={{ width: 300 }}>
   <Card
     sections={
       <>
-        <CardSection title="Section 1">Content 1</CardSection>
+        <CardSection
+          title="Section 1"
+          collapsed={state.isCollapsed}
+          onToggle={() => {
+            setState(prevState => ({
+              isCollapsed: !prevState.isCollapsed,
+            }))
+          }}
+        >
+          Content 1
+        </CardSection>
         <CardSection title="Section 2">Content2</CardSection>
       </>
     }

--- a/src/CardSection/README.md
+++ b/src/CardSection/README.md
@@ -44,6 +44,68 @@ initialState = {
 </div>
 ```
 
+### Synchronized stacking
+
+```jsx
+initialState = {
+  isCollapsed: false,
+  isHovered: false,
+}
+;<div style={{ width: 300 }}>
+  <Card
+    stackSections="horizontal"
+    sections={
+      <>
+        <CardSection
+          title="Section 1"
+          collapsed={state.isCollapsed}
+          forceToggleHoverStyles={state.isHovered}
+          onToggleMouseEnter={() => {
+            setState(() => ({
+              isHovered: true,
+            }))
+          }}
+          onToggleMouseLeave={() => {
+            setState(() => ({
+              isHovered: false,
+            }))
+          }}
+          onToggle={() => {
+            setState(prevState => ({
+              isCollapsed: !prevState.isCollapsed,
+            }))
+          }}
+        >
+          Content 1
+        </CardSection>
+        <CardSection
+          title="Section 2"
+          collapsed={state.isCollapsed}
+          forceToggleHoverStyles={state.isHovered}
+          onToggleMouseEnter={() => {
+            setState(() => ({
+              isHovered: true,
+            }))
+          }}
+          onToggleMouseLeave={() => {
+            setState(() => ({
+              isHovered: false,
+            }))
+          }}
+          onToggle={() => {
+            setState(prevState => ({
+              isCollapsed: !prevState.isCollapsed,
+            }))
+          }}
+        >
+          Content 2
+        </CardSection>
+      </>
+    }
+  />
+</div>
+```
+
 ### Actions
 
 ```jsx

--- a/src/Internals/IconButton.tsx
+++ b/src/Internals/IconButton.tsx
@@ -1,0 +1,24 @@
+import styled from "../utils/styled"
+
+const IconButton = styled("div")<{ hidden_?: boolean; hoverEffect?: boolean }>(({ theme, hidden_, hoverEffect }) => ({
+  cursor: "pointer",
+  width: 20,
+  height: 20,
+  padding: 4,
+  borderRadius: theme.borderRadius,
+  "& svg": {
+    cursor: "pointer",
+    width: 12,
+    height: 12,
+  },
+  ...(hidden_ ? { visibility: "hidden" } : {}),
+  ...(hoverEffect
+    ? {
+        ":hover": {
+          backgroundColor: theme.color.background.light,
+        },
+      }
+    : {}),
+}))
+
+export default IconButton

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import Icon from "../Icon/Icon"
+import IconButton from "../Internals/IconButton"
 import SmallNameTag from "../Internals/SmallNameTag"
 import { DefaultProps } from "../types"
 import constants, { expandColor } from "../utils/constants"
@@ -84,29 +85,6 @@ const TreeLabel = styled("span")`
   word-wrap: break-word;
   flex: 1;
 `
-
-/**
- * This is a single-use close button with hard-coded padding to ensure the close icon inside stays readable.
- * @todo look into re-using and formalizing this element.
- */
-const IconButton = styled("div")<{ hidden_?: boolean; hoverEffect?: boolean }>(({ theme, hidden_, hoverEffect }) => ({
-  cursor: "pointer",
-  width: 20,
-  height: 20,
-  padding: 4,
-  borderRadius: theme.borderRadius,
-  "& svg": {
-    cursor: "pointer",
-  },
-  ...(hidden_ ? { visibility: "hidden" } : {}),
-  ...(hoverEffect
-    ? {
-        ":hover": {
-          backgroundColor: theme.color.background.light,
-        },
-      }
-    : {}),
-}))
 
 export interface ReorderProps {
   onReorder: TreeProps["onReorder"]
@@ -226,7 +204,7 @@ const TreeRecursive: React.SFC<
       >
         {maxDepth > 1 && (
           <IconButton hidden_={childNodes.length === 0}>
-            <Icon name={isOpen ? "ChevronDown" : "Add"} size={12} />
+            <Icon name={isOpen ? "ChevronDown" : "Add"} />
           </IconButton>
         )}
         {tree.tag && <SmallNameTag color={tagColor}>{tree.tag}</SmallNameTag>}
@@ -239,7 +217,7 @@ const TreeRecursive: React.SFC<
               onRemove()
             }}
           >
-            <Icon name="No" size={12} />
+            <Icon name="No" />
           </IconButton>
         )}
       </TreeItem>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,6 +45,8 @@ const backgroundColors = {
  * A specialized color palette for separators.
  */
 const separatorColors = {
+  /** `#aaaaaa` */
+  dark: "#aaaaaa",
   /** `#e8e8e8` */
   default: "#e8e8e8",
   /** `#ececec` */


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

This PR takes care of foldable behavior for card sections with a simple `onToggle` handler. Fold behavior is fully controlled in this implementation, anticipating the need to expand/collapse card sections when not clicking (e.g. dragging something into a different card section).

![sections](https://user-images.githubusercontent.com/6738398/50836823-74daee00-135a-11e9-922b-11a6c0d9ec4e.gif)

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
