### PR TITLE
**Fix:** Unlocking back the version of Node for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "11.10.1"
+  - stable
 notifications:
   email: false
 before_install:

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.0.0-beta6",
     "husky": "^0.14.3",
-    "jest": "^24.3.0",
+    "jest": "^24.5.0",
     "jest-enzyme": "^6.0.2",
     "jest-serializer-enzyme": "^1.0.0",
     "lint-staged": "^7.2.0",


### PR DESCRIPTION
# Summary
Unlocking back the version of Node for TravisCI, which was locked to circumvent [this Jest bug](https://github.com/facebook/jest/issues/8069)

# Related issue
https://github.com/contiamo/operational-ui/issues/952

# To be tested
- [ ] CI build passes
