### PR TITLE
**Breaking**: (literally!) Break words in Cards

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -108,7 +108,6 @@ const Container = styled("div")(({ theme }) => ({
   boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.16)",
   backgroundColor: theme.color.white,
   wordWrap: "break-word",
-  wordBreak: "break-all",
   "& > img": {
     maxWidth: "100%",
   },

--- a/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Card Should render 1`] = `
     class="css-p29iif"
   />
   <div
-    class="css-1wstrtr"
+    class="css-13aykpc"
   >
     <div
       class="css-dj0vfm"


### PR DESCRIPTION
Currently, content in `Card` does not break words and words can overflow in certain cases. Words _wrap_, but they do not _break_. Let's break them for more predictable layouts.