### PR TITLE
**Fix:** Make SidenavItem extensible

### DIFF
--- a/src/SidenavItem/SidenavItem.tsx
+++ b/src/SidenavItem/SidenavItem.tsx
@@ -123,7 +123,7 @@ const SidenavItem: React.SFC<SidenavItemProps> = ({
         <BaseSidenavItem
           as={to ? "a" : undefined}
           {...props}
-          className={end ? "operational-ui__sidenav-item_end" : ""}
+          className={`${className}${end ? " operational-ui__sidenav-item_end" : ""}`}
           end_={Boolean(end)}
           compact={compact}
           href={to}


### PR DESCRIPTION
As of now, we don't really pass a `className` generated by `emotion` to `SidenavItem`. We just destructure it and let it hang around in memory. This PR fixes this by using `emotion`'s generated `className` in `SidenavItem` and making it extensible.