### PR TITLE
**Fix:** Add border to CardHeader

### DIFF
--- a/src/Internals/CardHeader.tsx
+++ b/src/Internals/CardHeader.tsx
@@ -20,6 +20,7 @@ const Container = styled("div")(({ theme }) => ({
   backgroundColor: theme.color.background.lighter,
   color: theme.color.text.lighter,
   flex: "0 0 auto", // Make sure it stays the same size if other parts of the card push it
+  borderBottom: `1px solid ${theme.color.separators.default}`,
 
   // This ensures that the card header text and card controls are placed in opposite corners.
   justifyContent: "space-between",


### PR DESCRIPTION
This PR adds a a border to `CardHeader` that was supposed to have been there with the initial designs a long time ago.