### PR TITLE
**Feature:** Allow Pages to have tabs without a title

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -157,7 +157,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
       >
         {({ tabsBar, activeChildren }) => (
           <>
-            {title && (
+            {title ? (
               <TitleBar color={color}>
                 <TitleContainer>
                   <Title>{title}</Title>
@@ -166,8 +166,10 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
                 </TitleContainer>
                 {!condensedTitle && tabsBar}
               </TitleBar>
+            ) : (
+              <TitleBar color={color}>{tabsBar}</TitleBar>
             )}
-            <ViewContainer isInTab isTitleCondensed={condensedTitle} hasTitle={Boolean(title)}>
+            <ViewContainer isInTab isTitleCondensed={condensedTitle} hasTitle>
               {activeChildren}
             </ViewContainer>
           </>

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -151,6 +151,23 @@ const Tab = props => (
 />
 ```
 
+### With tabs and no title
+
+```jsx
+const Tab = props => (
+  <PageContent>
+    <Card title={`${props.title} Tab`} />
+  </PageContent>
+)
+;<Page
+  tabs={[
+    { name: "overview", children: <Tab title="Overview" />, icon: "Search" },
+    { name: "jobs", children: <Tab title="Jobs" /> },
+    { name: "functions", children: <Tab title="Functions" /> },
+  ]}
+/>
+```
+
 ### With White Tabs
 
 ```jsx


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR allows pages to have Tabs without `title`s to implement a new design.

![image](https://user-images.githubusercontent.com/9947422/51850365-e25ab880-2321-11e9-810b-3d69609da3ee.png)



# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
