### PR TITLE
**Feature**: Full width column in modal

### DIFF
--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -9,14 +9,17 @@ export interface CardColumnProps extends DefaultProps {
   contentRight?: boolean
   /** Set the component as a flex-box column */
   flexColumn?: boolean
+  /** Force the column to be full with */
+  fullWidth?: boolean
 }
 
-const Container = styled("div")<CardColumnProps>(({ theme, contentRight, flexColumn }) => ({
+const Container = styled("div")<CardColumnProps>(({ theme, contentRight, flexColumn, fullWidth }) => ({
   label: "card-column",
   height: "min-content",
   minWidth: 280 / 2,
-  padding: theme!.space.element / 2,
-  flex: "1 0",
+  padding: theme.space.element / 2,
+  marginRight: fullWidth ? -theme.space.element : undefined,
+  flex: fullWidth ? "100%" : "1 0",
   " img": {
     maxWidth: "100%",
   },

--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -11,13 +11,15 @@ export interface CardColumnProps extends DefaultProps {
   flexColumn?: boolean
   /** Force the column to be full with */
   fullWidth?: boolean
+  /** Remove padding */
+  noPadding?: boolean
 }
 
-const Container = styled("div")<CardColumnProps>(({ theme, contentRight, flexColumn, fullWidth }) => ({
+const Container = styled("div")<CardColumnProps>(({ theme, contentRight, flexColumn, fullWidth, noPadding }) => ({
   label: "card-column",
   height: "min-content",
   minWidth: 280 / 2,
-  padding: theme.space.element / 2,
+  padding: noPadding ? 0 : theme.space.element / 2,
   flex: fullWidth ? "100%" : "1 0",
   " img": {
     maxWidth: "100%",

--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -18,7 +18,6 @@ const Container = styled("div")<CardColumnProps>(({ theme, contentRight, flexCol
   height: "min-content",
   minWidth: 280 / 2,
   padding: theme.space.element / 2,
-  marginRight: fullWidth ? -theme.space.element : undefined,
   flex: fullWidth ? "100%" : "1 0",
   " img": {
     maxWidth: "100%",

--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -20,7 +20,7 @@ const Container = styled("div")<CardColumnProps>(({ theme, contentRight, flexCol
   height: "min-content",
   minWidth: 280 / 2,
   padding: noPadding ? 0 : theme.space.element / 2,
-  flex: fullWidth ? "100%" : "1 0",
+  flex: fullWidth ? "1 1 100%" : "1 0",
   " img": {
     maxWidth: "100%",
   },

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -5,7 +5,6 @@ export const CardColumns = styled("div")<React.Props<{}>>(({ children, theme }) 
   display: "flex",
   flexWrap: "wrap",
   margin: -(theme.space.element / 2),
-  width: `calc(100% + ${theme.space.element}px)`,
   "& > *": {
     flexBasis: `${React.Children.count(children)}%`,
   },

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -5,7 +5,7 @@ export const CardColumns = styled("div")<React.Props<{}>>(({ children, theme }) 
   display: "flex",
   flexWrap: "wrap",
   margin: -(theme.space.element / 2),
-  maxWidth: "100%",
+  width: `calc(100% + ${theme.space.element}px)`,
   "& > *": {
     flexBasis: `${React.Children.count(children)}%`,
   },

--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -46,7 +46,7 @@ export const ControlledModalContent = styled("div")<{ fullSize: boolean }>(
     fullSize
       ? {
           height: `calc(100% - ${actionsBarSize}px)`,
-          overflow: "auto",
+          overflowY: "auto",
         }
       : {},
 )

--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -41,15 +41,18 @@ export const Actions = styled("div")`
   height: ${actionsBarSize}px;
 `
 
-export const ControlledModalContent = styled("div")<{ fullSize: boolean }>(
-  ({ fullSize }) =>
-    fullSize
-      ? {
-          height: `calc(100% - ${actionsBarSize}px)`,
-          overflowY: "auto",
-        }
-      : {},
-)
+export const ControlledModalContent = styled("div")<{ fullSize: boolean }>(({ fullSize, theme }) => ({
+  // Invert control of spacing from Card to Modal
+  margin: theme.space.element * -1,
+  padding: theme.space.element,
+
+  ...(fullSize
+    ? {
+        height: `calc(100% - ${actionsBarSize}px)`,
+        overflowY: "auto",
+      }
+    : {}),
+}))
 
 export class Confirm<T> extends React.Component<Props, Readonly<State<T>>> {
   public readonly state: State<T> = {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Improve how we deal with spacing between cardColumn and Confirm to allow more complex setup.

It's published as `@operational/components@12.4.0-43-gd7a2df8e` and tested in labs-ui and pantheon-ui to be sure that everything follow as expected.

It's breaking for custom modal implementation, the migration to `ControlledModalContent` and `Actions` fix everything.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] This looks amazing in pantheon-ui
- [x] This looks amazing in labs-ui (PR incoming for the migration)

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
