### PR TITLE
**Fix:** Remove outline from sidenavitem

### DIFF
--- a/src/SidenavItem/SidenavItem.styled.ts
+++ b/src/SidenavItem/SidenavItem.styled.ts
@@ -62,6 +62,8 @@ export const StyledSidenavItem = styled("div", {
   svg {
     pointer-events: none;
   }
+
+  outline: none;
 `
 
 export const Caret = styled("div")<{ isOpen: boolean }>`


### PR DESCRIPTION
Removes this:
![image](https://user-images.githubusercontent.com/9947422/59705712-2c9ee200-91bc-11e9-98f1-8a41756051ee.png)


When it's focused, it's `primaryDark`. This is enough, we do not need an outline.