### PR TITLE
Feature: Add placeholder for textarea

### DIFF
--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -5,6 +5,8 @@ A textarea field, with optional label, hint and error.
 The following snippet show the text area with various visual additions handling fixed heights, errors and hints.
 
 ```jsx
+json = JSON.stringify({ test: 123 }, null, 2)
+
 initialState = {
   v1: "",
   v2: "",
@@ -28,6 +30,7 @@ const handleChange = key => value => {
     <Textarea value={state.v6} onChange={handleChange("v6")} label="disabled" disabled />
     <Textarea value={state.v7} onChange={handleChange("v7")} label="a code" code />
     <Textarea value={state.v8} onChange={handleChange("v8")} label="fixed height" height={200} />
+    <Textarea value={state.v8} onChange={handleChange("v8")} label="with placeholder" placeholder={json} />
   </div>
   <div>
     <Textarea copy value={state.v2} onChange={handleChange("v2")} label="with copying" />

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -37,6 +37,8 @@ export interface TextareaProps extends DefaultProps {
   resize?: ResizeOptions
   /** Copy text to clipboard on click */
   copy?: boolean
+  /** Text for a placeholder */
+  placeholder?: string
   /** cmd+enter submit handler */
   onSubmit?: () => void
   /** Focus handler */
@@ -180,6 +182,7 @@ class Textarea extends React.Component<TextareaProps, State> {
       onSubmit,
       onFocus,
       onBlur,
+      placeholder,
       ...props
     } = this.props
     return (
@@ -211,6 +214,7 @@ class Textarea extends React.Component<TextareaProps, State> {
             }
             onChange(e.target.value)
           }}
+          placeholder={placeholder}
         />
         {(this.props.action || this.props.copy) && (
           <ActionHeader isLabel={Boolean(label)}>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add placeholder property for textarea
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

<img width="191" alt="screenshot 2019-02-27 at 17 49 47" src="https://user-images.githubusercontent.com/179534/53507408-1dcedb00-3ab8-11e9-92eb-70d3d7afda4d.png">


# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
