### PR TITLE
  **Fix:** Page controlled activeTabName

### DIFF
--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import Icon, { IconName } from "../Icon/Icon"
 import Spinner from "../Spinner/Spinner"
 import styled from "../utils/styled"
@@ -69,12 +69,16 @@ const Tabs = ({ onTabChange, tabs, activeTabName, condensed, children }: Props) 
     setActiveTab(activeTabIndex)
   }, [activeTabIndex])
 
-  const onTabClick = (index: number) => {
-    setActiveTab(index)
-    if (onTabChange) {
-      onTabChange(tabs[index].name)
-    }
-  }
+  const onTabClick = useCallback(
+    (index: number) => {
+      setActiveTab(index)
+      if (onTabChange) {
+        onTabChange(tabs[index].name)
+      }
+    },
+    [onTabChange, tabs, setActiveTab],
+  )
+
   // Work around: wrap return in fragment- to prevent type error and not having to change childrens return type
   // https://github.com/Microsoft/TypeScript/issues/21699
   return (

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import Icon, { IconName } from "../Icon/Icon"
 import Spinner from "../Spinner/Spinner"
 import styled from "../utils/styled"
@@ -54,15 +54,20 @@ const Tab = styled("div")<{ active?: boolean; condensed?: boolean }>(({ theme, a
   },
 }))
 
+const getTabIndexByName = (tabs: Tab[], tabName?: string): number => {
+  if (tabName) {
+    const index = tabs.findIndex(({ name }) => name === tabName)
+    return index === -1 ? 0 : index
+  }
+  return 0
+}
+
 const Tabs = ({ onTabChange, tabs, activeTabName, condensed, children }: Props) => {
-  // Using a prop to intialize state: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
-  const [activeTab, setActiveTab] = useState(() => {
-    if (activeTabName) {
-      const index = tabs.findIndex(({ name }) => name === activeTabName)
-      return index === -1 ? 0 : index
-    }
-    return 0
-  })
+  const activeTabIndex = getTabIndexByName(tabs, activeTabName)
+  const [activeTab, setActiveTab] = useState(activeTabIndex)
+  useEffect(() => {
+    setActiveTab(activeTabIndex)
+  }, [activeTabIndex])
 
   const onTabClick = (index: number) => {
     setActiveTab(index)


### PR DESCRIPTION
# Summary
Fixes the bug with non-working controlled activeTabName for Tabs at the page. The value of the activeTabName renders correctly at the first component renders and stays stale, ignoring new value being passed through props later

# Related issue
[bug 993](https://github.com/contiamo/operational-ui/issues/993)

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1
- [ ] Things look good on the demo.
- [ ] Tabs work as expected

Tester 2
- [ ] Things look good on the demo.
- [ ] Tabs work as expected
