### PR TITLE
**Fix:** Autocomplete z-index

### DIFF
--- a/src/Autocomplete/Autocomplete.tsx
+++ b/src/Autocomplete/Autocomplete.tsx
@@ -67,7 +67,6 @@ const Container = styled(ContextMenu)<{ fullWidth: boolean }>`
   width: ${({ fullWidth }) => (fullWidth ? "100%" : "fit-content")};
   display: inline-block;
   align-items: center;
-  z-index: ${({ theme }) => theme.zIndex.selectOptions - 1}; /* always be under a select's options */
 `
 
 const initialState = { isContextMenuOpen: false }


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR fixes #934, removing a useless z-index override from `Autocomplete` and using the correct z-index that `ContextMenu` got in #927.

Here is the clickable area on Autocompletes now:

![image](https://user-images.githubusercontent.com/9947422/53250296-c1b32380-367f-11e9-9095-38dfbd150fda.png)


# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
