### PR TITLE
**Fix:** Handling of clicking on ContextMenuItems

### DIFF
--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -140,23 +140,7 @@ const ContextMenuItemIcon: React.SFC<Pick<Props, "item" | "iconLocation">> = ({ 
 
 const ContextMenuItem: React.SFC<Props> = ({ iconLocation, item, onClick, condensed, ...props }) => {
   return (
-    <Container
-      {...props}
-      onKeyDown={e => {
-        switch (e.key) {
-          case " ":
-          case "Enter":
-            if (onClick) {
-              e.stopPropagation()
-              e.preventDefault()
-              onClick(e)
-            }
-        }
-      }}
-      onClick={onClick}
-      condensed={condensed}
-      item={item}
-    >
+    <Container {...props} onClick={onClick} condensed={condensed} item={item}>
       {(!iconLocation || iconLocation === "left") && <ContextMenuItemIcon iconLocation={iconLocation} item={item} />}
       <Content value={item} />
       {iconLocation === "right" && <ContextMenuItemIcon iconLocation={iconLocation} item={item} />}

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import isString from "lodash/isString"
 
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
@@ -212,7 +213,12 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
               iconLocation={iconLocation}
               width={width || "100%"}
               item={item}
-              onClick={() => {
+              onClick={e => {
+                e.stopPropagation()
+                if (!isString(item) && item.onClick) {
+                  item.onClick(makeItem(item))
+                  return
+                }
                 if (onClick) {
                   onClick(makeItem(item))
                 }


### PR DESCRIPTION
There's a bug when trying to click on a ContextMenuItem. It doesn't work. This PR fixes it.

## To test:
1. Open [PR Preview](https://deploy-preview-1047--operational-ui.netlify.com/#/Components/Table)
1. Diff with master
1. Make sure you're on Table
1. Go to **With row actions**

- [ ] Click on links in action menu, should work on this version, not on master
