### PR TITLE
**Breaking:** Page tabs

### DIFF
--- a/cypress/integration/Page.ts
+++ b/cypress/integration/Page.ts
@@ -9,7 +9,11 @@ describe("Page", () => {
       .tab()
       .tab()
       .tab()
+
     cy.focused().contains("jobs")
+    cy.get("body")
+      .find("[role=tabpanel]")
+      .contains("jobs")
   })
 
   it("Right arrow key moves focus to the next tab", () => {
@@ -19,11 +23,17 @@ describe("Page", () => {
     cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
 
     cy.focused().contains("functions")
+    cy.get("body")
+      .find("[role=tabpanel]")
+      .contains("functions")
 
     cy.focused().type("{rightarrow}")
     cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
 
     cy.focused().contains("overview")
+    cy.get("body")
+      .find("[role=tabpanel]")
+      .contains("overview")
   })
 
   it("Left arrow key moves focus to the previous tab", () => {
@@ -33,11 +43,17 @@ describe("Page", () => {
     cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
 
     cy.focused().contains("functions")
+    cy.get("body")
+      .find("[role=tabpanel]")
+      .contains("functions")
 
     cy.focused().type("{leftarrow}")
     cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
 
     cy.focused().contains("jobs")
+    cy.get("body")
+      .find("[role=tabpanel]")
+      .contains("jobs")
   })
 
   it("Home Key moves focus to the first tab", () => {
@@ -47,6 +63,9 @@ describe("Page", () => {
     cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
 
     cy.focused().contains("overview")
+    cy.get("body")
+      .find("[role=tabpanel]")
+      .contains("overview")
   })
 
   it("End key moves focus to the last tab", () => {
@@ -56,5 +75,8 @@ describe("Page", () => {
     cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
 
     cy.focused().contains("functions")
+    cy.get("body")
+      .find("[role=tabpanel]")
+      .contains("functions")
   })
 })

--- a/cypress/integration/Page.ts
+++ b/cypress/integration/Page.ts
@@ -1,0 +1,60 @@
+describe("Page", () => {
+  before(() => {
+    cy.visit("/#!/Page/15")
+  })
+
+  it("Focus gets on currently selected tab", () => {
+    cy.get("body")
+      .tab()
+      .tab()
+      .tab()
+      .tab()
+    cy.focused().contains("jobs")
+  })
+
+  it("Right arrow key moves focus to the next tab", () => {
+    cy.focused().contains("jobs")
+
+    cy.focused().type("{rightarrow}")
+    cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
+
+    cy.focused().contains("functions")
+
+    cy.focused().type("{rightarrow}")
+    cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
+
+    cy.focused().contains("overview")
+  })
+
+  it("Left arrow key moves focus to the previous tab", () => {
+    cy.focused().contains("overview")
+
+    cy.focused().type("{leftarrow}")
+    cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
+
+    cy.focused().contains("functions")
+
+    cy.focused().type("{leftarrow}")
+    cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
+
+    cy.focused().contains("jobs")
+  })
+
+  it("Home Key moves focus to the first tab", () => {
+    cy.focused().contains("jobs")
+
+    cy.focused().type("{home}")
+    cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
+
+    cy.focused().contains("overview")
+  })
+
+  it("End key moves focus to the last tab", () => {
+    cy.focused().contains("overview")
+
+    cy.focused().type("{end}")
+    cy.wait(50) // we need to wait a bit because focus switch doesn't happen immediately
+
+    cy.focused().contains("functions")
+  })
+})

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -3,6 +3,7 @@ import Spinner from "../Spinner/Spinner"
 import styled from "../utils/styled"
 import { IconComponentType } from "../Icon/Icon"
 import { inputFocus } from "../utils"
+import { useUniqueId } from "../useUniqueId"
 
 export interface Tab {
   name: string
@@ -101,6 +102,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
   const activeTabIndex = getTabIndexByName(tabs, activeTabName)
   const [activeTab, setActiveTab] = useState(activeTabIndex)
   const [isMouseDown, setMouseDown] = useState(false)
+  const uid = useUniqueId()
 
   useEffect(() => {
     setActiveTab(activeTabIndex)
@@ -118,7 +120,9 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      const tabElements: NodeListOf<HTMLElement> = document.querySelectorAll('[role="tab"]')
+      const tabElements: NodeListOf<HTMLElement> = (document.querySelector(
+        `[id=${uid}]`,
+      ) as HTMLElement).querySelectorAll('[role="tab"]')
       let newIndex: number
       switch (event.key) {
         case "ArrowRight":
@@ -152,13 +156,20 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
     [activeTab, onTabClick],
   )
 
+  const onFocus = (e: React.FocusEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    if (isMouseDown) {
+      e.target.blur()
+    }
+  }
+
   // Work around: wrap return in fragment- to prevent type error and not having to change childrens return type
   // https://github.com/Microsoft/TypeScript/issues/21699
   return (
     <>
       {children({
         tabsBar: (
-          <TabsBar role="tablist" onKeyDown={onKeyDown}>
+          <TabsBar role="tablist" id={uid} onKeyDown={onKeyDown}>
             {tabs
               .filter(({ hidden }) => !hidden)
               .map((tab, index: number) => {
@@ -172,11 +183,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
                     tabIndex={isActive ? 0 : -1}
                     onClick={() => onTabClick(index)}
                     onKeyDown={onKeyDown}
-                    onFocus={e => {
-                      if (isMouseDown) {
-                        e.target.blur()
-                      }
-                    }}
+                    onFocus={onFocus}
                     onMouseDown={() => setMouseDown(true)}
                     onMouseUp={() => setMouseDown(false)}
                   >

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -29,41 +29,40 @@ const TabsBar = styled("div")(({ theme }) => ({
   display: "flex",
   alignItems: "flex-end",
   height: tabsBarHeight,
-  color: "inherit",
-  position: "inherit",
+  position: "relative",
   margin: `0 ${theme.space.element}px`,
   "&::before": {
     content: "''",
     display: "block",
     position: "absolute",
     width: "100%",
+    height: 0,
     top: tabsBarHeight - 1,
     left: 0,
-    borderBottom: `1px solid ${theme.color.border.default}`,
+    borderBottom: `1px solid ${theme.color.border.select}`,
   },
 }))
 
 const Tab = styled("div")<{ active?: boolean }>(({ theme, active }) => ({
-  display: "flex",
   width: 150,
   height: "100%",
-  backgroundColor: active ? "inherit" : theme.color.background.lighter,
-  color: active ? theme.color.text.action : "currentColor",
-  zIndex: 2,
-  textTransform: "capitalize",
+  display: "flex",
+  alignItems: "center",
+  backgroundColor: active ? theme.color.white : theme.color.background.lighter,
+  color: active ? theme.color.text.action : theme.color.text.dark,
   fontFamily: theme.font.family.main,
   fontSize: theme.font.size.small,
   fontWeight: active ? theme.font.weight.bold : theme.font.weight.regular,
   padding: `0px ${theme.space.element}px`,
-  border: `1px solid ${theme.color.border.default}`,
-  borderBottomColor: active ? "white" : "border.default",
+  border: `1px solid ${theme.color.border.select}`,
+  zIndex: 2,
+  borderBottomColor: active ? theme.color.white : theme.color.border.select,
   borderRightWidth: 0,
   ":last-child": {
     borderRightWidth: 1,
   },
   ":hover": {
     cursor: "pointer",
-    opacity: 1,
   },
 }))
 
@@ -116,7 +115,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
                   ) : (
                     tab.icon && React.createElement(tab.icon, { size: 14, color: tab.iconColor, left: true })
                   )}
-                  {<TabName>{tab.name}</TabName>}
+                  <TabName>{tab.name}</TabName>
                 </Tab>
               ))}
           </TabsBar>

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -158,7 +158,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
     <>
       {children({
         tabsBar: (
-          <TabsBar role={"tablist"} onKeyDown={onKeyDown}>
+          <TabsBar role="tablist" onKeyDown={onKeyDown}>
             {tabs
               .filter(({ hidden }) => !hidden)
               .map((tab, index: number) => {
@@ -166,7 +166,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
                 return (
                   <SingleTab
                     key={index}
-                    role={"tab"}
+                    role="tab"
                     active={isActive}
                     aria-selected={isActive}
                     tabIndex={isActive ? 0 : -1}

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -35,12 +35,10 @@ export interface SingleTabProps {
   isKeyboardActive: boolean
 }
 
-const tabsBarHeight = 48
-
 const TabsBar = styled("div")(({ theme }) => ({
   display: "flex",
   alignItems: "flex-end",
-  height: tabsBarHeight,
+  height: theme.tabsBarHeight,
   position: "relative",
   margin: `0 ${theme.space.element}px`,
   // This draws the line underneath the tabs
@@ -50,7 +48,7 @@ const TabsBar = styled("div")(({ theme }) => ({
     position: "absolute",
     width: "100%",
     height: 0,
-    top: tabsBarHeight - 1,
+    top: theme.tabsBarHeight - 1,
     left: 0,
     borderBottom: `1px solid ${theme.color.border.select}`,
   },

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -88,13 +88,13 @@ const TabContainer = styled("div")<{ active?: boolean }>(({ theme, active }) => 
   },
 }))
 
-const TabName = styled("p")(() => ({
+const TabName = styled("p")({
   width: "100%",
   whiteSpace: "nowrap",
   overflow: "hidden",
   textOverflow: "ellipsis",
   textAlign: "center",
-}))
+})
 
 const getTabIndexByName = (tabs: Tab[], tabName?: string): number => {
   if (tabName) {

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -48,8 +48,6 @@ const Tab = styled("div")<{ active?: boolean }>(({ theme, active }) => ({
   display: "flex",
   width: 150,
   height: "100%",
-  alignItems: "center",
-  justifyContent: "center",
   backgroundColor: active ? "inherit" : theme.color.background.lighter,
   color: active ? theme.color.text.action : "currentColor",
   zIndex: 2,
@@ -68,6 +66,14 @@ const Tab = styled("div")<{ active?: boolean }>(({ theme, active }) => ({
     cursor: "pointer",
     opacity: 1,
   },
+}))
+
+const TabName = styled("p")(() => ({
+  width: "100%",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  textAlign: "center",
 }))
 
 const getTabIndexByName = (tabs: Tab[], tabName?: string): number => {
@@ -111,7 +117,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
                   ) : (
                     tab.icon && React.createElement(tab.icon, { size: 14, color: tab.iconColor, left: true })
                   )}
-                  {tab.name}
+                  {<TabName>{tab.name}</TabName>}
                 </Tab>
               ))}
           </TabsBar>

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -24,6 +24,7 @@ export interface State {
 }
 
 export const tabsBarHeight = 48
+export const tabsBarMargin = 20
 
 const TabsBar = styled("div")(({ theme }) => ({
   display: "flex",
@@ -31,7 +32,7 @@ const TabsBar = styled("div")(({ theme }) => ({
   height: tabsBarHeight,
   color: "inherit",
   position: "inherit",
-  margin: theme.space.element,
+  margin: tabsBarMargin,
   "&::before": {
     content: "''",
     display: "block",

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -103,6 +103,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
   const [activeTab, setActiveTab] = useState(activeTabIndex)
   const [isMouseDown, setMouseDown] = useState(false)
   const uid = useUniqueId()
+  const tabsList = tabs.map(() => React.useRef<HTMLDivElement>(null))
 
   useEffect(() => {
     setActiveTab(activeTabIndex)
@@ -120,35 +121,45 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      const tabElements: NodeListOf<HTMLElement> = (document.querySelector(
-        `[id=${uid}]`,
-      ) as HTMLElement).querySelectorAll('[role="tab"]')
       let newIndex: number
+      let tabEl: HTMLElement | null
       switch (event.key) {
         case "ArrowRight":
           event.preventDefault()
           newIndex = activeTab + 1 >= tabs.length ? 0 : activeTab + 1
-          tabElements[newIndex].focus()
+          tabEl = tabsList[newIndex].current
+          if (tabEl) {
+            tabEl.focus()
+          }
           onTabClick(newIndex)
           break
         case "ArrowLeft":
           event.preventDefault()
           newIndex = activeTab - 1 < 0 ? tabs.length - 1 : activeTab - 1
-          tabElements[newIndex].focus()
+          tabEl = tabsList[newIndex].current
+          if (tabEl) {
+            tabEl.focus()
+          }
           onTabClick(newIndex)
           break
         case "Home":
           event.preventDefault()
-          newIndex = 0
-          tabElements[newIndex].focus()
           // Activate first tab
+          newIndex = 0
+          tabEl = tabsList[newIndex].current
+          if (tabEl) {
+            tabEl.focus()
+          }
           onTabClick(newIndex)
           break
         case "End":
           event.preventDefault()
-          newIndex = tabs.length - 1
-          tabElements[newIndex].focus()
           // Activate last tab
+          newIndex = tabs.length - 1
+          tabEl = tabsList[newIndex].current
+          if (tabEl) {
+            tabEl.focus()
+          }
           onTabClick(newIndex)
           break
       }
@@ -177,6 +188,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
                 return (
                   <SingleTab
                     key={index}
+                    ref={tabsList[index]}
                     role="tab"
                     active={isActive}
                     aria-selected={isActive}

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -31,7 +31,7 @@ const TabsBar = styled("div")(({ theme }) => ({
   height: tabsBarHeight,
   color: "inherit",
   position: "inherit",
-  marginBottom: theme.space.content,
+  margin: theme.space.element,
   "&::before": {
     content: "''",
     display: "block",

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -149,6 +149,10 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
     getUniqueTabId,
   ])
 
+  useEffect(() => {
+    setActiveTab(activeTabIndex)
+  }, [activeTabIndex])
+
   const onTabClick = useCallback(
     (index: number) => {
       setActiveTab(index)

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -26,8 +26,13 @@ export interface Props {
   }) => React.ReactNode
 }
 
-export interface State {
-  activeTab: number
+export interface SingleTabProps {
+  id?: string
+  index: number
+  tab: Tab
+  onTabClick: (index: number) => void
+  isActive: boolean
+  isKeyboardActive: boolean
 }
 
 const tabsBarHeight = 48
@@ -104,16 +109,7 @@ const getTabIndexByName = (tabs: Tab[], tabName?: string): number => {
   return 0
 }
 
-interface TabProps {
-  id?: string
-  index: number
-  tab: Tab
-  onTabClick: (index: number) => void
-  isActive: boolean
-  isKeyboardActive: boolean
-}
-
-const SingleTab = ({ id, index, isActive, onTabClick, tab, isKeyboardActive }: TabProps) => {
+const SingleTab = ({ id, index, isActive, onTabClick, tab, isKeyboardActive }: SingleTabProps) => {
   const ref = React.useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (isActive && isKeyboardActive && ref.current) {

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -16,7 +16,6 @@ export interface Props {
   tabs: Tab[]
   activeTabName?: string
   onTabChange?: (newTabName: string) => void
-  condensed?: boolean
   children: (childrenConfig: { tabsBar: React.ReactNode; activeChildren: React.ReactNode }) => React.ReactNode
 }
 
@@ -24,30 +23,46 @@ export interface State {
   activeTab: number
 }
 
-export const tabsBarHeight = 40
+export const tabsBarHeight = 48
 
-const TabsBar = styled("div")<{ condensed?: boolean }>(({ theme, condensed }) => ({
+const TabsBar = styled("div")(({ theme }) => ({
   display: "flex",
   alignItems: "flex-end",
-  height: condensed ? theme.titleHeight : tabsBarHeight,
+  height: tabsBarHeight,
   color: "inherit",
-  ...(condensed ? { paddingLeft: theme.space.element } : {}),
+  position: "inherit",
+  marginBottom: theme.space.content,
+  "&::before": {
+    content: "''",
+    display: "block",
+    position: "absolute",
+    width: "100%",
+    top: tabsBarHeight - 1,
+    left: 0,
+    borderBottom: `1px solid ${theme.color.border.default}`,
+  },
 }))
 
-const Tab = styled("div")<{ active?: boolean; condensed?: boolean }>(({ theme, active }) => ({
+const Tab = styled("div")<{ active?: boolean }>(({ theme, active }) => ({
   display: "flex",
+  width: 150,
   height: "100%",
   alignItems: "center",
   justifyContent: "center",
-  color: "currentColor",
-  opacity: active ? 1 : 0.8,
-  textTransform: "uppercase",
+  backgroundColor: active ? "inherit" : theme.color.background.lighter,
+  color: active ? theme.color.text.action : "currentColor",
+  zIndex: 2,
+  textTransform: "capitalize",
   fontFamily: theme.font.family.main,
   fontSize: theme.font.size.small,
-  fontWeight: theme.font.weight.medium,
+  fontWeight: active ? theme.font.weight.bold : theme.font.weight.regular,
   padding: `0px ${theme.space.element}px`,
-  borderBottom: "2px solid",
-  borderBottomColor: active ? "currentColor" : "transparent",
+  border: `1px solid ${theme.color.border.default}`,
+  borderBottomColor: active ? "white" : "border.default",
+  borderRightWidth: 0,
+  ":last-child": {
+    borderRightWidth: 1,
+  },
   ":hover": {
     cursor: "pointer",
     opacity: 1,
@@ -62,7 +77,7 @@ const getTabIndexByName = (tabs: Tab[], tabName?: string): number => {
   return 0
 }
 
-const Tabs = ({ onTabChange, tabs, activeTabName, condensed, children }: Props) => {
+const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
   const activeTabIndex = getTabIndexByName(tabs, activeTabName)
   const [activeTab, setActiveTab] = useState(activeTabIndex)
   useEffect(() => {
@@ -85,11 +100,11 @@ const Tabs = ({ onTabChange, tabs, activeTabName, condensed, children }: Props) 
     <>
       {children({
         tabsBar: (
-          <TabsBar condensed={condensed}>
+          <TabsBar>
             {tabs
               .filter(({ hidden }) => !hidden)
               .map((tab, index: number) => (
-                <Tab condensed={condensed} key={index} active={activeTab === index} onClick={() => onTabClick(index)}>
+                <Tab key={index} active={activeTab === index} onClick={() => onTabClick(index)}>
                   {tab.loading ? (
                     <Spinner left size={14} />
                   ) : (

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react"
 import Spinner from "../Spinner/Spinner"
 import styled from "../utils/styled"
 import { IconComponentType } from "../Icon/Icon"
+import { inputFocus } from "../utils"
 
 export interface Tab {
   name: string
@@ -43,26 +44,40 @@ const TabsBar = styled("div")(({ theme }) => ({
   },
 }))
 
-const Tab = styled("div")<{ active?: boolean }>(({ theme, active }) => ({
+const SingleTab = styled("div")<{ active?: boolean }>(({ theme, active }) => ({
   width: 150,
   height: "100%",
   display: "flex",
   alignItems: "center",
-  backgroundColor: active ? theme.color.white : theme.color.background.lighter,
-  color: active ? theme.color.text.action : theme.color.text.dark,
   fontFamily: theme.font.family.main,
   fontSize: theme.font.size.small,
-  fontWeight: active ? theme.font.weight.bold : theme.font.weight.regular,
   padding: `0px ${theme.space.element}px`,
   border: `1px solid ${theme.color.border.select}`,
   zIndex: 2,
-  borderBottomColor: active ? theme.color.white : theme.color.border.select,
+  ...(active
+    ? {
+        backgroundColor: theme.color.white,
+        color: theme.color.text.action,
+        fontWeight: theme.font.weight.bold,
+        borderBottomColor: theme.color.white,
+      }
+    : {
+        backgroundColor: theme.color.background.lighter,
+        color: theme.color.text.dark,
+        fontWeight: theme.font.weight.regular,
+        borderBottomColor: theme.color.border.select,
+      }),
   borderRightWidth: 0,
   ":last-child": {
     borderRightWidth: 1,
   },
   ":hover": {
     cursor: "pointer",
+  },
+  ":focus": {
+    ...inputFocus({ theme, isError: false }),
+    borderRightWidth: 1,
+    zIndex: 3,
   },
 }))
 
@@ -85,6 +100,8 @@ const getTabIndexByName = (tabs: Tab[], tabName?: string): number => {
 const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
   const activeTabIndex = getTabIndexByName(tabs, activeTabName)
   const [activeTab, setActiveTab] = useState(activeTabIndex)
+  const [isMouseDown, setMouseDown] = useState(false)
+
   useEffect(() => {
     setActiveTab(activeTabIndex)
   }, [activeTabIndex])
@@ -99,25 +116,79 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
     [onTabChange, tabs, setActiveTab],
   )
 
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const tabElements: NodeListOf<HTMLElement> = document.querySelectorAll('[role="tab"]')
+      let newIndex: number
+      switch (event.key) {
+        case "ArrowRight":
+          event.preventDefault()
+          newIndex = activeTab + 1 >= tabs.length ? 0 : activeTab + 1
+          tabElements[newIndex].focus()
+          onTabClick(newIndex)
+          break
+        case "ArrowLeft":
+          event.preventDefault()
+          newIndex = activeTab - 1 < 0 ? tabs.length - 1 : activeTab - 1
+          tabElements[newIndex].focus()
+          onTabClick(newIndex)
+          break
+        case "Home":
+          event.preventDefault()
+          newIndex = tabs.length - 1
+          tabElements[newIndex].focus()
+          // Activate last tab
+          onTabClick(newIndex)
+          break
+        case "End":
+          event.preventDefault()
+          newIndex = 0
+          tabElements[newIndex].focus()
+          // Activate first tab
+          onTabClick(0)
+          break
+      }
+    },
+    [activeTab, onTabClick],
+  )
+
   // Work around: wrap return in fragment- to prevent type error and not having to change childrens return type
   // https://github.com/Microsoft/TypeScript/issues/21699
   return (
     <>
       {children({
         tabsBar: (
-          <TabsBar>
+          <TabsBar role={"tablist"} onKeyDown={onKeyDown}>
             {tabs
               .filter(({ hidden }) => !hidden)
-              .map((tab, index: number) => (
-                <Tab key={index} active={activeTab === index} onClick={() => onTabClick(index)}>
-                  {tab.loading ? (
-                    <Spinner left size={14} />
-                  ) : (
-                    tab.icon && React.createElement(tab.icon, { size: 14, color: tab.iconColor, left: true })
-                  )}
-                  <TabName>{tab.name}</TabName>
-                </Tab>
-              ))}
+              .map((tab, index: number) => {
+                const isActive: boolean = activeTab === index
+                return (
+                  <SingleTab
+                    key={index}
+                    role={"tab"}
+                    active={isActive}
+                    aria-selected={isActive}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => onTabClick(index)}
+                    onKeyDown={onKeyDown}
+                    onFocus={e => {
+                      if (isMouseDown) {
+                        e.target.blur()
+                      }
+                    }}
+                    onMouseDown={() => setMouseDown(true)}
+                    onMouseUp={() => setMouseDown(false)}
+                  >
+                    {tab.loading ? (
+                      <Spinner left size={14} />
+                    ) : (
+                      tab.icon && React.createElement(tab.icon, { size: 14, color: tab.iconColor, left: true })
+                    )}
+                    <TabName>{tab.name}</TabName>
+                  </SingleTab>
+                )
+              })}
           </TabsBar>
         ),
         activeChildren: tabs[activeTab].children,

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -23,8 +23,7 @@ export interface State {
   activeTab: number
 }
 
-export const tabsBarHeight = 48
-export const tabsBarMargin = 20
+const tabsBarHeight = 48
 
 const TabsBar = styled("div")(({ theme }) => ({
   display: "flex",
@@ -32,7 +31,7 @@ const TabsBar = styled("div")(({ theme }) => ({
   height: tabsBarHeight,
   color: "inherit",
   position: "inherit",
-  margin: tabsBarMargin,
+  margin: `0 ${theme.space.element}px`,
   "&::before": {
     content: "''",
     display: "block",

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -3,7 +3,6 @@ import Spinner from "../Spinner/Spinner"
 import styled from "../utils/styled"
 import { IconComponentType } from "../Icon/Icon"
 import { inputFocus } from "../utils"
-import { useUniqueId } from "../useUniqueId"
 
 export interface Tab {
   name: string
@@ -33,6 +32,7 @@ const TabsBar = styled("div")(({ theme }) => ({
   height: tabsBarHeight,
   position: "relative",
   margin: `0 ${theme.space.element}px`,
+  // This draws the line underneath the tabs
   "&::before": {
     content: "''",
     display: "block",
@@ -137,7 +137,6 @@ const SingleTab = ({ index, isActive, onTabClick, tab, isKeyboardActive }: TabPr
 const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
   const activeTabIndex = getTabIndexByName(tabs, activeTabName)
   const [activeTab, setActiveTab] = useState(activeTabIndex)
-  const uid = useUniqueId()
   const isKeyboardActive = useRef(false)
 
   const onTabClick = useCallback(
@@ -183,7 +182,7 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
     <>
       {children({
         tabsBar: (
-          <TabsBar role="tablist" id={uid} onKeyDown={onKeyDown} onMouseDown={() => (isKeyboardActive.current = false)}>
+          <TabsBar role="tablist" onKeyDown={onKeyDown} onMouseDown={() => (isKeyboardActive.current = false)}>
             {tabs
               .filter(({ hidden }) => !hidden)
               .map((tab, index: number) => (

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -135,17 +135,17 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
           break
         case "Home":
           event.preventDefault()
-          newIndex = tabs.length - 1
+          newIndex = 0
           tabElements[newIndex].focus()
-          // Activate last tab
+          // Activate first tab
           onTabClick(newIndex)
           break
         case "End":
           event.preventDefault()
-          newIndex = 0
+          newIndex = tabs.length - 1
           tabElements[newIndex].focus()
-          // Activate first tab
-          onTabClick(0)
+          // Activate last tab
+          onTabClick(newIndex)
           break
       }
     },

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -29,7 +29,6 @@ export interface PropsWithSimplePage extends BaseProps {
   tabs?: never
   activeTabName?: never
   onTabChange?: never
-  condensedTitle?: never
 }
 
 export interface PropsWithComplexPage extends BaseProps {
@@ -40,7 +39,6 @@ export interface PropsWithComplexPage extends BaseProps {
   tabs?: never
   activeTabName?: never
   onTabChange?: never
-  condensedTitle?: never
 }
 
 export interface PropsWithTabs extends BaseProps {
@@ -62,8 +60,6 @@ export interface PropsWithTabs extends BaseProps {
   children?: never
   areas?: never
   fill?: never
-  /** Condensed option */
-  condensedTitle?: boolean
 }
 
 export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTabs
@@ -82,16 +78,14 @@ const TitleContainer = styled("div")(({ theme }) => ({
   fontWeight: theme.font.weight.medium,
 }))
 
-const ViewContainer = styled("div")<{ isInTab?: boolean; isTitleCondensed?: boolean; hasTitle?: boolean }>(
-  ({ theme, isInTab, isTitleCondensed, hasTitle }) => {
-    const calculatedTitleOffset = isInTab && !isTitleCondensed ? theme.titleHeight + tabsBarHeight : theme.titleHeight
-    return {
-      height: hasTitle ? `calc(100% - ${calculatedTitleOffset}px)` : "100%",
-      overflow: "hidden",
-      position: "relative",
-    }
-  },
-)
+const ViewContainer = styled("div")<{ isInTab?: boolean; hasTitle?: boolean }>(({ theme, isInTab, hasTitle }) => {
+  const calculatedTitleOffset = isInTab ? theme.titleHeight + tabsBarHeight : theme.titleHeight
+  return {
+    height: hasTitle ? `calc(100% - ${calculatedTitleOffset}px)` : "100%",
+    overflow: "hidden",
+    position: "relative",
+  }
+})
 
 const ActionsContainer = styled("div")`
   display: flex;
@@ -118,30 +112,24 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
 
   private renderPageWithTabs() {
     const tabs = this.props.tabs!
-    const { title, actions, condensedTitle } = this.props
+    const { title, actions } = this.props
 
     return (
-      <Tabs
-        tabs={tabs}
-        activeTabName={this.props.activeTabName}
-        onTabChange={this.props.onTabChange}
-        condensed={condensedTitle}
-      >
+      <Tabs tabs={tabs} activeTabName={this.props.activeTabName} onTabChange={this.props.onTabChange}>
         {({ tabsBar, activeChildren }) => (
           <>
             {title ? (
               <>
                 <TitleContainer>
                   <Title>{title}</Title>
-                  {condensedTitle && tabsBar}
                   <ActionsContainer>{actions}</ActionsContainer>
                 </TitleContainer>
-                {!condensedTitle && tabsBar}
+                {tabsBar}
               </>
             ) : (
               tabsBar
             )}
-            <ViewContainer isInTab isTitleCondensed={condensedTitle} hasTitle>
+            <ViewContainer isInTab hasTitle>
               {activeChildren}
             </ViewContainer>
           </>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -67,7 +67,7 @@ export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTa
 const Container = styled("div")(({ theme }) => ({
   height: "100%",
   position: "relative",
-  backgroundColor: theme.color.background.lighter,
+  backgroundColor: theme.color.white,
 }))
 
 const TitleContainer = styled("div")(({ theme }) => ({

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -70,7 +70,8 @@ const Container = styled("div")(({ theme }) => ({
   display: "grid",
   gridRowGap: theme.space.element,
   backgroundColor: theme.color.white,
-  gridTemplateRows: "max-content",
+  gridTemplateRows: `${theme.titleHeight}px ${theme.tabsBarHeight}px calc(100% - ${theme.titleHeight +
+    theme.tabsBarHeight}px);`,
 }))
 
 const TitleContainer = styled("div")(({ theme }) => ({

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -7,6 +7,7 @@ import Progress from "../Progress/Progress"
 import { DefaultProps } from "../types"
 import { Title } from "../Typography/Title"
 import styled from "../utils/styled"
+import { OperationalStyleConstants } from "../utils/constants"
 
 export interface BaseProps extends DefaultProps {
   /** Content of the page */
@@ -64,15 +65,22 @@ export interface PropsWithTabs extends BaseProps {
 
 export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTabs
 
-const Container = styled("div")<{ hasTabs: boolean }>(({ theme, hasTabs }) => ({
+const computeRowHeights = (theme: OperationalStyleConstants, hasTitle: boolean, hasTabs: boolean) => {
+  const titleHeightString = hasTitle ? `${theme.titleHeight}px ` : ""
+  const tabsHeightString = hasTabs ? `${theme.tabsBarHeight}px ` : ""
+  const titleHeightWithRowGap = hasTitle ? theme.titleHeight + theme.space.element : 0
+  const tabsHeightWithRowGap = hasTabs ? theme.tabsBarHeight + theme.space.element : 0
+  const viewContainerHeightString = `calc(100% - ${titleHeightWithRowGap + tabsHeightWithRowGap}px)`
+  return `${titleHeightString}${tabsHeightString}${viewContainerHeightString}`
+}
+
+const Container = styled("div")<{ hasTitle: boolean; hasTabs: boolean }>(({ theme, hasTitle, hasTabs }) => ({
   height: "100%",
   position: "relative",
   display: "grid",
   gridRowGap: theme.space.element,
   backgroundColor: theme.color.white,
-  gridTemplateRows: hasTabs
-    ? `${theme.titleHeight}px ${theme.tabsBarHeight}px calc(100% - ${theme.titleHeight + theme.tabsBarHeight}px);`
-    : `${theme.titleHeight}px calc(100% - ${theme.titleHeight}px);`,
+  gridTemplateRows: computeRowHeights(theme, hasTitle, hasTabs),
 }))
 
 const TitleContainer = styled("div")(({ theme }) => ({
@@ -166,7 +174,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
     const { tabs, fill, onTabChange, loading, title, ...props } = this.props
 
     return (
-      <Container hasTabs={Boolean(tabs)} {...props}>
+      <Container hasTabs={Boolean(tabs)} hasTitle={Boolean(title)} {...props}>
         {loading && <FixedProgress />}
         {tabs ? this.renderPageWithTabs() : this.renderPageWithoutTabs()}
       </Container>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import Tabs, { Tab, tabsBarHeight } from "../Internals/Tabs"
+import Tabs, { Tab, tabsBarHeight, tabsBarMargin } from "../Internals/Tabs"
 import PageArea from "../PageArea/PageArea"
 import PageContent, { PageContentProps, isChildFunction } from "../PageContent/PageContent"
 import Progress from "../Progress/Progress"
@@ -79,7 +79,7 @@ const TitleContainer = styled("div")(({ theme }) => ({
 }))
 
 const ViewContainer = styled("div")<{ isInTab?: boolean; hasTitle?: boolean }>(({ theme, isInTab, hasTitle }) => {
-  const calculatedTitleOffset = isInTab ? theme.titleHeight + tabsBarHeight : theme.titleHeight
+  const calculatedTitleOffset = isInTab ? theme.titleHeight + tabsBarHeight + tabsBarMargin * 2 : theme.titleHeight
   return {
     height: hasTitle ? `calc(100% - ${calculatedTitleOffset}px)` : "100%",
     overflow: "hidden",

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -64,14 +64,15 @@ export interface PropsWithTabs extends BaseProps {
 
 export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTabs
 
-const Container = styled("div")(({ theme }) => ({
+const Container = styled("div")<{ hasTabs: boolean }>(({ theme, hasTabs }) => ({
   height: "100%",
   position: "relative",
   display: "grid",
   gridRowGap: theme.space.element,
   backgroundColor: theme.color.white,
-  gridTemplateRows: `${theme.titleHeight}px ${theme.tabsBarHeight}px calc(100% - ${theme.titleHeight +
-    theme.tabsBarHeight}px);`,
+  gridTemplateRows: hasTabs
+    ? `${theme.titleHeight}px ${theme.tabsBarHeight}px calc(100% - ${theme.titleHeight + theme.tabsBarHeight}px);`
+    : `${theme.titleHeight}px calc(100% - ${theme.titleHeight}px);`,
 }))
 
 const TitleContainer = styled("div")(({ theme }) => ({
@@ -165,7 +166,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
     const { tabs, fill, onTabChange, loading, title, ...props } = this.props
 
     return (
-      <Container {...props}>
+      <Container hasTabs={Boolean(tabs)} {...props}>
         {loading && <FixedProgress />}
         {tabs ? this.renderPageWithTabs() : this.renderPageWithoutTabs()}
       </Container>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -127,7 +127,9 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
             ) : (
               tabsBar
             )}
-            <ViewContainer>{activeChildren}</ViewContainer>
+            <ViewContainer role="tabpanel" aria-labelledby={this.props.activeTabName} tabIndex={0}>
+              {activeChildren}
+            </ViewContainer>
           </>
         )}
       </Tabs>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -128,7 +128,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
             ) : (
               tabsBar
             )}
-            <ViewContainer role="tabpanel" aria-labelledby={this.props.activeTabName} tabIndex={0}>
+            <ViewContainer role="tabpanel" tabIndex={0}>
               {activeChildren}
             </ViewContainer>
           </>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -70,7 +70,7 @@ const Container = styled("div")(({ theme }) => ({
   display: "grid",
   gridRowGap: theme.space.element,
   backgroundColor: theme.color.white,
-  gridTemplateRows: `${theme.titleHeight}px auto`,
+  gridTemplateRows: "max-content",
 }))
 
 const TitleContainer = styled("div")(({ theme }) => ({

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import Tabs, { Tab, tabsBarHeight, tabsBarMargin } from "../Internals/Tabs"
+import Tabs, { Tab } from "../Internals/Tabs"
 import PageArea from "../PageArea/PageArea"
 import PageContent, { PageContentProps, isChildFunction } from "../PageContent/PageContent"
 import Progress from "../Progress/Progress"
@@ -67,6 +67,8 @@ export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTa
 const Container = styled("div")(({ theme }) => ({
   height: "100%",
   position: "relative",
+  display: "grid",
+  gridRowGap: theme.space.element,
   backgroundColor: theme.color.white,
 }))
 
@@ -78,14 +80,10 @@ const TitleContainer = styled("div")(({ theme }) => ({
   fontWeight: theme.font.weight.medium,
 }))
 
-const ViewContainer = styled("div")<{ isInTab?: boolean; hasTitle?: boolean }>(({ theme, isInTab, hasTitle }) => {
-  const calculatedTitleOffset = isInTab ? theme.titleHeight + tabsBarHeight + tabsBarMargin * 2 : theme.titleHeight
-  return {
-    height: hasTitle ? `calc(100% - ${calculatedTitleOffset}px)` : "100%",
-    overflow: "hidden",
-    position: "relative",
-  }
-})
+const ViewContainer = styled("div")`
+  overflow: hidden;
+  position: relative;
+`
 
 const ActionsContainer = styled("div")`
   display: flex;
@@ -129,9 +127,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
             ) : (
               tabsBar
             )}
-            <ViewContainer isInTab hasTitle>
-              {activeChildren}
-            </ViewContainer>
+            <ViewContainer>{activeChildren}</ViewContainer>
           </>
         )}
       </Tabs>
@@ -149,7 +145,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
             <ActionsContainer>{actions}</ActionsContainer>
           </TitleContainer>
         )}
-        <ViewContainer hasTitle={Boolean(title)}>
+        <ViewContainer>
           <PageContent noPadding={Boolean(noPadding)} areas={areas} fill={fill}>
             {modalConfirmContext => {
               const resolvedChildren = isChildFunction(children) ? children(modalConfirmContext) : children

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -94,6 +94,7 @@ const TitleContainer = styled("div")(({ theme }) => ({
 const ViewContainer = styled("div")`
   overflow: hidden;
   position: relative;
+  outline: none;
 `
 
 const ActionsContainer = styled("div")`

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -70,6 +70,7 @@ const Container = styled("div")(({ theme }) => ({
   display: "grid",
   gridRowGap: theme.space.element,
   backgroundColor: theme.color.white,
+  gridTemplateRows: `${theme.titleHeight}px auto`,
 }))
 
 const TitleContainer = styled("div")(({ theme }) => ({

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -115,7 +115,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
 
     return (
       <Tabs tabs={tabs} activeTabName={this.props.activeTabName} onTabChange={this.props.onTabChange}>
-        {({ tabsBar, activeChildren }) => (
+        {({ tabsBar, activeChildren, activeTabId }) => (
           <>
             {title ? (
               <>
@@ -128,7 +128,7 @@ class Page extends React.Component<PageProps, Readonly<typeof initialState>> {
             ) : (
               tabsBar
             )}
-            <ViewContainer role="tabpanel" tabIndex={0}>
+            <ViewContainer aria-labelledby={activeTabId} role="tabpanel" tabIndex={0}>
               {activeChildren}
             </ViewContainer>
           </>

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -142,6 +142,8 @@ import { PageContent, Card, Page, Button } from "@operational/components"
 
 const TabContent = props => (
   <PageContent areas="side main">
+    <h1>{props.title}</h1>
+    <h1>Column 2</h1>
     {Array(50)
       .fill("Hello, this is page content")
       .map((text, index) => (
@@ -154,9 +156,9 @@ const TabContent = props => (
     actions={<Button icon="Open">Go somewhere else</Button>}
     title="Bundle detail"
     tabs={[
-      { name: "overview", children: <TabContent /> },
-      { name: "jobs", children: <TabContent /> },
-      { name: "functions", children: <TabContent /> },
+      { name: "overview", children: <TabContent title="overview" /> },
+      { name: "jobs", children: <TabContent title="jobs" /> },
+      { name: "functions", children: <TabContent title="functions" /> },
     ]}
     activeTabName={"jobs"}
   />

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -158,6 +158,7 @@ const TabContent = props => (
       { name: "jobs", children: <TabContent /> },
       { name: "functions", children: <TabContent /> },
     ]}
+    activeTabName={"jobs"}
   />
 </div>
 ```

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -81,10 +81,10 @@ import { Page, Card } from "@operational/components"
 
 ```jsx
 import * as React from "react"
-import { Button, Page, Card } from "@operational/components"
+import { OpenIcon, Button, Page, Card } from "@operational/components"
 
 const actions = (
-  <Button color="primary" icon="Open">
+  <Button color="primary" icon={OpenIcon}>
     Go somewhere else
   </Button>
 )
@@ -138,7 +138,7 @@ const Tab = props => (
 
 ```jsx
 import * as React from "react"
-import { PageContent, Card, Page, Button } from "@operational/components"
+import { OpenIcon, PageContent, Card, Page, Button } from "@operational/components"
 
 const TabContent = props => (
   <PageContent areas="side main">
@@ -153,7 +153,7 @@ const TabContent = props => (
 )
 ;<div style={{ height: 300 }}>
   <Page
-    actions={<Button icon="Open">Go somewhere else</Button>}
+    actions={<Button icon={OpenIcon}>Go somewhere else</Button>}
     title="Bundle detail"
     tabs={[
       { name: "overview", children: <TabContent title="overview" /> },

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -107,7 +107,7 @@ const Tab = props => (
 ;<Page
   title="Bundle detail"
   tabs={[
-    { name: "overview", children: <Tab title="Overview" />, icon: "Search" },
+    { name: "overview", children: <Tab title="Overview" /> },
     { name: "jobs", children: <Tab title="Jobs" /> },
     { name: "functions and more text to check label truncation", children: <Tab title="Functions" /> },
   ]}
@@ -127,7 +127,7 @@ const Tab = props => (
 )
 ;<Page
   tabs={[
-    { name: "overview", children: <Tab title="Overview" />, icon: "Search" },
+    { name: "overview", children: <Tab title="Overview" /> },
     { name: "jobs", children: <Tab title="Jobs" /> },
     { name: "functions", children: <Tab title="Functions" /> },
   ]}

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -109,7 +109,7 @@ const Tab = props => (
   tabs={[
     { name: "overview", children: <Tab title="Overview" />, icon: "Search" },
     { name: "jobs", children: <Tab title="Jobs" /> },
-    { name: "functions", children: <Tab title="Functions" /> },
+    { name: "functions and more text to check label truncation", children: <Tab title="Functions" /> },
   ]}
 />
 ```

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -149,7 +149,7 @@ const TabContent = props => (
       ))}
   </PageContent>
 )
-;<div style={{ height: 200 }}>
+;<div style={{ height: 300 }}>
   <Page
     actions={<Button icon="Open">Go somewhere else</Button>}
     title="Bundle detail"

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -257,6 +257,7 @@ const constants = {
   sidebarWidth: 220,
   topbarHeight: 42,
   titleHeight: 50,
+  tabsBarHeight: 48,
 }
 
 /*


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Update page content tabs to reflect new design. 

https://contiamo.atlassian.net/secure/RapidBoard.jspa?rapidView=43&projectKey=UI&modal=detail&selectedIssue=UI-52

Changes made:
- Style.
- Location - "condensed" tabs to the right of the title are no longer supported.
- Label truncation if too long.
- Page background changed to white to correspond to the new design and to ensure tabs don't look odd. 

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
- [ ] Scrolling behaviour
- [ ] Label truncation

Tester 2

- [ ] Things look good on the demo.
- [ ] Scrolling behaviour
- [ ] Label truncation
