### PR TITLE
**Fix:** Adjust context menu's overlay z-index to cover everything

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -74,7 +74,7 @@ const InvisibleOverlay = styled("div")(({ theme }) => ({
   right: 0,
   left: 0,
   cursor: "default",
-  zIndex: theme.zIndex.selectOptions - 1,
+  zIndex: theme.zIndex.selectOptions + 1,
 }))
 
 class ContextMenu extends React.Component<ContextMenuProps, Readonly<State>> {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR fixes the z-index of the `InvisibleOverlay` for `ContextMenu` to properly cover everything.

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
