### PR TITLE
**Feature:** Add `width` to table columns

### DIFF
--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -11,6 +11,18 @@ You can render a simple use-case of the table by specifying a list of records an
 />
 ```
 
+### With Fixed Layout
+
+Tables perform better with a forced fixed layout, since the browser doesn't have to recalculate positions depending on the contents of the table. Here's what the same table looks like with a fixed layout.
+
+```js
+<Table
+  fixedLayout
+  data={[{ name: "Max", profession: "Carpenter" }, { name: "Moritz", profession: "Baker" }]}
+  columns={["name", "profession"]}
+/>
+```
+
 ### Simple Usage without Header
 
 ```js
@@ -72,6 +84,63 @@ const data = [
     { heading: "Name", cell: dataEntry => dataEntry.name },
     { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
     { heading: "Tags", cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>) },
+    { heading: "Collaborators", cell: dataEntry => <AvatarGroup avatars={dataEntry.collaborators} /> },
+  ]}
+  onRowClick={(dataEntry, i) => console.log({ dataEntry, i })}
+/>
+```
+
+### With custom widths per column
+
+We can customize the look of the table by specifying a `width` property on certain columns.
+
+```jsx
+const data = [
+  {
+    name: "Mega Deal Dev",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+    collaborators: [
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+    ],
+  },
+  {
+    name: "Mega Deal Dev",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+    collaborators: [
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+    ],
+  },
+  {
+    name: "Toy Bundle",
+    lastUpdated: "2018-06-06",
+    tags: ["agent-view", "production"],
+    collaborators: [
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+      { photo: "https://graph.facebook.com/775278331/picture", name: "Tejas Kumar" },
+    ],
+  },
+]
+;<Table
+  data={data}
+  columns={[
+    { heading: "", cell: dataEntry => <Icon name="Box" color="info" /> },
+    { heading: "Name", width: 600, cell: dataEntry => dataEntry.name },
+    { heading: "Last updated", cell: dataEntry => dataEntry.lastUpdated },
+    {
+      heading: "Tags",
+      width: 100,
+      cell: dataEntry => dataEntry.tags.map((tag, tagIndex) => <Chip key={tagIndex}>{tag}</Chip>),
+    },
     { heading: "Collaborators", cell: dataEntry => <AvatarGroup avatars={dataEntry.collaborators} /> },
   ]}
   onRowClick={(dataEntry, i) => console.log({ dataEntry, i })}

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -96,13 +96,17 @@ const Td = styled("td")<{ cellWidth?: Column<any>["width"] }>(({ theme, cellWidt
   verticalAlign: "middle",
   borderBottom: `1px solid ${theme.color.separators.default}`,
   color: theme.color.text.default,
-  wordBreak: "break-all",
-  wordWrap: "break-word",
   hyphens: "auto",
   "&:first-child": {
     paddingLeft: theme.space.small,
   },
-  ...(cellWidth ? { width: cellWidth } : {}),
+  ...(cellWidth
+    ? {
+        width: cellWidth,
+        wordBreak: "break-all",
+        wordWrap: "break-word",
+      }
+    : {}),
 }))
 
 const Actions = styled(Td)(({ theme }) => ({

--- a/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Table Component Should render 1`] = `
     class="css-ar73w8-Messages"
   />
   <table
-    class="css-39fsjl"
+    class="css-je0z3e"
   >
     <thead
       class="css-x4ot8q"
@@ -22,7 +22,7 @@ exports[`Table Component Should render 1`] = `
         class="css-16kb41"
       >
         <td
-          class="css-1lbz3s3"
+          class="css-1umysmp"
           colspan="0"
         >
           There are no records available

--- a/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Table Component Should render 1`] = `
         class="css-16kb41"
       >
         <td
-          class="css-1umysmp"
+          class="css-1duroev"
           colspan="0"
         >
           There are no records available


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR adds an optional `width` property to Table's `Column` type, which will allow us to specify widths for columns and fix the IdP weird ugly issue.

It also adds support for fixed table layouts in case our users want perf benefits.

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
