### PR TITLE
**Feature: ** Add custom padding prop to PageContent

### DIFF
--- a/src/PageArea/README.md
+++ b/src/PageArea/README.md
@@ -55,6 +55,29 @@ In this case `PageArea` is implicit
 </PageContent>
 ```
 
+### With 2 columns and custom padding
+
+```jsx
+<PageContent areas="side main" padding="small">
+  <PageArea name="main">
+    <Card title="My bundle" />
+  </PageArea>
+  <PageArea name="side">
+    <Card title="Deploy functions" />
+    <Card title="Sync" />
+    <Card title="Repository" />
+  </PageArea>
+</PageContent>
+```
+
+### With no padding
+
+```jsx
+<PageContent noPadding fill>
+  <Card title="My bundle" />
+</PageContent>
+```
+
 ### Inside tabs
 
 ```jsx

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -10,7 +10,7 @@ export interface ModalConfirmContext {
   confirm: <T = undefined>(confirmOptions: ConfirmOptions<T>) => void
 }
 
-const isRenderChild = (
+const isChildFunction = (
   children: PageContentProps["children"],
 ): children is ((modalConfirmContext: ModalConfirmContext) => React.ReactNode) => typeof children === "function"
 
@@ -104,7 +104,7 @@ const PageContent = ({ children, ...props }: PageContentProps) => {
           {confirm => (
             <Container>
               <StyledPageContent {...props}>
-                {isRenderChild(children) ? children({ confirm, modal }) : children}
+                {isChildFunction(children) ? children({ confirm, modal }) : children}
               </StyledPageContent>
             </Container>
           )}

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import Confirm, { ConfirmOptions } from "../Internals/Confirm"
 import Modal, { ModalOptions } from "../Internals/Modal"
 import { DefaultProps } from "../types"
+import { space } from "../utils/constants"
 import styled from "../utils/styled"
 
 export interface ModalConfirmContext {
@@ -9,66 +10,84 @@ export interface ModalConfirmContext {
   confirm: <T = undefined>(confirmOptions: ConfirmOptions<T>) => void
 }
 
-export interface PageContentProps extends DefaultProps {
+const isRenderChild = (
+  children: PageContentProps["children"],
+): children is ((modalConfirmContext: ModalConfirmContext) => React.ReactNode) => typeof children === "function"
+
+export interface BasePageContentProps extends DefaultProps {
   /** Children to render, you */
   children?: React.ReactNode | ((modalConfirmContext: ModalConfirmContext) => React.ReactNode)
   /** Areas template for `PageArea` disposition */
   areas?: "main" | "main side" | "side main"
   /** Fill the entire width */
   fill?: boolean
+}
+
+export interface PageContentNoPaddingProps extends BasePageContentProps {
   /** Don't pad */
   noPadding?: boolean
+  /** Add a padding */
+  padding?: never
 }
+
+export interface PageContentWithPaddingProps extends BasePageContentProps {
+  /** Don't pad */
+  noPadding?: never
+  /** Add a padding */
+  padding?: keyof typeof space
+}
+
+export type PageContentProps = PageContentNoPaddingProps | PageContentWithPaddingProps
 
 const sideSize = 280
 
-const StyledPageContent = styled("div")<{ areas?: PageContentProps["areas"]; fill_: boolean; noPadding: boolean }>(
-  props => {
-    const gridTemplateColumns = {
-      main: props.fill_ ? "100%" : "auto",
-      "main side": `auto ${sideSize}px`,
-      "side main": `${sideSize}px auto`,
-    }[props.areas || "main"]
+const StyledPageContent = styled("div", {
+  shouldForwardProp: props => !["fill", "padding", "noPadding"].includes(props),
+})<PageContentProps>(props => {
+  const gridTemplateColumns = {
+    main: props.fill ? "100%" : "auto",
+    "main side": `auto ${sideSize}px`,
+    "side main": `${sideSize}px auto`,
+  }[props.areas || "main"]
 
-    return {
-      gridTemplateColumns,
-      display: "grid",
-      alignItems: "start",
-      gridTemplateAreas: `"${props.areas || "main"}"`,
-      gridGap: props.theme.space.element,
-      width: "100%",
-      height: "100%",
-      minWidth: 800,
-      maxWidth: props.fill_ ? "none" : 1150,
-      padding: props.noPadding ? 0 : `${props.theme.space.element}px`,
+  return {
+    gridTemplateColumns,
+    display: "grid",
+    alignItems: "start",
+    gridTemplateAreas: `"${props.areas || "main"}"`,
+    gridGap: props.theme.space.element,
+    width: "100%",
+    height: "100%",
+    minWidth: 800,
+    maxWidth: props.fill ? "none" : 1150,
+    padding: props.noPadding ? 0 : `${props.theme.space[props.padding || "element"]}px`,
 
-      /**
-       * Since PageContent is in a scrollable context,
-       * a user often scrolls past the bottom padding
-       * on large pages, and the bottom edge of the last
-       * child touches the bottom of the container: there
-       * _is no padding on the bottom_ because it has been
-       * passed.
-       *
-       * The following hack adds a small piece of pseudo-DOM
-       * in order to preserve space on the bottom.
-       *
-       * The `grid-gap` adds appropriate bottom spacing to
-       * PageContent since this pseudo-element is seen as a
-       * grid row.
-       */
-      ...(props.fill_
-        ? {}
-        : {
-            "::after": {
-              content: '""',
-              display: "block",
-              height: 1,
-            },
-          }),
-    }
-  },
-)
+    /**
+     * Since PageContent is in a scrollable context,
+     * a user often scrolls past the bottom padding
+     * on large pages, and the bottom edge of the last
+     * child touches the bottom of the container: there
+     * _is no padding on the bottom_ because it has been
+     * passed.
+     *
+     * The following hack adds a small piece of pseudo-DOM
+     * in order to preserve space on the bottom.
+     *
+     * The `grid-gap` adds appropriate bottom spacing to
+     * PageContent since this pseudo-element is seen as a
+     * grid row.
+     */
+    ...(props.fill
+      ? {}
+      : {
+          "::after": {
+            content: '""',
+            display: "block",
+            height: 1,
+          },
+        }),
+  }
+})
 
 const Container = styled("div")({
   position: "relative",
@@ -77,16 +96,15 @@ const Container = styled("div")({
   overflow: "auto",
 })
 
-// `fill` must be rename internally to avoid conflict with the native `fill` DOM attribute
-const PageContent: React.SFC<PageContentProps> = ({ fill, children, noPadding, ...props }) => {
+const PageContent = ({ children, ...props }: PageContentProps) => {
   return (
     <Modal>
       {modal => (
         <Confirm>
           {confirm => (
             <Container>
-              <StyledPageContent {...props} noPadding={Boolean(noPadding)} fill_={Boolean(fill)}>
-                {typeof children === "function" ? children({ confirm, modal }) : children}
+              <StyledPageContent {...props}>
+                {isRenderChild(children) ? children({ confirm, modal }) : children}
               </StyledPageContent>
             </Container>
           )}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -167,7 +167,7 @@ const font = {
  * A container of space-related constants to be
  * used throughout Operational UI.
  */
-const space = {
+export const space = {
   /** Base space is `4px` */
   base: 4,
 


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add `padding` props to `PageContent` to handle custom configuration.

It's a bit more flexible than before but still restrictive by design -> we only allow theme value as `padding`.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
