### PR TITLE
**Breaking**: Scroll buttons for Tabs

### DIFF
--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -48,8 +48,7 @@ const MyComponent = () => {
             <div>
               <p>Lorem ipsum {tabs.length + 1}</p>
             </div>
-          ),
-          key: Math.random(),
+          )
         },
       ]
       setTabs(newTabs)

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -33,7 +33,7 @@ const MyComponent = () => {
         </div>
       ),
       key: 1,
-      icon: <OlapIcon size={14} />,
+      icon: <OlapIcon size={12} />,
     },
     {
       title: "tab 3",

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -12,46 +12,16 @@ const MyComponent = () => {
   const [tabs, setTabs] = React.useState([
     {
       title: "tab 1 tab 1 tab 1 tab 1 tab 1 tab 1 tab 1 tab 1",
-      content: () => (
-        <div>
-          <p>Lorem ipsum 1</p>
-          <p>Lorem ipsum 1</p>
-          <p>Lorem ipsum 1</p>
-          <p>Lorem ipsum 1</p>
-          <p>Lorem ipsum 1</p>
-          <p>Lorem ipsum 1</p>
-          <p>Lorem ipsum 1</p>
-        </div>
-      ),
-      key: 0,
     },
     {
       title: "tab 2",
-      content: () => (
-        <div>
-          <p>Lorem ipsum 2</p>
-        </div>
-      ),
-      key: 1,
       icon: <OlapIcon size={12} />,
     },
     {
       title: "tab 3",
-      content: () => (
-        <div>
-          <p>Lorem ipsum 3</p>
-        </div>
-      ),
-      key: 2,
     },
     {
       title: "tab 4",
-      content: () => (
-        <div>
-          <p>Lorem ipsum 4</p>
-        </div>
-      ),
-      key: 3,
     },
   ])
   const [active, setActive] = React.useState(0)
@@ -97,7 +67,17 @@ const MyComponent = () => {
         onClose={onClose}
         onInsert={onInsert}
         style={{ height: "100%", width: "100%" }}
-      />
+      >
+        <div style={{ padding: 20 }}>
+          <p>Lorem ipsum {active + 1}</p>
+          <p>Lorem ipsum {active + 1}</p>
+          <p>Lorem ipsum {active + 1}</p>
+          <p>Lorem ipsum {active + 1}</p>
+          <p>Lorem ipsum {active + 1}</p>
+          <p>Lorem ipsum {active + 1}</p>
+          <p>Lorem ipsum {active + 1}</p>
+        </div>
+      </Tabs>
     </div>
   )
 }

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -79,7 +79,7 @@ const MyComponent = () => {
               <p>Lorem ipsum {tabs.length + 1}</p>
             </div>
           ),
-          key: tabs.length,
+          key: Math.random(),
         },
       ]
       setTabs(newTabs)

--- a/src/Tabs/ScrollButton.tsx
+++ b/src/Tabs/ScrollButton.tsx
@@ -7,7 +7,7 @@ export const ScrollButton: React.FC<{ onClick: any }> = ({ children, onClick, ..
       type="button"
       onMouseDown={e => {
         onClick(e)
-        isDown.current = setInterval(() => onClick(e), 100) as any
+        isDown.current = setInterval(() => onClick(), 100) as any
       }}
       onMouseUp={() => {
         isDown.current && clearTimeout(isDown.current)

--- a/src/Tabs/ScrollButton.tsx
+++ b/src/Tabs/ScrollButton.tsx
@@ -7,7 +7,7 @@ export const ScrollButton: React.FC<{ onClick: any }> = ({ children, onClick, ..
       type="button"
       onMouseDown={e => {
         onClick(e)
-        isDown.current = setInterval(() => onClick(), 100) as any
+        isDown.current = window.setInterval(() => onClick(), 100)
       }}
       onMouseUp={() => {
         isDown.current && clearTimeout(isDown.current)
@@ -23,5 +23,3 @@ export const ScrollButton: React.FC<{ onClick: any }> = ({ children, onClick, ..
     </button>
   )
 }
-
-// export default ScrollButton

--- a/src/Tabs/ScrollButton.tsx
+++ b/src/Tabs/ScrollButton.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+
+export const ScrollButton: React.FC<{ onClick: any }> = ({ children, onClick, ...props }) => {
+  const isDown = React.useRef<number | null>(null)
+  return (
+    <button
+      type="button"
+      onMouseDown={e => {
+        onClick(e)
+        isDown.current = setInterval(() => onClick(e), 100) as any
+      }}
+      onMouseUp={() => {
+        isDown.current && clearTimeout(isDown.current)
+        isDown.current = null
+      }}
+      onMouseLeave={() => {
+        isDown.current && clearTimeout(isDown.current)
+        isDown.current = null
+      }}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
+// export default ScrollButton

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -34,10 +34,16 @@ const Container = styled("div")`
 const TabList = styled("div")`
   display: flex;
   height: ${({ theme }) => theme.space.element * 2}px;
-  overflow-x: hidden;
+  overflow-x: auto;
   max-width: calc(100% - 110px);
   scroll-behavior: smooth;
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
+  overflow-y: hidden;
+  height: ${({ theme }) => theme.space.element * 2 + 20}px;
+  -webkit-overflow-scrolling: auto;
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `
 
 TabList.defaultProps = {
@@ -51,7 +57,7 @@ const TabScroll = styled("div")`
 const TabHeader = styled(SectionHeader)<{
   first: boolean
   "aria-selected": boolean
-  addButton?: boolean
+  condensed?: boolean
   as?: React.FC<any> | string
 }>`
   cursor: pointer;
@@ -67,10 +73,11 @@ const TabHeader = styled(SectionHeader)<{
          font-weight: bold;`
       : ""}
 
-  ${({ addButton }) => (addButton ? "max-width: 55px; min-width: 55px;" : "max-width: 180px;")}
+  ${({ condensed }) => (condensed ? "max-width: 55px; min-width: 55px;" : "max-width: 180px;")}
   flex-grow: 1;
   & svg {
-    pointer-events: none;
+    ${({ condensed }) => (condensed ? "pointer-events: none;" : "")}
+    cursor: pointer;
   }
   :focus {
     outline: none;
@@ -80,7 +87,7 @@ const TabHeader = styled(SectionHeader)<{
     color: ${({ theme }) => theme.color.disabled};
     cursor: not-allowed;
   }
-  z-index: 1;
+  margin: 0;
 `
 
 TabHeader.defaultProps = {
@@ -130,10 +137,12 @@ const TabIcon = styled("span")`
 
 const ScrollButtons = styled("div")`
   position: absolute;
-  right: 0;
+  right: 1px;
   width: 110px;
   display: flex;
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
+  border-right: solid 1px ${({ theme }) => theme.color.separators.default};
+  z-index: 1;
 `
 
 const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }: TabsProps) => {
@@ -274,14 +283,14 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
               tabIndex={-1}
               first={false}
               aria-selected={false}
-              addButton={true}
+              condensed={true}
               onMouseDown={e => {
                 e.preventDefault()
                 userAction.current = true
                 onInsert(tabs.length - 1)
               }}
             >
-              <PlusIcon size={12} />
+              <PlusIcon size={12} color="primary" />
             </TabHeader>
           )}
         </TabScroll>
@@ -292,7 +301,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
           tabIndex={-1}
           first={true}
           aria-selected={false}
-          addButton={true}
+          condensed={true}
           onClick={scrollLeft}
         >
           <ChevronLeftIcon size={14} />
@@ -302,7 +311,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
           tabIndex={-1}
           first={false}
           aria-selected={false}
-          addButton={true}
+          condensed={true}
           onClick={scrollRight}
         >
           <ChevronRightIcon size={14} />

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -8,9 +8,7 @@ import { ScrollButton } from "./ScrollButton"
 
 export interface Tab {
   title: string
-  content: () => React.ReactNode
-  key: string | number
-  icon: React.ReactNode
+  icon?: React.ReactNode
 }
 
 export interface TabsProps extends DefaultProps {
@@ -19,7 +17,6 @@ export interface TabsProps extends DefaultProps {
   onActivate: (tabIndex: number) => void
   onClose?: (tabIndex: number) => void
   onInsert?: (tabIndex: number) => void
-  children?: never
   label?: string
   style?: React.CSSProperties
   id?: string
@@ -152,7 +149,7 @@ const ScrollButtons = styled("div")`
   z-index: 1;
 `
 
-const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }: TabsProps) => {
+const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id, children }: TabsProps) => {
   if (!Number.isInteger(active) || active < 0 || active >= tabs.length) {
     active = active > 0 ? tabs.length - 1 : 0
     if (process.env.NODE_ENV !== "production")
@@ -252,7 +249,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
     <Container data-cy="operational-ui__Tabs" style={style}>
       <TabList aria-label={label} onKeyDown={onKeyDown} ref={tabListRef}>
         <TabScroll ref={tabScrollRef}>
-          {tabs.map(({ key, title, icon }, i) => {
+          {tabs.map(({ title, icon }, i) => {
             const onClick = () => {
               userAction.current = true
               onActivate(i)
@@ -262,9 +259,9 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
                 tabIndex={i === active ? 0 : -1}
                 first={i === 0}
                 aria-selected={i === active}
-                aria-controls={`TabPanel-${uid}-${key}`}
-                id={`TabHeader-${uid}-${key}`}
-                key={key}
+                aria-controls={`TabPanel-${uid}-${i}`}
+                id={`TabHeader-${uid}-${i}`}
+                key={i}
                 onClick={onClick}
                 onFocus={onClick}
                 ref={i === active ? activeTab : undefined}
@@ -328,14 +325,9 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
         </TabHeader>
       </ScrollButtons>
       <TabContainer>
-        {tabs.map(({ key, content }, i) => (
-          <TabPanel
-            hidden={i !== active}
-            id={`TabPanel-${uid}-${key}`}
-            aria-labelledby={`TabHeader-${uid}-${key}`}
-            key={key}
-          >
-            {i === active && content()}
+        {tabs.map((_, i) => (
+          <TabPanel hidden={i !== active} id={`TabPanel-${uid}-${i}`} aria-labelledby={`TabHeader-${uid}-${i}`} key={i}>
+            {i === active && children}
           </TabPanel>
         ))}
       </TabContainer>

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -5,6 +5,7 @@ import styled from "../utils/styled"
 import { useUniqueId } from "../useUniqueId"
 import noop from "lodash/noop"
 import { NoIcon, PlusIcon, ChevronLeftIcon, ChevronRightIcon } from "../Icon/Icon"
+import { ScrollButton } from "./ScrollButton"
 
 export interface Tab {
   title: string
@@ -37,6 +38,7 @@ const TabList = styled("div")`
   overflow-x: hidden;
   max-width: calc(100% - 110px);
   scroll-behavior: smooth;
+  border-left: solid 1px ${({ theme }) => theme.color.separators.default};
 `
 
 TabList.defaultProps = {
@@ -47,12 +49,17 @@ const TabScroll = styled("div")`
   display: flex;
 `
 
-const TabHeader = styled(SectionHeader)<{ first: boolean; "aria-selected": boolean; addButton?: boolean }>`
+const TabHeader = styled(SectionHeader)<{
+  first: boolean
+  "aria-selected": boolean
+  addButton?: boolean
+  as?: React.FC<any> | string
+}>`
   cursor: pointer;
   font-weight: normal;
   background-color: ${({ theme }) => theme.color.background.light};
   border: solid 1px ${({ theme }) => theme.color.separators.default};
-  ${({ first }) => (first ? "" : "border-left: none;")}
+  border-left: none;
   ${props =>
     props["aria-selected"]
       ? `border-bottom: 1px solid ${props.theme.color.background.lighter}; 
@@ -72,7 +79,6 @@ const TabHeader = styled(SectionHeader)<{ first: boolean; "aria-selected": boole
 
 TabHeader.defaultProps = {
   role: "tab",
-  // @ts-ignore styled components TS definitions doesn't like `as` prop, but it works just fine
   as: "button",
 }
 
@@ -120,6 +126,7 @@ const ScrollButtons = styled("div")`
   right: 0;
   width: 110px;
   display: flex;
+  border-left: solid 1px ${({ theme }) => theme.color.separators.default};
 `
 
 const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }: TabsProps) => {
@@ -266,17 +273,31 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
                 onInsert(tabs.length - 1)
               }}
             >
-              <PlusIcon size={14} onMouseDown={noop} />
+              <PlusIcon size={14} onClick={noop} />
             </TabHeader>
           )}
         </TabScroll>
       </TabList>
       <ScrollButtons>
-        <TabHeader tabIndex={-1} first={true} aria-selected={false} addButton={true} onMouseDown={scrollLeft}>
-          <ChevronLeftIcon size={14} onMouseDown={noop} />
+        <TabHeader
+          as={ScrollButton}
+          tabIndex={-1}
+          first={true}
+          aria-selected={false}
+          addButton={true}
+          onClick={scrollLeft}
+        >
+          <ChevronLeftIcon size={14} onClick={noop} />
         </TabHeader>
-        <TabHeader tabIndex={-1} first={false} aria-selected={false} addButton={true} onMouseDown={scrollRight}>
-          <ChevronRightIcon size={14} onMouseDown={noop} />
+        <TabHeader
+          as={ScrollButton}
+          tabIndex={-1}
+          first={false}
+          aria-selected={false}
+          addButton={true}
+          onClick={scrollRight}
+        >
+          <ChevronRightIcon size={14} onClick={noop} />
         </TabHeader>
       </ScrollButtons>
       <TabContainer>

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -6,6 +6,8 @@ import { useUniqueId } from "../useUniqueId"
 import { NoIcon, PlusIcon, ChevronLeftIcon, ChevronRightIcon } from "../Icon/Icon"
 import { ScrollButton } from "./ScrollButton"
 
+const buttonWidth = 55
+
 export interface Tab {
   title: string
   icon?: React.ReactNode
@@ -32,10 +34,11 @@ const TabList = styled("div")`
   display: flex;
   height: ${({ theme }) => theme.space.element * 2}px;
   overflow-x: auto;
-  max-width: calc(100% - 110px);
+  max-width: calc(100% - ${buttonWidth * 2}px);
   scroll-behavior: smooth;
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
   overflow-y: hidden;
+  /* magic number to hide scroll bar underneath tabpanel */
   height: ${({ theme }) => theme.space.element * 2 + 20}px;
   -webkit-overflow-scrolling: auto;
   ::-webkit-scrollbar {
@@ -71,7 +74,8 @@ const TabHeader = styled(SectionHeader)<{
          font-weight: bold;`
       : ""}
 
-  ${({ condensed }) => (condensed ? "max-width: 55px; min-width: 55px;" : "max-width: 180px;")}
+  ${({ condensed }) =>
+    condensed ? `max-width: ${buttonWidth}px; min-width: ${buttonWidth}px;` : "max-width: 180px;"}
   flex-grow: 1;
   & svg {
     ${({ condensed }) => (condensed ? "pointer-events: none;" : "")}
@@ -142,14 +146,14 @@ const TabIcon = styled("span")`
 const ScrollButtons = styled("div")`
   position: absolute;
   right: 1px;
-  width: 110px;
+  width: ${buttonWidth * 2}px;
   display: flex;
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
   border-right: solid 1px ${({ theme }) => theme.color.separators.default};
   z-index: 1;
 `
 
-const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id, children }: TabsProps) => {
+const Tabs: React.FC<TabsProps> = ({ tabs, active, onClose, onActivate, onInsert, label, style, id, children }) => {
   if (!Number.isInteger(active) || active < 0 || active >= tabs.length) {
     active = active > 0 ? tabs.length - 1 : 0
     if (process.env.NODE_ENV !== "production")
@@ -220,16 +224,6 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id, c
 
   const tabListRef = React.useRef<HTMLDivElement>(null)
   const tabScrollRef = React.useRef<HTMLDivElement>(null)
-
-  React.useEffect(() => {
-    if (tabListRef.current && tabScrollRef.current) {
-      if (tabListRef.current.getBoundingClientRect().width < tabScrollRef.current.getBoundingClientRect().width) {
-        // console.log("enable scroll")
-      } else {
-        // console.log("disable scroll")
-      }
-    }
-  }, [tabs])
 
   const scrollLeft = React.useCallback(event => {
     event && event.preventDefault() // so the button won't get focus when clicked

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -3,7 +3,6 @@ import { SectionHeader } from "../Internals/SectionHeader"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 import { useUniqueId } from "../useUniqueId"
-import noop from "lodash/noop"
 import { NoIcon, PlusIcon, ChevronLeftIcon, ChevronRightIcon } from "../Icon/Icon"
 import { ScrollButton } from "./ScrollButton"
 
@@ -70,9 +69,16 @@ const TabHeader = styled(SectionHeader)<{
 
   ${({ addButton }) => (addButton ? "max-width: 55px; min-width: 55px;" : "max-width: 180px;")}
   flex-grow: 1;
+  & svg {
+    pointer-events: none;
+  }
   :focus {
     outline: none;
-    ${({ theme }) => `box-shadow: ${theme.shadows.insetFocus};`}
+    box-shadow: ${({ theme }) => theme.shadows.insetFocus};
+  }
+  :disabled {
+    color: ${({ theme }) => theme.color.disabled};
+    cursor: not-allowed;
   }
   z-index: 1;
 `
@@ -115,6 +121,7 @@ const TitleWrapper = styled("span")`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  margin-right: ${({ theme }) => theme.space.small}px;
 `
 
 const TabIcon = styled("span")`
@@ -211,15 +218,15 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
     }
   }, [tabs])
 
-  const scrollLeft = React.useCallback(e => {
-    e.preventDefault()
+  const scrollLeft = React.useCallback(event => {
+    event && event.preventDefault() // so the button won't get focus when clicked
     if (tabListRef.current) {
       tabListRef.current.scrollLeft = tabListRef.current.scrollLeft - 100
     }
   }, [])
 
-  const scrollRight = React.useCallback(e => {
-    e.preventDefault()
+  const scrollRight = React.useCallback(event => {
+    event && event.preventDefault() // so the button won't get focus when clicked
     if (tabListRef.current) {
       tabListRef.current.scrollLeft = tabListRef.current.scrollLeft + 100
     }
@@ -270,10 +277,11 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
               addButton={true}
               onMouseDown={e => {
                 e.preventDefault()
+                userAction.current = true
                 onInsert(tabs.length - 1)
               }}
             >
-              <PlusIcon size={14} onClick={noop} />
+              <PlusIcon size={12} />
             </TabHeader>
           )}
         </TabScroll>
@@ -287,7 +295,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
           addButton={true}
           onClick={scrollLeft}
         >
-          <ChevronLeftIcon size={14} onClick={noop} />
+          <ChevronLeftIcon size={14} />
         </TabHeader>
         <TabHeader
           as={ScrollButton}
@@ -297,7 +305,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
           addButton={true}
           onClick={scrollRight}
         >
-          <ChevronRightIcon size={14} onClick={noop} />
+          <ChevronRightIcon size={14} />
         </TabHeader>
       </ScrollButtons>
       <TabContainer>

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -44,6 +44,7 @@ const TabList = styled("div")`
   ::-webkit-scrollbar {
     display: none;
   }
+  z-index: 1;
 `
 
 TabList.defaultProps = {
@@ -83,6 +84,9 @@ const TabHeader = styled(SectionHeader)<{
     outline: none;
     box-shadow: ${({ theme }) => theme.shadows.insetFocus};
   }
+  ::-moz-focus-inner {
+    border: none;
+  }
   :disabled {
     color: ${({ theme }) => theme.color.disabled};
     cursor: not-allowed;
@@ -103,10 +107,13 @@ const TabContainer = styled("div")`
 `
 
 const TabPanel = styled("div")`
-  padding: ${({ theme }) => theme.space.element}px;
+  z-index: 2;
   :focus {
     outline: none;
     ${({ theme }) => `box-shadow: ${theme.shadows.insetFocus};`}
+  }
+  ::-moz-focus-inner {
+    border: none;
   }
   height: 100%;
   overflow: auto;
@@ -280,6 +287,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
           })}
           {onInsert && (
             <TabHeader
+              aria-hidden={true}
               tabIndex={-1}
               first={false}
               aria-selected={false}
@@ -297,6 +305,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
       </TabList>
       <ScrollButtons>
         <TabHeader
+          aria-hidden={true}
           as={ScrollButton}
           tabIndex={-1}
           first={true}
@@ -307,6 +316,7 @@ const Tabs = ({ tabs, active, onClose, onActivate, onInsert, label, style, id }:
           <ChevronLeftIcon size={14} />
         </TabHeader>
         <TabHeader
+          aria-hidden={true}
           as={ScrollButton}
           tabIndex={-1}
           first={false}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Adds scroll buttons

<img width="1062" alt="Screenshot 2019-06-14 at 17 44 22" src="https://user-images.githubusercontent.com/179534/59521241-16e3a100-8ecc-11e9-8c03-a6a671ddc2d5.png">

And changes API (as discussed)

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
