### PR TITLE
**Fix:** `Table` - Remove hover if no click action

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -229,7 +229,7 @@ function Table<T>({
             })()
             return (
               <Tr
-                hover={Boolean(data)}
+                hover={Boolean(onRowClick)}
                 key={dataEntryIndex}
                 clickable={Boolean(onRowClick)}
                 onClick={() => {


### PR DESCRIPTION
Let's remove any hover feedback from table rows that are not clickable.