### PR TITLE
**Breaking:** More flexible drag & drop on Tree

### DIFF
--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -16,6 +16,7 @@ const ChildTree: React.SFC<Props> = ({
   droppableProps,
   onClick,
   onRemove,
+  cursor,
   ...props
 }) => {
   const [isOpen, setIsOpen] = React.useState(Boolean(initiallyOpen))
@@ -44,6 +45,7 @@ const ChildTree: React.SFC<Props> = ({
         label={label}
         color={color}
         onRemove={onRemove}
+        cursor={cursor}
       />
       {hasChildren && isOpen && <Tree trees={childNodes} droppableProps={droppableProps} />}
     </Container>

--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -13,6 +13,7 @@ const ChildTree: React.SFC<Props> = ({
   disabled,
   forwardRef,
   childNodes = [],
+  droppableProps,
   onClick,
   onRemove,
   ...props
@@ -44,7 +45,7 @@ const ChildTree: React.SFC<Props> = ({
         color={color}
         onRemove={onRemove}
       />
-      {hasChildren && isOpen && <Tree trees={childNodes} />}
+      {hasChildren && isOpen && <Tree trees={childNodes} droppableProps={droppableProps} />}
     </Container>
   )
 }

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -108,3 +108,147 @@ import { Tree } from "@operational/components"
   ]}
 />
 ```
+
+### With react-beautiful-dnd
+
+This tree component have `Droppable` and `Draggable` implemented from [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd/).
+
+To offer the most flexibility as possible in your drag & drop implementation, we are just spreading `draggableProps` and `droppableProps`.
+
+```jsx
+import * as React from "react"
+import { Button, Card, Tree, Title } from "@operational/components"
+import { DragDropContext } from "react-beautiful-dnd"
+
+// a little function to help us with reordering the result
+const reorder = (list, startIndex, endIndex) => {
+  const result = Array.from(list)
+  const [removed] = result.splice(startIndex, 1)
+  result.splice(endIndex, 0, removed)
+
+  return result
+}
+
+const getMessage = item => {
+  switch (item) {
+    case "Dough":
+      return "Always a good start!"
+    case "Jalapeño":
+      return "Hot! 🌶"
+    case "Pineapples":
+      return "Really?!"
+    case "Cheese":
+      return "Oh yeah! 😎"
+    default:
+      return "Yum!"
+  }
+}
+const PlaceHolder = ({ isDraggingOver, draggingOverWith }) => (
+  <div style={{ minHeight: 30, border: "1px dashed gray", padding: 8, borderRadius: 3 }}>
+    {isDraggingOver ? getMessage(draggingOverWith) : "Drag your stuff here"}
+  </div>
+)
+
+const PizzaMaker = () => {
+  const [inventory, setInventory] = React.useState([
+    "Cheese",
+    "Pepperoni",
+    "Dough",
+    "Mozzarella",
+    "Tomato sauce",
+    "Flour",
+    "Pineapples",
+    "Jalapeño",
+    "Artichokes",
+    "Cauliflower",
+    "Crushed red pepper",
+    "Blue cheese",
+    "Garlic",
+    "Olive Oil",
+    "Beef",
+    "Pork",
+  ])
+  const [ingredients, setIngredients] = React.useState([])
+
+  const onDragEnd = React.useCallback(result => {
+    if (result.destination) {
+      switch (result.destination.droppableId) {
+        case "inventory":
+          if (result.source.droppableId === "inventory") {
+            // reorder
+            setInventory(prev => reorder(prev, result.source.index, result.destination.index))
+          } else {
+            // ingredients -> inventory
+            setIngredients(prev => prev.filter(i => i !== result.draggableId))
+            setInventory(prev => [
+              ...prev.slice(0, result.destination.index),
+              result.draggableId,
+              ...prev.slice(result.destination.index),
+            ])
+          }
+          break
+        case "ingredients":
+          if (result.source.droppableId === "ingredients") {
+            // reorder
+            setIngredients(prev => reorder(prev, result.source.index, result.destination.index))
+          } else {
+            // inventory -> ingredients
+            setInventory(prev => prev.filter(i => i != result.draggableId))
+            setIngredients(prev => [
+              ...prev.slice(0, result.destination.index),
+              result.draggableId,
+              ...prev.slice(result.destination.index),
+            ])
+          }
+          break
+      }
+    }
+  }, [])
+
+  const cook = React.useCallback(() => {
+    if (ingredients.includes("Mozzarella")) {
+      alert("What an amazing pizza!")
+    } else if (ingredients.includes("Pineapples")) {
+      alert("Why are you doing this to a pizza?!")
+    } else if (ingredients.includes("Jalapeño")) {
+      alert("Tasty!")
+    } else {
+      alert("Not bad ^^")
+    }
+  })
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Title>Let's make a pizza!</Title>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", grgridGap: 8, marginTop: 8 }}>
+        <Card title="Inventory">
+          <Tree
+            droppableProps={{ droppableId: "inventory" }}
+            trees={inventory.map(item => ({
+              key: item,
+              label: item,
+              draggableProps: { draggableId: item },
+            }))}
+            placeholder={PlaceHolder}
+          />
+        </Card>
+        <Card title="Ingredients">
+          <Tree
+            droppableProps={{ droppableId: "ingredients" }}
+            trees={ingredients.map(item => ({
+              key: item,
+              label: item,
+              draggableProps: { draggableId: item },
+            }))}
+            placeholder={PlaceHolder}
+          />
+        </Card>
+        <Button fullWidth color="primary" onClick={cook} disabled={ingredients.length === 0}>
+          Cook! 🍕
+        </Button>
+      </div>
+    </DragDropContext>
+  )
+}
+;<PizzaMaker />
+```

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -1,6 +1,6 @@
 import { Omit } from "emotion-theming/types/helper"
 import * as React from "react"
-import { Draggable, DraggableProps, Droppable, DroppableProps } from "react-beautiful-dnd"
+import { Draggable, DraggableProps, Droppable, DroppableProps, DroppableStateSnapshot } from "react-beautiful-dnd"
 import styled from "../utils/styled"
 import ChildTree from "./ChildTree"
 
@@ -33,6 +33,7 @@ export type Tree = TreeWithChildren | TreeWithoutChildren
 export interface TreeProps {
   trees: Tree[]
   droppableProps?: Omit<DroppableProps, "children">
+  placeholder?: React.ComponentType<DroppableStateSnapshot>
 }
 
 const Container = styled("div")`
@@ -42,8 +43,8 @@ const Container = styled("div")`
   }
 `
 
-const Tree: React.SFC<TreeProps> = ({ trees, droppableProps }) => {
-  const isLowestLevel = trees.some(tree => !tree.childNodes || !tree.childNodes.length)
+const Tree: React.SFC<TreeProps> = ({ trees, droppableProps, placeholder }) => {
+  const isLowestLevel = trees.length === 0 || trees.some(tree => !tree.childNodes || !tree.childNodes.length)
 
   /**
    * If this is a category with children, no drag and drop
@@ -61,23 +62,29 @@ const Tree: React.SFC<TreeProps> = ({ trees, droppableProps }) => {
 
   return (
     <Droppable {...droppableProps}>
-      {droppableProvided => (
+      {(droppableProvided, droppableSnapshot) => (
         <Container ref={droppableProvided.innerRef} {...droppableProvided.droppableProps}>
-          {trees.map((treeData, index) => (
-            <Draggable key={index} {...treeData.draggableProps || { draggableId: treeData.label }} index={index}>
-              {draggableProvided => {
-                return (
-                  <ChildTree
-                    forwardRef={draggableProvided.innerRef}
-                    {...treeData}
-                    {...draggableProvided.draggableProps}
-                    {...draggableProvided.dragHandleProps}
-                  />
-                )
-              }}
-            </Draggable>
-          ))}
-          {droppableProvided.placeholder}
+          {trees.length ? (
+            <>
+              {trees.map((treeData, index) => (
+                <Draggable key={index} {...treeData.draggableProps || { draggableId: treeData.label }} index={index}>
+                  {draggableProvided => {
+                    return (
+                      <ChildTree
+                        forwardRef={draggableProvided.innerRef}
+                        {...treeData}
+                        {...draggableProvided.draggableProps}
+                        {...draggableProvided.dragHandleProps}
+                      />
+                    )
+                  }}
+                </Draggable>
+              ))}
+              {droppableProvided.placeholder}
+            </>
+          ) : (
+            placeholder && React.createElement(placeholder, droppableSnapshot)
+          )}
         </Container>
       )}
     </Droppable>

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -12,6 +12,7 @@ interface BaseTree {
   disabled?: boolean
   color?: string
   onClick?: () => void
+  cursor?: string
   onRemove?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   forwardRef?: (element?: HTMLElement | null) => any
 }
@@ -80,11 +81,11 @@ const Tree: React.SFC<TreeProps> = ({ trees, droppableProps, placeholder }) => {
                   }}
                 </Draggable>
               ))}
-              {droppableProvided.placeholder}
             </>
           ) : (
             placeholder && React.createElement(placeholder, droppableSnapshot)
           )}
+          {droppableProvided.placeholder}
         </Container>
       )}
     </Droppable>

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -14,11 +14,12 @@ export const Container = styled("div")<{ hasChildren: boolean; disabled: boolean
 const Header = styled("div")<{
   highlight: boolean
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void
+  cursor?: string
 }>`
   label: TreeItem;
   display: flex;
   align-items: center;
-  cursor: ${({ onClick }) => (onClick ? "pointer" : "inherit")};
+  cursor: ${({ onClick, cursor }) => cursor || (onClick ? "pointer" : "inherit")};
   background-color: ${({ highlight, theme }) => (highlight ? theme.color.highlight : "none")};
   padding: ${({ theme }) => theme.space.base}px;
   border-radius: 2px;
@@ -63,6 +64,7 @@ interface TreeItemProps {
   label: string
   tag?: string
   color?: string
+  cursor?: string
   onNodeClick?: (e: React.MouseEvent<HTMLDivElement>) => void
   onRemove?: (e: React.MouseEvent<HTMLDivElement>) => void
 }
@@ -76,8 +78,9 @@ const TreeItem: React.SFC<TreeItemProps> = ({
   onRemove,
   hasChildren,
   isOpen,
+  cursor,
 }) => (
-  <Header onClick={onNodeClick} highlight={Boolean(highlight)}>
+  <Header onClick={onNodeClick} highlight={Boolean(highlight)} cursor={cursor}>
     {hasChildren && <TreeIcon color="color.text.lightest" size={12} left name={isOpen ? "ChevronDown" : "Add"} />}
     {!hasChildren && tag && (
       <NameTag condensed left color={color}>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

To be able to have the best drag and drop experience (at least a better one 😅) we need to expose `react-beautiful-dnd` props into our `Tree` component.

The idea is to provide flexibility here, so we can define `Droppable` and `Draggable` props as we use `react-beautiful-dnd` directly.

This PR was tested against my local usecase and it works as expected. 

## Example of usage

```tsx
<Tree
  droppableProps={{ droppableId: getDroppableId("aggregateMeasure") }}
  trees={state.aggregate.query.measures.map(m => ({
    label: m,
    key: m,
    color: PslColor.measure,
    tag: "M",
    draggableProps: { draggableId: getDraggableId("aggregateMeasure", m) },
  }))}
/>
```

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
