### PR TITLE
**Breaking:** Add columns param to CardColumns

### DIFF
--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -9,8 +9,6 @@ export interface BaseCardColumnProps extends DefaultProps {
   title?: string
   /** Align the content to the right */
   contentRight?: boolean
-  /** Set the component as a flex-box column */
-  flexColumn?: boolean
   /** Force the column to be full with */
   fullWidth?: boolean
   /** Remove padding */
@@ -37,8 +35,8 @@ export interface CardColumnPropsWithoutTabs extends BaseCardColumnProps {
 
 export type CardColumnProps = CardColumnPropsWithTabs | CardColumnPropsWithoutTabs
 
-const Container = styled("div")<Pick<CardColumnProps, "contentRight" | "flexColumn" | "fullWidth" | "noPadding">>(
-  ({ theme, contentRight, flexColumn, fullWidth, noPadding }) => ({
+const Container = styled("div")<Pick<CardColumnProps, "contentRight" | "fullWidth" | "noPadding">>(
+  ({ theme, contentRight, fullWidth, noPadding }) => ({
     label: "card-column",
     height: "min-content",
     minWidth: 280 / 2,
@@ -48,13 +46,6 @@ const Container = styled("div")<Pick<CardColumnProps, "contentRight" | "flexColu
       maxWidth: "100%",
     },
     textAlign: contentRight ? "right" : "left",
-    ...(flexColumn
-      ? {
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: contentRight ? "flex-end" : "flex-start",
-        }
-      : {}),
   }),
 )
 

--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -41,7 +41,7 @@ const Container = styled("div")<Pick<CardColumnProps, "contentRight" | "fullWidt
     height: "min-content",
     minWidth: 280 / 2,
     padding: noPadding ? 0 : theme.space.element / 2,
-    flex: fullWidth ? "1 1 100%" : "1 0",
+    ...(fullWidth ? { flex: "1 1 100%", maxWidth: "100%" } : {}),
     img: {
       maxWidth: "100%",
     },

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -1,13 +1,18 @@
 import * as React from "react"
 import styled from "../utils/styled"
 
-export const CardColumns = styled("div")<React.Props<{}>>(({ children, theme }) => ({
-  display: "flex",
-  flexWrap: "wrap",
-  margin: -(theme.space.element / 2),
-  "& > *": {
-    flexBasis: `${React.Children.count(children)}%`,
-  },
-}))
+export const CardColumns = styled("div")<React.Props<{}> & { columns?: number }>(({ children, theme, columns }) => {
+  columns = columns === undefined ? React.Children.count(children) : columns
+  return {
+    display: "flex",
+    flexWrap: "wrap",
+    margin: -(theme.space.element / 2),
+    "& > *": {
+      // !important required for flexColumn
+      flexBasis: `calc(100% / ${columns}) !important`,
+      maxWidth: `calc(100% / ${columns})`,
+    },
+  }
+})
 
 export default CardColumns

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -8,8 +8,7 @@ export const CardColumns = styled("div")<React.Props<{}> & { columns?: number }>
     flexWrap: "wrap",
     margin: -(theme.space.element / 2),
     "& > *": {
-      // !important required for flexColumn
-      flexBasis: `calc(100% / ${columns}) !important`,
+      flexBasis: `calc(100% / ${columns})`,
       maxWidth: `calc(100% / ${columns})`,
     },
   }

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -1,14 +1,19 @@
 import * as React from "react"
 import styled from "../utils/styled"
 
-export const CardColumns = styled("div")<React.Props<{}> & { columns?: number }>(({ children, theme, columns }) => {
+export type CardColumnsProps = React.Props<{}> & {
+  /** Force exact number of columns */
+  columns?: number
+}
+
+export const CardColumns = styled("div")<CardColumnsProps>(({ children, theme, columns }) => {
   columns = columns === undefined ? React.Children.count(children) : columns
   return {
     display: "flex",
     flexWrap: "wrap",
     margin: -(theme.space.element / 2),
     "& > *": {
-      flexBasis: `calc(100% / ${columns})`,
+      flex: `1 1 calc(100% / ${columns})`,
       maxWidth: `calc(100% / ${columns})`,
     },
   }

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import styled from "../utils/styled"
 
 export type CardColumnsProps = React.Props<{}> & {
-  /** Force exact number of columns */
+  /** Render an exact number of columns */
   columns?: number
 }
 

--- a/src/CardColumns/README.md
+++ b/src/CardColumns/README.md
@@ -113,3 +113,23 @@ The `CardColumns` component is used as a wrapper around groups of `CardColumn` c
   </CardColumns>
 </Card>
 ```
+
+If there is not enough space to place required number of columns, columns will wrap
+
+```jsx
+<Card title="Bundle information">
+  <p>Here is the information available about this bundle.</p>
+  <CardColumns columns={3} style={{ width: "200px" }}>
+    <CardColumn title="Contributors">
+      <AvatarGroup>
+        <Avatar name="Alice Bernoulli" />
+        <Avatar name="Clarence Dermot" />
+      </AvatarGroup>
+    </CardColumn>
+    <CardColumn title="Tags">
+      <Chip>agent-view</Chip>
+      <Chip>production</Chip>
+    </CardColumn>
+  </CardColumns>
+</Card>
+```

--- a/src/CardColumns/README.md
+++ b/src/CardColumns/README.md
@@ -126,3 +126,23 @@ The `CardColumns` component is used as a wrapper around groups of `CardColumn` c
   </CardColumns>
 </Card>
 ```
+
+### With columns param
+
+```jsx
+<Card title="Bundle information">
+  <p>Here is the information available about this bundle.</p>
+  <CardColumns columns={3}>
+    <CardColumn title="Contributors">
+      <AvatarGroup>
+        <Avatar name="Alice Bernoulli" />
+        <Avatar name="Clarence Dermot" />
+      </AvatarGroup>
+    </CardColumn>
+    <CardColumn title="Tags">
+      <Chip>agent-view</Chip>
+      <Chip>production</Chip>
+    </CardColumn>
+  </CardColumns>
+</Card>
+```

--- a/src/CardColumns/README.md
+++ b/src/CardColumns/README.md
@@ -94,7 +94,7 @@ The `CardColumns` component is used as a wrapper around groups of `CardColumn` c
 </Card>
 ```
 
-### With columns param
+### With an exact number of columns
 
 ```jsx
 <Card title="Bundle information">

--- a/src/CardColumns/README.md
+++ b/src/CardColumns/README.md
@@ -94,39 +94,6 @@ The `CardColumns` component is used as a wrapper around groups of `CardColumn` c
 </Card>
 ```
 
-### With flexColumn
-
-```jsx
-<Card title="Playground">
-  <CardColumns>
-    <CardColumn title="Input">
-      <Textarea code value="hello-word" fullWidth />
-    </CardColumn>
-    <CardColumn title="Schema" flexColumn>
-      <Code
-        syntax="json"
-        src={{
-          items: {
-            type: "integer",
-          },
-          type: "array",
-        }}
-      />
-    </CardColumn>
-  </CardColumns>
-  <CardColumns>
-    <CardColumn>
-      <Button color="primary">Send Request</Button>
-    </CardColumn>
-    <CardColumn contentRight>
-      <Button color="grey" icon="Open">
-        curl/code
-      </Button>
-    </CardColumn>
-  </CardColumns>
-</Card>
-```
-
 ### With columns param
 
 ```jsx

--- a/src/CardColumns/README.md
+++ b/src/CardColumns/README.md
@@ -114,7 +114,7 @@ The `CardColumns` component is used as a wrapper around groups of `CardColumn` c
 </Card>
 ```
 
-If there is not enough space to place required number of columns, columns will wrap
+Columns will always wrap and overflow if their containing element is not wide enough for them.
 
 ```jsx
 <Card title="Bundle information">


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add `columns` param to the CardColumns component, so you can specify how many columns there can be inside the CardColumns.
- if there are not enough columns, it will show empty space for missing columns
- it there more columns than specified it will wrap columns (create rows)
- fixes bug with wrong margin for case when there is only one column

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue

N/A

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
