### PR TITLE
Add `leftOfTabs` prop to cards

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -8,12 +8,6 @@ import styled from "../utils/styled"
 export interface BaseProps extends DefaultProps {
   /** Component containing buttons/links/actions assigned to the card */
   action?: React.ReactNode
-  /** Card tabs */
-  tabs?: Tab[]
-  /** Active tab name */
-  activeTabName?: string
-  /** Callback fired on tab change */
-  onTabChange?: (newTabName: string) => void
   /**
    * Fill all the height of the parent.
    */
@@ -82,6 +76,8 @@ export interface CardPropsWithTabs extends BaseProps {
    * This will disable any children to render `tabs[i].component` instead
    */
   tabs: Tab[]
+  /** UI to render left of tabs */
+  leftOfTabs?: React.ReactNode
   /**
    * Active tab name
    *
@@ -92,6 +88,11 @@ export interface CardPropsWithTabs extends BaseProps {
    * Send the active name tab on each tab change (in lowercase).
    */
   onTabChange?: (name: string) => void
+}
+
+// Type guard to check whether we're working with a card with tabs, detecting type correctly afterwards
+const isWithTabs = <T extends {}>(props: CardProps<T>): props is CardPropsWithTabs => {
+  return props.hasOwnProperty("tabs")
 }
 
 export type CardProps<T extends {} = {}> = CardPropsWithChildrenOrData<T> | CardPropsWithSections | CardPropsWithTabs
@@ -125,6 +126,19 @@ const Content = styled("div")<{ fullSize?: boolean }>`
   white-space: pre-wrap;
   word-wrap: break-all;
   hyphens: auto;
+`
+
+const TabsBarContainer = styled("div")`
+  display: flex;
+  align-items: center;
+`
+
+/**
+ * This extra element is necessary to prevent buttons added in the `leftOfTabs` prop to extend
+ * to full height.
+ */
+const TabsBarLeftContainer = styled("div")`
+  margin-right: 32px;
 `
 
 const SectionsContainer = styled("div")<{ stackHorizontal: boolean }>`
@@ -167,9 +181,6 @@ function Card<T extends {}>(props: CardProps<T>) {
     keys,
     children,
     action,
-    tabs,
-    activeTabName,
-    onTabChange,
     fullSize,
     ...rest
   } = props
@@ -183,12 +194,20 @@ function Card<T extends {}>(props: CardProps<T>) {
     )
   }
 
-  if (tabs) {
+  if (isWithTabs(props)) {
     return (
-      <Tabs tabs={tabs} activeTabName={activeTabName} onTabChange={onTabChange}>
+      <Tabs tabs={props.tabs} activeTabName={props.activeTabName} onTabChange={props.onTabChange}>
         {({ tabsBar, activeChildren }) => (
           <Container {...rest}>
-            <CardHeader title={tabsBar} action={action} />
+            <CardHeader
+              title={
+                <TabsBarContainer>
+                  <TabsBarLeftContainer>{props.leftOfTabs}</TabsBarLeftContainer>
+                  {tabsBar}
+                </TabsBarContainer>
+              }
+              action={props.action}
+            />
             <Content fullSize={fullSize}>{activeChildren}</Content>
           </Container>
         )}

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -108,7 +108,7 @@ These features are shown in the example below:
 
 ```jsx
 initialState = {
-  activeTab: "Tab 1",
+  activeTab: "Results",
   isTab1Loading: false,
 }
 ;<Card
@@ -116,33 +116,36 @@ initialState = {
   onTabChange={newTabName => {
     setState(() => ({ activeTab: newTabName }))
   }}
+  leftOfTabs={
+    <Button
+      condensed
+      color="primary"
+      onClick={() => {
+        setState(() => ({
+          isTab1Loading: true,
+        }))
+        setTimeout(() => {
+          setState(() => ({
+            isTab1Loading: false,
+          }))
+        }, 1500)
+      }}
+    >
+      Run query
+    </Button>
+  }
   tabs={[
     {
-      name: "Tab 1",
-      children: (
-        <Button
-          onClick={() => {
-            setState(() => ({
-              isTab1Loading: true,
-            }))
-            setTimeout(() => {
-              setState(() => ({
-                isTab1Loading: false,
-              }))
-            }, 1500)
-          }}
-        >
-          Refresh
-        </Button>
-      ),
+      name: "Results",
+      children: state.isTab1Loading ? "" : "The answer is 42",
       loading: state.isTab1Loading,
       // The icon is replaced by a spinner when loading.
       icon: "Yes",
       iconColor: "success",
     },
     {
-      name: "Tab 2",
-      children: <Button>The other kind of button</Button>,
+      name: "Logs",
+      children: "Here are some logs to the calculation",
     },
   ]}
 />
@@ -160,7 +163,7 @@ initialState = {
 ```jsx
 <div style={{ display: "flex" }}>
   <div style={{ width: 200 }}>
-    <Card>zOMGWTFBBQ!!!11!!1https://github.com/contiamo/operational-ui</Card>
+    <Card>https://github.com/contiamo/operational-ui</Card>
   </div>
   <div style={{ marginLeft: 16, width: 200 }}>
     <Card title="I have a Header">


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

There is a design need to add elements like a button left of card tabs, as shown here:

![left-of-tabs](https://user-images.githubusercontent.com/6738398/50827103-da6cb180-133d-11e9-97b1-9f7fe5b48a4e.gif)

This is done with a `leftOfTabs` prop, which is on the descriptive side. Let me know if you have naming alternatives in mind.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
