### PR TITLE
  **Fix:** Select not showing list of items if no labels are provided

### DIFF
--- a/cypress/integration/Select.ts
+++ b/cypress/integration/Select.ts
@@ -59,6 +59,15 @@ describe("Select Components", () => {
   it("should be labelled correctly", () => {
     cy.get('[data-cy="basic-select"]').contains("Basic")
   })
+  it("should display values from the options if no labels were provided", () => {
+    cy.get('[data-cy="basic-select-no-labels"] input[value="one"]')
+      .type("{downarrow}")
+      .focused()
+      .type("{downarrow}")
+      .contains("two")
+      .type("enter")
+    cy.get('[data-cy="basic-select-no-labels"] input[value="two"]')
+  })
   it("should allow multi-select", () => {
     cy.get('[data-cy="multi-select"]')
       .type("{enter}")

--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -53,6 +53,55 @@ ${JSON.stringify(lastChanged, null, 2)}
 ;<MyComponent />
 ```
 
+If options are provided without labels, values are be displayed in the list.
+
+```jsx
+import * as React from "react"
+import { Select, Code } from "@operational/components"
+
+const options = [
+  { value: "one" },
+  { value: "two" },
+  { value: "three" },
+  { value: "four" },
+  { value: "five" },
+  { value: "six" },
+  { value: "seven" },
+  { value: "eight" },
+]
+
+const MyComponent = () => {
+  const [value, setValue] = React.useState("one")
+  const [lastChanged, setLastChanged] = React.useState(null)
+
+  return (
+    <>
+      <Select
+        id="basic-no-labels"
+        label="Without labels"
+        data-cy="basic-select-no-labels"
+        value={value}
+        options={options}
+        onChange={(newValue, lastChanged) => {
+          setValue(newValue)
+          setLastChanged(lastChanged)
+        }}
+      />
+      <Code>
+        {`
+Current value: ${value}
+Last changed option:
+
+${JSON.stringify(lastChanged, null, 2)}
+      `}
+      </Code>
+    </>
+  )
+}
+
+;<MyComponent />
+```
+
 ### Usage as multiselect
 
 Using an array prop in the `value` makes the component work as multiselect. The pop-up stays open so that additional values may be added.

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -81,7 +81,7 @@ export const Select: React.FC<SelectProps> = ({
     const filteredOptions = filterList(filter)(initialOptions)
     const truncatedOptions = truncateList(maxOptions)(filteredOptions)
     const contextMenuItems = optionsToContextMenuItems(option => ({
-      label: option.label ? option.label : "",
+      label: option.label ? option.label : String(option.value),
       isActive: isOptionSelected(value)(option),
     }))(truncatedOptions)
 

--- a/src/Select/Select.types.ts
+++ b/src/Select/Select.types.ts
@@ -1,6 +1,6 @@
 import { DefaultProps } from "../types"
 
-export type Value = number | symbol | string
+export type Value = number | string
 
 export interface IOption {
   label?: string


### PR DESCRIPTION
# Summary
Makes Select use `values` if no labels are provided in options list 

# Related issue
https://github.com/contiamo/operational-ui/issues/1032

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1
- [ ] Things look good on the demo.

Tester 2
- [ ] Things look good on the demo.
