### PR TITLE
**Fix:** Stop propagation on click of ContextMenu

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -171,7 +171,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         {...props}
         isOpen={isOpen || false}
         side={align}
-        onClick={() => {
+        onClick={e => {
+          e.stopPropagation()
           if (keepOpenOnItemClick && isOpen) {
             return
           }


### PR DESCRIPTION
When opening a menu on table rows, the table row is clicked because the event bubbles up. This PR fixes this.