### PR TITLE
**Fix:** Avatar stretch

### DIFF
--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -71,20 +71,16 @@ const Picture = styled("div")<{
       : null
     const backgroundColor = assignedBackgroundColor || fixedBackgroundColor
     const textColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
+    const sizeInPixels = size === "medium" ? 48 : 32
+    const fontSizeInPixels = size === "medium" ? 13 : 11
 
     // Calculate sizes based on the state of the size prop
-    const sizes =
-      size === "medium"
-        ? {
-            fontSize: 13,
-            width: 48,
-            height: 48,
-          }
-        : {
-            fontSize: 11,
-            width: 32,
-            height: 32,
-          }
+    const sizes = {
+      fontSize: fontSizeInPixels,
+      width: sizeInPixels,
+      height: sizeInPixels,
+      flex: `0 0 ${sizeInPixels}px`,
+    }
 
     // Calculate background based on the state of the photo prop
     const background = photo

--- a/src/Avatar/README.md
+++ b/src/Avatar/README.md
@@ -49,3 +49,17 @@ import { Avatar } from "@operational/components"
   <Avatar photo="https://thecatapi.com/api/images/get?format=src&size=small" name="Franklin Green" />
 </div>
 ```
+
+### Should not shrink with long neighbors
+
+```jsx
+import * as React from "react"
+import { HeaderMenu, Icon, HeaderBar } from "@operational/components"
+;<HeaderBar
+  end={
+    <HeaderMenu items={[{ label: "Hello" }, { label: "Merci" }]} onClick={() => alert("sup")} withCaret>
+      <Avatar showName name="Franklingreenchimichangaroosevelt Aaron Theodore Knettle" />
+    </HeaderMenu>
+  }
+/>
+```


### PR DESCRIPTION
Currently, `Avatar` stretches with multiline names. This PR fixes it.