### PR TITLE
**Breaking:** Make error message inline instead of floating

### DIFF
--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -29,7 +29,7 @@ const handleChange = key => value => {
   <div>
     <Textarea value={state.v0} onChange={handleChange("v0")} />
   </div>
-  <div>
+  <div style={{ verticalAlign: "top" }}>
     <Textarea value={state.v1} onChange={handleChange("v1")} label="simple" />
     <Textarea value={state.v4} onChange={handleChange("v4")} label="with error" error="oh no!" />
     <Textarea value={state.v5} onChange={handleChange("v5")} label="with hint" hint="this is a hint" />

--- a/src/Textarea/README.md
+++ b/src/Textarea/README.md
@@ -36,7 +36,7 @@ const handleChange = key => value => {
     <Textarea value={state.v6} onChange={handleChange("v6")} label="disabled" disabled />
     <Textarea value={state.v7} onChange={handleChange("v7")} label="a code" code />
     <Textarea value={state.v8} onChange={handleChange("v8")} label="fixed height" height={200} />
-    <Textarea value={state.v8} onChange={handleChange("v8")} label="with placeholder" placeholder={json} />
+    <Textarea value={state.v9} onChange={handleChange("v8")} label="with placeholder" placeholder={json} />
   </div>
   <div>
     <Textarea copy value={state.v2} onChange={handleChange("v2")} label="with copying" />

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -72,6 +72,7 @@ const TextareaComp = styled("textarea")<{
     fontFamily: isCode ? "monospace" : theme.font.family.main,
     outline: "none",
     border: "none",
+    // There's an white subpixel if it's theme.borderRadius and no noticeable regression if -1
     borderRadius: theme.borderRadius - 1,
   }
 })
@@ -114,7 +115,7 @@ const Outline = styled("div")<{
   boxShadow: focus
     ? `0 0 0 3px ${error ? lighten(theme.color.error, 60) : lighten(theme.color.primary, 40)}`
     : "initial",
-  borderRadius: `2px`,
+  borderRadius: theme.borderRadius,
   border: `${theme.color.border.default} 1px solid`,
   borderColor: error ? theme.color.error : theme.color.border.default,
   opacity: disabled ? 0.6 : 1.0,


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Before:

<img width="382" alt="Screenshot 2019-03-13 at 12 06 48" src="https://user-images.githubusercontent.com/179534/54274496-8b830880-4588-11e9-9b05-a693f145b2c7.png">

After:
<img width="380" alt="Screenshot 2019-03-13 at 12 06 55" src="https://user-images.githubusercontent.com/179534/54274497-8b830880-4588-11e9-9528-edbc38b1c4a1.png">

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
