### PR TITLE
**Feature:** Splash hooks & useInterval

### DIFF
--- a/src/Splash/Splash.Animation.tsx
+++ b/src/Splash/Splash.Animation.tsx
@@ -97,31 +97,24 @@ const Animation: React.FC<Props> = ({ isFullscreen, size = 600 }) => {
     5000,
     true,
   )
-  // Only will change if isFullscreen or size changes, a workaround from not having to set outter container width and height to max(window.height,window.width)
-  const Wrap = useCallback(
-    ({ children }) =>
-      isFullscreen ? (
-        <FullScreenWrap>
-          <Container>{children}</Container>
-        </FullScreenWrap>
-      ) : (
-        <Container style={{ width: size, height: size }}>{children}</Container>
-      ),
-    [isFullscreen, size],
-  )
 
-  return (
-    <Wrap>
-      {state.coordinates.map((coord: { x: number; y: number }, index: number) => (
-        <Box
-          key={index}
-          style={{
-            top: `${(coord.x / (squares - 1)) * 100}%`,
-            left: `${(coord.y / (squares - 1)) * 100}%`,
-          }}
-        />
-      ))}
-    </Wrap>
+  const children = state.coordinates.map((coord: { x: number; y: number }, index: number) => (
+    <Box
+      key={index}
+      style={{
+        top: `${(coord.x / (squares - 1)) * 100}%`,
+        left: `${(coord.y / (squares - 1)) * 100}%`,
+      }}
+    />
+  ))
+
+  // Only will change if isFullscreen or size changes, a workaround from not having to set outter container width and height to max(window.height,window.width)
+  return isFullscreen ? (
+    <FullScreenWrap>
+      <Container>{children}</Container>
+    </FullScreenWrap>
+  ) : (
+    <Container style={{ width: size, height: size }}>{children}</Container>
   )
 }
 

--- a/src/Splash/Splash.Animation.tsx
+++ b/src/Splash/Splash.Animation.tsx
@@ -108,7 +108,7 @@ const Animation: React.FC<Props> = ({ isFullscreen, size = 600 }) => {
     />
   ))
 
-  // Only will change if isFullscreen or size changes, a workaround from not having to set outter container width and height to max(window.height,window.width)
+  // Only will change if isFullscreen or size changes, a workaround from not having to set outer container width and height to max(window.height, window.width)
   return isFullscreen ? (
     <FullScreenWrap>
       <Container>{children}</Container>

--- a/src/Splash/Splash.Animation.tsx
+++ b/src/Splash/Splash.Animation.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react"
+import React, { useState } from "react"
 import useInterval from "../useInterval"
 import styled from "../utils/styled"
 

--- a/src/Splash/Splash.Animation.tsx
+++ b/src/Splash/Splash.Animation.tsx
@@ -35,7 +35,8 @@ const bounce = (coord: number): number => {
   return coord
 }
 
-// css Hack so we dont need to worry about max(window.height,window.width)
+// css Hack so we dont need to worry about max(window.height,window.width)- Only needed when fullscreen is enabled
+// https://spin.atomicobject.com/2015/07/14/css-responsive-square/
 const FullScreenWrap = styled("div")({
   position: "absolute",
   width: "100%",
@@ -96,7 +97,7 @@ const Animation: React.FC<Props> = ({ isFullscreen, size = 600 }) => {
     5000,
     true,
   )
-
+  // Only will change if isFullscreen or size changes, a workaround from not having to set outter container width and height to max(window.height,window.width)
   const Wrap = useCallback(
     ({ children }) =>
       isFullscreen ? (

--- a/src/Splash/Splash.tsx
+++ b/src/Splash/Splash.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 
 import { readableTextColor } from "../utils"
 import { expandColor, OperationalStyleConstants } from "../utils/constants"
-
 import styled from "../utils/styled"
 import Animation from "./Splash.Animation"
 import OperationalLogo from "./Splash.Logo"
@@ -93,7 +92,7 @@ const Static = styled("div")`
 const Splash: React.FC<SplashProps> = ({ color, logo, children, title, actions }) => {
   return (
     <Container color={color}>
-      <Animation fullscreen />
+      <Animation isFullscreen />
       <Content color={color}>
         <TitleBar>
           <OperationalLogo size={110} logo={logo} />

--- a/src/Splash/Splash.tsx
+++ b/src/Splash/Splash.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import { readableTextColor } from "../utils"
 import { expandColor, OperationalStyleConstants } from "../utils/constants"
+
 import styled from "../utils/styled"
 import Animation from "./Splash.Animation"
 import OperationalLogo from "./Splash.Logo"
@@ -89,47 +90,22 @@ const Static = styled("div")`
   }
 `
 
-class Splash extends React.Component<SplashProps, Readonly<State>> {
-  public readonly state = {
-    animationSize: Math.max(window.innerWidth, window.innerHeight),
-  }
-
-  public static defaultProps = {
-    color: "#fff",
-  }
-
-  public handleResize = () => {
-    this.setState({
-      animationSize: Math.max(window.innerWidth, window.innerHeight) as number,
-    })
-  }
-
-  public componentDidMount() {
-    window.addEventListener("resize", this.handleResize)
-  }
-
-  public componentWillUnmount() {
-    window.removeEventListener("resize", this.handleResize)
-  }
-
-  public render() {
-    const { logo, color } = this.props
-    return (
-      <Container color={color}>
-        <Animation size={this.state.animationSize} />
-        <Content color={color}>
-          <TitleBar>
-            <OperationalLogo size={110} logo={logo} />
-            <TitleBarContent>
-              <h1>{this.props.title}</h1>
-              <div>{this.props.actions}</div>
-            </TitleBarContent>
-          </TitleBar>
-          <Static>{this.props.children}</Static>
-        </Content>
-      </Container>
-    )
-  }
+const Splash: React.FC<SplashProps> = ({ color, logo, children, title, actions }) => {
+  return (
+    <Container color={color}>
+      <Animation fullscreen />
+      <Content color={color}>
+        <TitleBar>
+          <OperationalLogo size={110} logo={logo} />
+          <TitleBarContent>
+            <h1>{title}</h1>
+            <div>{actions}</div>
+          </TitleBarContent>
+        </TitleBar>
+        <Static>{children}</Static>
+      </Content>
+    </Container>
+  )
 }
 
 export default Splash

--- a/src/useInterval/README.md
+++ b/src/useInterval/README.md
@@ -1,18 +1,112 @@
-## Usage
+Hook version of setInterval.
 
-This hook sets up an interval and clears it after unmounting
+### Referece
+
+[Making setInterval Declarative with React Hooks](https://overreacted.io/making-setinterval-declarative-with-react-hooks/).
+
+### Usage
+
+#### Basic Counter
 
 ```jsx
-const MyComponent = () => {
-  let [count, setCount] = React.useState(0)
+function BasicCounter() {
+  const [count, setCount] = useState(0)
 
   useInterval(() => {
-    // Your custom logic here
     setCount(count + 1)
   }, 1000)
 
   return <h1>{count}</h1>
 }
 
-;<MyComponent />
+;<BasicCounter />
+```
+
+#### Using two intervals to manipulate the counter
+
+Example, we can have a delay of one interval be controlled by another:
+
+```jsx
+function Counter() {
+  const [delay, setDelay] = useState(1000)
+  const [count, setCount] = useState(0)
+
+  // Increment the counter.
+  useInterval(() => {
+    setCount(count + 1)
+  }, delay)
+
+  // Make it faster every second!
+  useInterval(() => {
+    if (delay > 10) {
+      setDelay(delay / 2)
+    }
+  }, 1000)
+
+  function handleReset() {
+    setDelay(1000)
+  }
+
+  return (
+    <>
+      <h1>Counter: {count}</h1>
+      <h4>Delay: {delay}</h4>
+      <button onClick={handleReset}>Reset delay</button>
+    </>
+  )
+}
+
+;<Counter />
+```
+
+#### Immediate argument
+
+If you need your callback to be delayed for an extended period of time, but you want it to trigger imediatley upon mounting, then pass in immediate.
+
+```jsx
+function MyComp() {
+  const [inverted, setInvert] = useState(false)
+
+  const [inverted2, setInvert2] = useState(false)
+
+  // Invert colors Immediately
+  useInterval(
+    () => {
+      setInvert(!inverted)
+    },
+    10000,
+    true,
+  )
+
+  // Invert colors
+  useInterval(() => {
+    setInvert2(!inverted2)
+  }, 10000)
+
+  // Make it faster every second!
+
+  return (
+    <div>
+      <div
+        style={{
+          background: inverted ? "navy" : "white",
+          color: inverted ? "white" : "navy",
+        }}
+      >
+        <h3> This immediatly gets inverted with navy BG </h3>
+      </div>
+
+      <div
+        style={{
+          background: inverted2 ? "navy" : "white",
+          color: inverted2 ? "white" : "navy",
+        }}
+      >
+        <h3> This needs to wait for delay to pass to make Navy </h3>
+      </div>
+    </div>
+  )
+}
+
+;<MyComp />
 ```

--- a/src/useInterval/README.md
+++ b/src/useInterval/README.md
@@ -1,0 +1,18 @@
+## Usage
+
+This hook sets up an interval and clears it after unmounting
+
+```jsx
+const MyComponent = () => {
+  let [count, setCount] = React.useState(0)
+
+  useInterval(() => {
+    // Your custom logic here
+    setCount(count + 1)
+  }, 1000)
+
+  return <h1>{count}</h1>
+}
+
+;<MyComponent />
+```

--- a/src/useInterval/README.md
+++ b/src/useInterval/README.md
@@ -1,6 +1,6 @@
-Hook version of setInterval.
+An implementation of `setInterval` with Hooks.
 
-### Referece
+### Reference
 
 [Making setInterval Declarative with React Hooks](https://overreacted.io/making-setinterval-declarative-with-react-hooks/).
 
@@ -61,12 +61,11 @@ function Counter() {
 
 #### Immediate argument
 
-If you need your callback to be delayed for an extended period of time, but you want it to trigger imediatley upon mounting, then pass in immediate.
+If you need your callback to be delayed for an extended period of time, but you want it to trigger immediately upon mounting, then pass in immediate as the third argument.
 
 ```jsx
 function MyComp() {
   const [inverted, setInvert] = useState(false)
-
   const [inverted2, setInvert2] = useState(false)
 
   // Invert colors Immediately
@@ -86,14 +85,14 @@ function MyComp() {
   // Make it faster every second!
 
   return (
-    <div>
+    <>
       <div
         style={{
           background: inverted ? "navy" : "white",
           color: inverted ? "white" : "navy",
         }}
       >
-        <h3> This immediatly gets inverted with navy BG </h3>
+        <h3>This immediately gets inverted with a navy background</h3>
       </div>
 
       <div
@@ -102,7 +101,7 @@ function MyComp() {
           color: inverted2 ? "white" : "navy",
         }}
       >
-        <h3> This needs to wait for delay to pass to make Navy </h3>
+        <h3>This needs to wait for the delay to pass to fire</h3>
       </div>
     </div>
   )

--- a/src/useInterval/README.md
+++ b/src/useInterval/README.md
@@ -10,7 +10,7 @@ An implementation of `setInterval` with Hooks.
 
 ```jsx
 function BasicCounter() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = React.useState(0)
 
   useInterval(() => {
     setCount(count + 1)
@@ -28,17 +28,20 @@ Example, we can have a delay of one interval be controlled by another:
 
 ```jsx
 function Counter() {
-  const [delay, setDelay] = useState(1000)
-  const [count, setCount] = useState(0)
+  const [start, setStart] = React.useState(false)
+  const [delay, setDelay] = React.useState(1000)
+  const [count, setCount] = React.useState(0)
 
   // Increment the counter.
   useInterval(() => {
-    setCount(count + 1)
+    if (start) {
+      setCount(count + 1)
+    }
   }, delay)
 
   // Make it faster every second!
   useInterval(() => {
-    if (delay > 10) {
+    if (delay > 10 && start) {
       setDelay(delay / 2)
     }
   }, 1000)
@@ -49,6 +52,7 @@ function Counter() {
 
   return (
     <>
+      <button onClick={() => setStart(!start)}>Toggle Counter!</button>
       <h1>Counter: {count}</h1>
       <h4>Delay: {delay}</h4>
       <button onClick={handleReset}>Reset delay</button>
@@ -65,8 +69,8 @@ If you need your callback to be delayed for an extended period of time, but you 
 
 ```jsx
 function MyComp() {
-  const [inverted, setInvert] = useState(false)
-  const [inverted2, setInvert2] = useState(false)
+  const [inverted, setInvert] = React.useState(false)
+  const [inverted2, setInvert2] = React.useState(false)
 
   // Invert colors Immediately
   useInterval(
@@ -83,7 +87,7 @@ function MyComp() {
   }, 10000)
 
   return (
-    <>
+    <div>
       <div
         style={{
           background: inverted ? "navy" : "white",

--- a/src/useInterval/README.md
+++ b/src/useInterval/README.md
@@ -82,8 +82,6 @@ function MyComp() {
     setInvert2(!inverted2)
   }, 10000)
 
-  // Make it faster every second!
-
   return (
     <>
       <div

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -1,17 +1,19 @@
 import noop from "lodash/noop"
 import { useEffect, useRef } from "react"
 
-// From: https://overreacted.io/making-setinterval-declarative-with-react-hooks/
-
 /**
- * Hook version of setInterval. Pass null to the delay to cancel an execution.
+ * Hook version of setInterval.
+ * @param {() => void} callback - Callback to be repeatedly excuted over a certain interval.
+ * @param {number | null} delay - Interval duration in ms. Pass null to cancel an execution.
+ * @param {boolean} immediate - Pass true to execute the callback immediately upon mounting.
+ * @see https://overreacted.io/making-setinterval-declarative-with-react-hooks/
  */
 export function useInterval(callback: () => void, delay: number | null, immediate?: boolean) {
   const savedCallback = useRef(noop)
 
   // Remember the latest callback.
   // useEffect has no second argument so it will be executed after each render
-  // but we don't want to change this value directly in the body of the render function, 
+  // but we don't want to change this value directly in the body of the render function,
   // because render should be pure function
   // useEffect has no second argument so it will be executed after each render
   // but we don't want to change this value directly in the body of the render function,

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react"
+
+// Ref: https://github.com/Hermanya/use-interval/blob/master/src/index.tsx
+
+// tslint:disable-next-line
+const noop = () => {}
+
+export const useInterval = (callback: () => void, delay: number | null, immediate?: boolean) => {
+  const savedCallback = useRef(noop)
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback
+  })
+
+  // Execute callback if immediate is set.
+  useEffect(() => {
+    if (immediate && delay !== null) {
+      savedCallback.current()
+    }
+  }, [immediate])
+
+  // Set up the interval.
+  useEffect(() => {
+    if (delay === null) {
+      return undefined
+    }
+    const tick = () => savedCallback.current()
+    const id = setInterval(tick, delay)
+    return () => clearInterval(id)
+  }, [delay])
+}
+
+export default useInterval

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -5,6 +5,9 @@ import { useEffect, useRef } from "react"
 // tslint:disable-next-line
 const noop = () => {}
 
+/**
+ * useInterval
+ */
 export function useInterval(callback: () => void, delay: number | null, immediate?: boolean) {
   const savedCallback = useRef(noop)
 

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react"
 // tslint:disable-next-line
 const noop = () => {}
 
-export const useInterval = (callback: () => void, delay: number | null, immediate?: boolean) => {
+export function useInterval(callback: () => void, delay: number | null, immediate?: boolean) {
   const savedCallback = useRef(noop)
 
   // Remember the latest callback.

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -6,12 +6,15 @@ import { useEffect, useRef } from "react"
 const noop = () => {}
 
 /**
- * useInterval
+ * Hook version of setInterval. Pass null to the delay to cancel an execution.
  */
 export function useInterval(callback: () => void, delay: number | null, immediate?: boolean) {
   const savedCallback = useRef(noop)
 
   // Remember the latest callback.
+  // useEffect has no second argument so it will be executed after each render
+  // but we don't want to change this value directly in the body of the render function, 
+  // because render should be pure function
   useEffect(() => {
     savedCallback.current = callback
   })
@@ -29,7 +32,7 @@ export function useInterval(callback: () => void, delay: number | null, immediat
       return undefined
     }
     const tick = () => savedCallback.current()
-    const id = setInterval(tick, delay)
+  const id = setInterval(() => savedCallback.current(), delay)
     return () => clearInterval(id)
   }, [delay])
 }

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -15,9 +15,6 @@ export function useInterval(callback: () => void, delay: number | null, immediat
   // useEffect has no second argument so it will be executed after each render
   // but we don't want to change this value directly in the body of the render function,
   // because render should be pure function
-  // useEffect has no second argument so it will be executed after each render
-  // but we don't want to change this value directly in the body of the render function,
-  // because render should be pure function
 
   // After every render, save the latest callback into our ref.
   useEffect(() => {

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -11,6 +11,9 @@ export function useInterval(callback: () => void, delay: number | null, immediat
 
   // Remember the latest callback.
   // useEffect has no second argument so it will be executed after each render
+  // but we don't want to change this value directly in the body of the render function, 
+  // because render should be pure function
+  // useEffect has no second argument so it will be executed after each render
   // but we don't want to change this value directly in the body of the render function,
   // because render should be pure function
 

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -1,4 +1,4 @@
-import { noop } from "lodash"
+import noop from "lodash/noop"
 import { useEffect, useRef } from "react"
 
 // From: https://overreacted.io/making-setinterval-declarative-with-react-hooks/

--- a/src/useInterval/index.ts
+++ b/src/useInterval/index.ts
@@ -1,9 +1,7 @@
+import { noop } from "lodash"
 import { useEffect, useRef } from "react"
 
-// Ref: https://github.com/Hermanya/use-interval/blob/master/src/index.tsx
-
-// tslint:disable-next-line
-const noop = () => {}
+// From: https://overreacted.io/making-setinterval-declarative-with-react-hooks/
 
 /**
  * Hook version of setInterval. Pass null to the delay to cancel an execution.
@@ -13,28 +11,29 @@ export function useInterval(callback: () => void, delay: number | null, immediat
 
   // Remember the latest callback.
   // useEffect has no second argument so it will be executed after each render
-  // but we don't want to change this value directly in the body of the render function, 
+  // but we don't want to change this value directly in the body of the render function,
   // because render should be pure function
+
+  // After every render, save the latest callback into our ref.
   useEffect(() => {
     savedCallback.current = callback
   })
 
-  // Execute callback if immediate is set.
   useEffect(() => {
     if (immediate && delay !== null) {
       savedCallback.current()
     }
-  }, [immediate])
+  }, [immediate]) // when immediate changes, we want to restart the timer
 
   // Set up the interval.
   useEffect(() => {
     if (delay === null) {
       return undefined
     }
-    const tick = () => savedCallback.current()
-  const id = setInterval(() => savedCallback.current(), delay)
+    // we can read and call latest callback from inside our interval:
+    const id = setInterval(() => savedCallback.current(), delay)
     return () => clearInterval(id)
-  }, [delay])
+  }, [delay]) // when delay changes, we want to restart the timer
 }
 
 export default useInterval

--- a/src/useInterval/useInterval.test.tsx
+++ b/src/useInterval/useInterval.test.tsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { cleanup, render } from "react-testing-library"
+
+import useInterval, { useInterval as namedHook } from "."
+
+// ref https://github.com/Hermanya/use-interval/blob/master/src/test.tsx
+
+beforeEach(cleanup)
+
+const MyComponent: React.FC<{ fn: () => void; delay: number | null; immediate?: boolean }> = ({
+  fn,
+  delay,
+  immediate,
+}) => {
+  useInterval(fn, delay, immediate)
+  return <span>A Interval is running </span>
+}
+
+describe("useInterval", () => {
+  it("exports a function (default)", () => {
+    expect(useInterval).toBeInstanceOf(Function)
+  })
+  it("exports a function (named)", () => {
+    expect(namedHook).toBeInstanceOf(Function)
+  })
+  it("hooks identity are the same", () => {
+    expect(useInterval).toBe(namedHook)
+  })
+  it("is a named function", () => {
+    // aids stack trace debugging.
+    expect(useInterval.name).toBe("useInterval")
+  })
+
+  describe("regular mode (delayed)", () => {
+    jest.useFakeTimers()
+
+    const fn: () => void = jest.fn()
+    const { container } = render(<MyComponent fn={fn} delay={500} />)
+
+    expect(fn).toBeCalledTimes(0 /* not called on first render */)
+    jest.advanceTimersByTime(500)
+    expect(fn).toBeCalledTimes(1)
+    jest.advanceTimersByTime(1500)
+    expect(fn).toBeCalledTimes(4)
+
+    test("cancels interval when delay is null", () => {
+      render(<MyComponent immediate fn={fn} delay={null} />, { container })
+      jest.advanceTimersByTime(1500)
+      expect(fn).toBeCalledTimes(4)
+    })
+
+    jest.clearAllTimers()
+  })
+
+  describe("immediate mode", () => {
+    jest.useFakeTimers()
+
+    const fn = jest.fn()
+    const { container } = render(<MyComponent immediate fn={fn} delay={500} />)
+
+    expect(fn).toBeCalledTimes(1 /* called immediatelly on render */)
+    jest.advanceTimersByTime(500)
+    expect(fn).toBeCalledTimes(2)
+    jest.advanceTimersByTime(1500)
+    expect(fn).toBeCalledTimes(5)
+
+    it("cancels interval when delay is null", () => {
+      render(<MyComponent immediate fn={fn} delay={null} />, { container })
+      jest.advanceTimersByTime(1500)
+      expect(fn).toBeCalledTimes(5)
+    })
+
+    jest.clearAllTimers()
+  })
+})

--- a/src/useInterval/useInterval.test.tsx
+++ b/src/useInterval/useInterval.test.tsx
@@ -4,7 +4,6 @@ import { cleanup, render } from "react-testing-library"
 import useInterval, { useInterval as namedHook } from "."
 
 // ref https://github.com/Hermanya/use-interval/blob/master/src/test.tsx
-
 beforeEach(cleanup)
 
 const MyComponent: React.FC<{ fn: () => void; delay: number | null; immediate?: boolean }> = ({

--- a/src/useInterval/useInterval.test.tsx
+++ b/src/useInterval/useInterval.test.tsx
@@ -13,7 +13,7 @@ const MyComponent: React.FC<{ fn: () => void; delay: number | null; immediate?: 
   immediate,
 }) => {
   useInterval(fn, delay, immediate)
-  return <span>A Interval is running </span>
+  return <span>An Interval is running </span>
 }
 
 describe("useInterval", () => {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Convert Splash component to use hooks and optimized a bit.
- Removed State from main  [Splash Component](https://github.com/contiamo/operational-ui/blob/master/src/Splash/Splash.tsx)( window state moved to Splash.Animation)

- Added hook useInterval (forked from [use-interval](https://github.com/Hermanya/use-interval))
- Updated [Splash.Animation](https://github.com/contiamo/operational-ui/blob/master/src/Splash/Splash.Animation.tsx) to use hooks useWindowSize & useInterval
-useInterval has option for immediate, therefore animation is triggered immediately when loaded.
- Updated small logic where dynamic styles (top & left) do not pass through styled to eliminate hectic class generation
- Added fullscreen prop inorder to trigger useWindowSize 
- use type React.FC  ( SFC is depreciated)
- Fixed type warning on intialState array creator `Array.apply(null, { length: boxes })	
      .map(Number.call, Number)` to `Array.apply(null, Array(boxes)).map((_: any, i: number) => i)`
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
[#910](https://github.com/contiamo/operational-ui/issues/910) 
<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`


