### PR TITLE
**Fix:** width of fullWidth textareas

### DIFF
--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -4,10 +4,13 @@ import { isCmdEnter } from "../utils"
 import styled from "../utils/styled"
 
 const Container = styled("form")(({ theme }) => ({
+  "> div, > label": {
+    display: "block",
+  },
+
   // Space between groups
   "> :not(:last-child)": {
     marginBottom: 34 - theme.space.small,
-    display: "block",
   },
 
   // Space between children _inside_ groups

--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -21,27 +21,35 @@ const handleChange = key => value => {
   setState(() => ({ [key]: value }))
 }
 ;<Form>
-  <Textarea value={state.v1} onChange={handleChange("v1")} label="simple" />
-  <Textarea copy value={state.v2} onChange={handleChange("v2")} label="with copying" />
-  <Textarea
-    value={state.v3}
-    onChange={handleChange("v3")}
-    label="with actions"
-    action={
-      <div>
-        <Icon size={8} name="Open" />
-        <a href="#textarea">More information</a>
-      </div>
-    }
-  />
-  <Textarea value={state.v4} onChange={handleChange("v4")} label="with error" error="oh no!" />
-  <Textarea value={state.v5} onChange={handleChange("v5")} label="with hint" hint="this is a hint" />
-  <Textarea value={state.v6} onChange={handleChange("v6")} label="disabled" disabled />
-  <Textarea value={state.v7} onChange={handleChange("v7")} label="a code" code />
-  <Textarea value={state.v8} onChange={handleChange("v8")} label="fixed height" height={200} />
-  <Textarea value={state.v9} onChange={handleChange("v9")} label="full width" height={200} fullWidth />
-  /* full width without a label can behave differently */
-  <Textarea value={state.v9} onChange={handleChange("v9")} height={200} fullWidth />
+  <div>
+    <Textarea value={state.v1} onChange={handleChange("v1")} label="simple" />
+    <Textarea value={state.v4} onChange={handleChange("v4")} label="with error" error="oh no!" />
+    <Textarea value={state.v5} onChange={handleChange("v5")} label="with hint" hint="this is a hint" />
+    <Textarea value={state.v6} onChange={handleChange("v6")} label="disabled" disabled />
+    <Textarea value={state.v7} onChange={handleChange("v7")} label="a code" code />
+    <Textarea value={state.v8} onChange={handleChange("v8")} label="fixed height" height={200} />
+  </div>
+  <div>
+    <Textarea copy value={state.v2} onChange={handleChange("v2")} label="with copying" />
+    <Textarea
+      value={state.v3}
+      onChange={handleChange("v3")}
+      label="with actions"
+      action={
+        <div>
+          <Icon size={8} name="Open" />
+          <a href="#textarea">More information</a>
+        </div>
+      }
+    />
+  </div>
+  <div>
+    <Textarea value={state.v9} onChange={handleChange("v9")} label="full width" fullWidth />
+  </div>
+  <div>
+    {/* full width without a label can behave differently */}
+    <Textarea value={state.v9} onChange={handleChange("v9")} fullWidth />
+  </div>
 </Form>
 ```
 

--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -14,6 +14,7 @@ initialState = {
   v6: "",
   v7: "",
   v8: "",
+  v9: "",
 }
 
 const handleChange = key => value => {
@@ -38,6 +39,9 @@ const handleChange = key => value => {
   <Textarea value={state.v6} onChange={handleChange("v6")} label="disabled" disabled />
   <Textarea value={state.v7} onChange={handleChange("v7")} label="a code" code />
   <Textarea value={state.v8} onChange={handleChange("v8")} label="fixed height" height={200} />
+  <Textarea value={state.v9} onChange={handleChange("v9")} label="full width" height={200} fullWidth />
+  /* full width without a label can behave differently */
+  <Textarea value={state.v9} onChange={handleChange("v9")} height={200} fullWidth />
 </Form>
 ```
 

--- a/src/utils/mixins.ts
+++ b/src/utils/mixins.ts
@@ -20,7 +20,7 @@ export const Label = styled("label")<{ fullWidth?: boolean; left?: boolean }>(({
 
 export const FormFieldControls = styled("div")({
   position: "absolute",
-  top: 3,
+  top: -2,
   right: 0,
 })
 
@@ -41,10 +41,11 @@ export const FormFieldControl = styled("div")(({ theme }) => ({
   cursor: "pointer",
   position: "relative",
   verticalAlign: "middle",
-  display: "inline-block",
-  width: "fit-content",
+  display: "inline-flex",
+  width: 12,
   marginLeft: theme.space.base,
   color: theme.color.text.lightest,
+  height: 12,
   ...hoverTooltip,
   "& svg": {
     position: "relative",

--- a/src/utils/mixins.ts
+++ b/src/utils/mixins.ts
@@ -14,6 +14,7 @@ export const Label = styled("label")<{ fullWidth?: boolean; left?: boolean }>(({
   display: "inline-block",
   position: "relative",
   maxWidth: fullWidth ? "none" : "360px",
+  width: fullWidth ? "100%" : "auto",
   marginRight: left ? theme.space.small : 0,
 }))
 


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR fixes a regression on textareas that didn't honor the `fullWidth` prop.
