### PR TITLE
**Feature:** UI-43 Id input style and a custom status icon

### DIFF
--- a/cypress/integration/Input.ts
+++ b/cypress/integration/Input.ts
@@ -1,0 +1,32 @@
+describe("Input", () => {
+  it("should be visible in the DOM", () => {
+    cy.visit("/#!/Input/17")
+    cy.get('[data-cy="operational-ui__Input"]')
+  })
+
+  it("Should be clearable when clicking a dedicated button", () => {
+    cy.visit("/#!/Input/3")
+
+    cy.get('input[value="Clear me..."]')
+    cy.get('[data-cy="operational-ui__Input-clear-button"]')
+
+    cy.get('[data-cy="operational-ui__Input"]')
+      .tab()
+      .click()
+
+    cy.get('input[value="Clear me..."]').should("not.exist")
+    cy.get('[data-cy="operational-ui__Input-clear-button"]').should("not.exist")
+  })
+
+  it("Should be clearable when has Id style", () => {
+    cy.visit("/#!/Input/17")
+    cy.get('input[value="MyTable_01"]')
+    cy.get('[data-cy="operational-ui__Input-clear-button"]').click()
+    cy.get('input[value="MyTable_01"]').should("not.exist")
+  })
+
+  it("Should display custom status icon if provided", () => {
+    cy.visit("/#!/Input/19")
+    cy.get('[data-cy="operational-ui__Input-status-icon"]')
+  })
+})

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -5,7 +5,7 @@ import styled from "../utils/styled"
 import { InputProps } from "./Input"
 import InputButton from "./Input.Button"
 import { height } from "./Input.constants"
-import { NoIcon } from "../Icon/Icon"
+import { NoIcon, ServiceAccountIcon } from "../Icon/Icon"
 
 const width = 360
 
@@ -27,10 +27,9 @@ const Field = styled("input")<{
   preset: InputProps["preset"]
   disabled: InputProps["disabled"]
   clear: InputProps["clear"]
-  idStyle?: boolean
-}>(({ theme, disabled, isError, withIconButton, preset, clear, idStyle }) => {
-  console.log("idStyle", idStyle)
 
+  idStyle: InputProps["idStyle"]
+}>(({ theme, disabled, isError, withIconButton, preset, clear, idStyle }) => {
   const makeBackgroundColor = () => {
     if (disabled) {
       return theme.color.disabled
@@ -55,6 +54,18 @@ const Field = styled("input")<{
     return theme.font.weight.regular
   }
 
+  const getRightPadding = () => {
+    if (clear && idStyle) {
+      return height + theme.space.big
+    }
+
+    if (clear || idStyle) {
+      return height
+    }
+
+    return theme.space.small
+  }
+
   return {
     ...(withIconButton
       ? { borderTopRightRadius: theme.borderRadius, borderBottomRightRadius: theme.borderRadius, marginLeft: -1 }
@@ -67,9 +78,7 @@ const Field = styled("input")<{
     height,
     label: "input",
     flexGrow: 1,
-    padding: `${theme.space.small}px ${idStyle ? height : theme.space.medium}px ${theme.space.small}px ${
-      theme.space.medium
-    }px`,
+    padding: `${theme.space.small}px ${getRightPadding()}px ${theme.space.small}px ${theme.space.medium}px`,
     opacity: disabled ? 0.6 : 1.0,
     border: "1px solid",
     borderColor: isError ? theme.color.error : theme.color.border.default,
@@ -79,7 +88,6 @@ const Field = styled("input")<{
     "::placeholder": {
       color: theme.color.text.disabled,
     },
-    ...(clear ? { paddingRight: 40 } : {}),
     "&:focus": inputFocus({
       theme,
       isError,
@@ -87,11 +95,7 @@ const Field = styled("input")<{
   }
 })
 
-const ClearButton = styled("div")`
-  position: absolute;
-  top: 0; /* anchor the position to the top so the browser doesn't guess */
-  right: 0; /* not 12px but 0 because we want a _box_ to attach to the end of Input and not just an X pushed in from the right */
-
+const ClearButton = styled.div`
   /* We also probably should specify the dimensions of this box */
   width: ${height}px;
   height: ${height}px;
@@ -109,13 +113,17 @@ const ClearButton = styled("div")`
   }
 `
 
-const IdIconContainer = styled.div`
+const IconContainer = styled.div<{
+  clear: InputProps["clear"]
+  value: InputProps["value"]
+  idStyle: InputProps["idStyle"]
+}>`
   position: absolute;
   top: 0; /* anchor the position to the top so the browser doesn't guess */
   right: 0; /* not 12px but 0 because we want a _box_ to attach to the end of Input and not just an X pushed in from the right */
 
   /* We also probably should specify the dimensions of this box */
-  width: ${height}px;
+  width: ${({ clear, value, idStyle }) => (clear && value && idStyle ? 2 * height : height)}px;
   height: ${height}px;
 
   /* Also, let's center the contents of this box */
@@ -191,16 +199,14 @@ const InputField: React.SFC<InputProps> = ({
           idStyle={idStyle}
           {...props}
         />
-        {idStyle && (
-          <IdIconContainer>
-            <NoIcon />
-          </IdIconContainer>
-        )}
-        {!idStyle && clear && value && (
-          <ClearButton onClick={clear}>
-            <NoIcon />
-          </ClearButton>
-        )}
+        <IconContainer clear={clear} value={value} idStyle={idStyle}>
+          {clear && value && (
+            <ClearButton onClick={clear}>
+              <NoIcon />
+            </ClearButton>
+          )}
+          {idStyle && <ServiceAccountIcon />}
+        </IconContainer>
         {error && !ErrorComponent ? <FormFieldError>{error}</FormFieldError> : null}
       </Container>
       {error && ErrorComponent ? <ErrorComponent errorMessage={error} /> : null}

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -8,17 +8,30 @@ import { height } from "./Input.constants"
 import { NoIcon, ServiceAccountIcon } from "../Icon/Icon"
 
 const width = 360
+const iconBoxSize = height // Fit icons into the square with the side of the input height
 
-const Container = styled("div")<{
+const getMaxWidth = (fullWidth: InputProps["fullWidth"], statusIcon: InputProps["statusIcon"]) => {
+  if (fullWidth && statusIcon) {
+    return `calc(100% - ${iconBoxSize}px)`
+  }
+
+  if (fullWidth) {
+    return "none"
+  }
+
+  return `${width}px`
+}
+
+const Container = styled.div<{
   fullWidth: InputProps["fullWidth"]
-  withLabel: boolean
+  statusIcon: InputProps["statusIcon"]
 }>`
   position: relative;
   align-items: center;
   justify-content: center;
   display: inline-flex;
   width: 100%;
-  max-width: ${({ fullWidth }) => (fullWidth ? "none" : `${width}px`)};
+  max-width: ${({ fullWidth, statusIcon }) => getMaxWidth(fullWidth, statusIcon)};
 `
 
 const Field = styled("input")<{
@@ -27,7 +40,6 @@ const Field = styled("input")<{
   preset: InputProps["preset"]
   disabled: InputProps["disabled"]
   clear: InputProps["clear"]
-
   idStyle: InputProps["idStyle"]
 }>(({ theme, disabled, isError, withIconButton, preset, clear, idStyle }) => {
   const makeBackgroundColor = () => {
@@ -56,11 +68,11 @@ const Field = styled("input")<{
 
   const getRightPadding = () => {
     if (clear && idStyle) {
-      return height + theme.space.big
+      return iconBoxSize + theme.space.big
     }
 
     if (clear || idStyle) {
-      return height
+      return iconBoxSize
     }
 
     return theme.space.small
@@ -70,7 +82,7 @@ const Field = styled("input")<{
     ...(withIconButton
       ? { borderTopRightRadius: theme.borderRadius, borderBottomRightRadius: theme.borderRadius, marginLeft: -1 }
       : { borderRadius: theme.borderRadius }),
-    font: idStyle ? undefined : "inherit",
+    font: idStyle ? "none" : "inherit",
     fontFamily: idStyle ? theme.font.family.code : theme.font.family.main,
     fontWeight: getFontWeight(),
     fontSize: theme.font.size.body,
@@ -97,8 +109,8 @@ const Field = styled("input")<{
 
 const ClearButton = styled.div`
   /* We also probably should specify the dimensions of this box */
-  width: ${height}px;
-  height: ${height}px;
+  width: ${iconBoxSize}px;
+  height: ${iconBoxSize}px;
 
   /* Also, let's center the contents of this box */
   display: flex;
@@ -116,12 +128,11 @@ const ClearButton = styled.div`
 const IconContainer = styled.div<{ iconAmount: number; right: number }>`
   position: absolute;
   top: 0; /* anchor the position to the top so the browser doesn't guess */
-  right: ${({ right }) =>
-    right}px; /* not 12px but 0 because we want a _box_ to attach to the end of Input and not just an X pushed in from the right */
+  right: ${({ right }) => right}px;
 
-  /* We also probably should specify the dimensions of this box */
-  width: ${({ iconAmount }) => iconAmount * height}px;
-  height: ${height}px;
+  /* Dimensions of the container */
+  width: ${({ iconAmount }) => iconAmount * iconBoxSize}px;
+  height: ${iconBoxSize}px;
 
   /* Also, let's center the contents of this box */
   display: flex;
@@ -152,8 +163,8 @@ const InputField: React.FC<InputProps> = ({
   copy,
   onIconClick,
   tabIndex,
-  idStyle,
   errorComponent: ErrorComponent,
+  idStyle,
   statusIcon,
   ...props
 }) => {
@@ -169,7 +180,7 @@ const InputField: React.FC<InputProps> = ({
 
   return (
     <>
-      <Container fullWidth={fullWidth} withLabel={Boolean(label)}>
+      <Container fullWidth={fullWidth} statusIcon={statusIcon}>
         {shouldShowIconButton && renderButton()}
         <Field
           ref={inputRef}
@@ -198,6 +209,7 @@ const InputField: React.FC<InputProps> = ({
           {...props}
         />
         <IconContainer iconAmount={(clear && value ? 1 : 0) + (idStyle ? 1 : 0)} right={0}>
+          {/* Clear button and Id style icon within the input border */}
           {clear && value && (
             <ClearButton onClick={clear}>
               <NoIcon />
@@ -206,7 +218,8 @@ const InputField: React.FC<InputProps> = ({
           {idStyle && <ServiceAccountIcon />}
         </IconContainer>
         {Boolean(statusIcon) && (
-          <IconContainer iconAmount={1} right={-height}>
+          <IconContainer iconAmount={1} right={-iconBoxSize}>
+            {/* negative `right` to place the status icon on the right side of the input */}
             {statusIcon}
           </IconContainer>
         )}

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -37,8 +37,8 @@ const Field = styled("input")<{
   preset: InputProps["preset"]
   disabled: InputProps["disabled"]
   clear: InputProps["clear"]
-  idStyle: InputProps["idStyle"]
-}>(({ theme, disabled, isError, withIconButton, preset, clear, idStyle }) => {
+  isUniqueId: InputProps["isUniqueId"]
+}>(({ theme, disabled, isError, withIconButton, preset, clear, isUniqueId }) => {
   const makeBackgroundColor = () => {
     if (disabled) {
       return theme.color.disabled
@@ -52,7 +52,7 @@ const Field = styled("input")<{
   }
 
   const getFontWeight = () => {
-    if (idStyle) {
+    if (isUniqueId) {
       return theme.font.weight.bold
     }
 
@@ -64,11 +64,11 @@ const Field = styled("input")<{
   }
 
   const getRightPadding = () => {
-    if (clear && idStyle) {
+    if (clear && isUniqueId) {
       return iconBoxSize + theme.space.big
     }
 
-    if (clear || idStyle) {
+    if (clear || isUniqueId) {
       return iconBoxSize
     }
 
@@ -79,8 +79,8 @@ const Field = styled("input")<{
     ...(withIconButton
       ? { borderTopRightRadius: theme.borderRadius, borderBottomRightRadius: theme.borderRadius, marginLeft: -1 }
       : { borderRadius: theme.borderRadius }),
-    font: idStyle ? "none" : "inherit",
-    fontFamily: idStyle ? theme.font.family.code : "inherit",
+    font: isUniqueId ? "none" : "inherit",
+    fontFamily: isUniqueId ? theme.font.family.code : "inherit",
     fontWeight: getFontWeight(),
     fontSize: theme.font.size.small,
     width: "100%",
@@ -169,7 +169,7 @@ const InputField: React.FC<InputProps> = ({
   onIconClick,
   tabIndex,
   errorComponent: ErrorComponent,
-  idStyle,
+  isUniqueId,
   statusIcon,
   ...props
 }) => {
@@ -211,10 +211,10 @@ const InputField: React.FC<InputProps> = ({
           withIconButton={shouldShowIconButton}
           autoComplete={autoComplete}
           tabIndex={tabIndex}
-          idStyle={idStyle}
+          isUniqueId={isUniqueId}
           {...props}
         />
-        <IconContainer iconAmount={(clear && value ? 1 : 0) + (idStyle ? 1 : 0)} right={0}>
+        <IconContainer iconAmount={(clear && value ? 1 : 0) + (isUniqueId ? 1 : 0)} right={0}>
           {/* Clear button and Id style icon within the input border */}
           {clear && value && (
             <ClearButton
@@ -226,7 +226,7 @@ const InputField: React.FC<InputProps> = ({
               <NoIcon />
             </ClearButton>
           )}
-          {idStyle && <ServiceAccountIcon />}
+          {isUniqueId && <ServiceAccountIcon />}
         </IconContainer>
         {Boolean(statusIcon) && (
           <IconContainer data-cy="operational-ui__Input-status-icon" iconAmount={1} right={-iconBoxSize}>

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -83,9 +83,9 @@ const Field = styled("input")<{
       ? { borderTopRightRadius: theme.borderRadius, borderBottomRightRadius: theme.borderRadius, marginLeft: -1 }
       : { borderRadius: theme.borderRadius }),
     font: idStyle ? "none" : "inherit",
-    fontFamily: idStyle ? theme.font.family.code : theme.font.family.main,
+    fontFamily: idStyle ? theme.font.family.code : "inherit",
     fontWeight: getFontWeight(),
-    fontSize: theme.font.size.body,
+    fontSize: theme.font.size.small,
     width: "100%",
     height,
     label: "input",
@@ -118,6 +118,14 @@ const ClearButton = styled.div`
   justify-content: center;
 
   cursor: pointer; /* Let the user know this is clickable */
+
+  outline: none;
+  :focus {
+    ${({ theme }) =>
+      inputFocus({
+        theme,
+      })}
+  }
 
   /* We want the user to click on thix _box_, not the icon inside it */
   > svg {
@@ -183,6 +191,7 @@ const InputField: React.FC<InputProps> = ({
       <Container fullWidth={fullWidth} statusIcon={statusIcon}>
         {shouldShowIconButton && renderButton()}
         <Field
+          data-cy="operational-ui__Input"
           ref={inputRef}
           autoFocus={autoFocus}
           name={name}
@@ -211,14 +220,19 @@ const InputField: React.FC<InputProps> = ({
         <IconContainer iconAmount={(clear && value ? 1 : 0) + (idStyle ? 1 : 0)} right={0}>
           {/* Clear button and Id style icon within the input border */}
           {clear && value && (
-            <ClearButton onClick={clear}>
+            <ClearButton
+              data-cy="operational-ui__Input-clear-button"
+              aria-label="Clear Input"
+              tabIndex={0}
+              onClick={clear}
+            >
               <NoIcon />
             </ClearButton>
           )}
           {idStyle && <ServiceAccountIcon />}
         </IconContainer>
         {Boolean(statusIcon) && (
-          <IconContainer iconAmount={1} right={-iconBoxSize}>
+          <IconContainer data-cy="operational-ui__Input-status-icon" iconAmount={1} right={-iconBoxSize}>
             {/* negative `right` to place the status icon on the right side of the input */}
             {statusIcon}
           </IconContainer>

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -27,7 +27,10 @@ const Field = styled("input")<{
   preset: InputProps["preset"]
   disabled: InputProps["disabled"]
   clear: InputProps["clear"]
-}>(({ theme, disabled, isError, withIconButton, preset, clear }) => {
+  idStyle?: boolean
+}>(({ theme, disabled, isError, withIconButton, preset, clear, idStyle }) => {
+  console.log("idStyle", idStyle)
+
   const makeBackgroundColor = () => {
     if (disabled) {
       return theme.color.disabled
@@ -40,22 +43,37 @@ const Field = styled("input")<{
     return theme.color.white
   }
 
+  const getFontWeight = () => {
+    if (idStyle) {
+      return theme.font.weight.bold
+    }
+
+    if (preset) {
+      return theme.font.weight.medium
+    }
+
+    return theme.font.weight.regular
+  }
+
   return {
     ...(withIconButton
       ? { borderTopRightRadius: theme.borderRadius, borderBottomRightRadius: theme.borderRadius, marginLeft: -1 }
       : { borderRadius: theme.borderRadius }),
+    font: idStyle ? undefined : "inherit",
+    fontFamily: idStyle ? theme.font.family.code : theme.font.family.main,
+    fontWeight: getFontWeight(),
     fontSize: theme.font.size.body,
     width: "100%",
     height,
     label: "input",
     flexGrow: 1,
-    padding: `${theme.space.small}px ${theme.space.medium}px`,
+    padding: `${theme.space.small}px ${idStyle ? 2 * theme.space.big : theme.space.medium}px ${theme.space.small}px ${
+      theme.space.medium
+    }px`,
     opacity: disabled ? 0.6 : 1.0,
-    font: "inherit",
     border: "1px solid",
     borderColor: isError ? theme.color.error : theme.color.border.default,
     appearance: "none",
-    fontWeight: preset ? theme.font.weight.medium : theme.font.weight.regular,
     color: preset ? theme.color.text.dark : theme.color.text.default,
     backgroundColor: makeBackgroundColor(),
     "::placeholder": {
@@ -114,6 +132,7 @@ const InputField: React.SFC<InputProps> = ({
   copy,
   onIconClick,
   tabIndex,
+  idStyle,
   errorComponent: ErrorComponent,
   ...props
 }) => {
@@ -154,6 +173,7 @@ const InputField: React.SFC<InputProps> = ({
           withIconButton={shouldShowIconButton}
           autoComplete={autoComplete}
           tabIndex={tabIndex}
+          idStyle={idStyle}
           {...props}
         />
         {clear && value && (

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -67,7 +67,7 @@ const Field = styled("input")<{
     height,
     label: "input",
     flexGrow: 1,
-    padding: `${theme.space.small}px ${idStyle ? 2 * theme.space.big : theme.space.medium}px ${theme.space.small}px ${
+    padding: `${theme.space.small}px ${idStyle ? height : theme.space.medium}px ${theme.space.small}px ${
       theme.space.medium
     }px`,
     opacity: disabled ? 0.6 : 1.0,
@@ -107,6 +107,21 @@ const ClearButton = styled("div")`
   > svg {
     pointer-events: none;
   }
+`
+
+const IdIconContainer = styled.div`
+  position: absolute;
+  top: 0; /* anchor the position to the top so the browser doesn't guess */
+  right: 0; /* not 12px but 0 because we want a _box_ to attach to the end of Input and not just an X pushed in from the right */
+
+  /* We also probably should specify the dimensions of this box */
+  width: ${height}px;
+  height: ${height}px;
+
+  /* Also, let's center the contents of this box */
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `
 
 const InputField: React.SFC<InputProps> = ({
@@ -176,7 +191,12 @@ const InputField: React.SFC<InputProps> = ({
           idStyle={idStyle}
           {...props}
         />
-        {clear && value && (
+        {idStyle && (
+          <IdIconContainer>
+            <NoIcon />
+          </IdIconContainer>
+        )}
+        {!idStyle && clear && value && (
           <ClearButton onClick={clear}>
             <NoIcon />
           </ClearButton>

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -113,17 +113,14 @@ const ClearButton = styled.div`
   }
 `
 
-const IconContainer = styled.div<{
-  clear: InputProps["clear"]
-  value: InputProps["value"]
-  idStyle: InputProps["idStyle"]
-}>`
+const IconContainer = styled.div<{ iconAmount: number; right: number }>`
   position: absolute;
   top: 0; /* anchor the position to the top so the browser doesn't guess */
-  right: 0; /* not 12px but 0 because we want a _box_ to attach to the end of Input and not just an X pushed in from the right */
+  right: ${({ right }) =>
+    right}px; /* not 12px but 0 because we want a _box_ to attach to the end of Input and not just an X pushed in from the right */
 
   /* We also probably should specify the dimensions of this box */
-  width: ${({ clear, value, idStyle }) => (clear && value && idStyle ? 2 * height : height)}px;
+  width: ${({ iconAmount }) => iconAmount * height}px;
   height: ${height}px;
 
   /* Also, let's center the contents of this box */
@@ -132,7 +129,7 @@ const IconContainer = styled.div<{
   justify-content: center;
 `
 
-const InputField: React.SFC<InputProps> = ({
+const InputField: React.FC<InputProps> = ({
   id,
   hint,
   fullWidth,
@@ -157,6 +154,7 @@ const InputField: React.SFC<InputProps> = ({
   tabIndex,
   idStyle,
   errorComponent: ErrorComponent,
+  statusIcon,
   ...props
 }) => {
   const shouldShowIconButton = Boolean(icon) || Boolean(copy)
@@ -199,7 +197,7 @@ const InputField: React.SFC<InputProps> = ({
           idStyle={idStyle}
           {...props}
         />
-        <IconContainer clear={clear} value={value} idStyle={idStyle}>
+        <IconContainer iconAmount={(clear && value ? 1 : 0) + (idStyle ? 1 : 0)} right={0}>
           {clear && value && (
             <ClearButton onClick={clear}>
               <NoIcon />
@@ -207,6 +205,11 @@ const InputField: React.SFC<InputProps> = ({
           )}
           {idStyle && <ServiceAccountIcon />}
         </IconContainer>
+        {Boolean(statusIcon) && (
+          <IconContainer iconAmount={1} right={-height}>
+            {statusIcon}
+          </IconContainer>
+        )}
         {error && !ErrorComponent ? <FormFieldError>{error}</FormFieldError> : null}
       </Container>
       {error && ErrorComponent ? <ErrorComponent errorMessage={error} /> : null}

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -5,7 +5,7 @@ import styled from "../utils/styled"
 import { InputProps } from "./Input"
 import InputButton from "./Input.Button"
 import { height, iconBoxSize, width } from "./Input.constants"
-import { NoIcon, ServiceAccountIcon } from "../Icon/Icon"
+import { NoIcon, IDIcon } from "../Icon/Icon"
 
 const getMaxWidth = (fullWidth: InputProps["fullWidth"], statusIcon: InputProps["statusIcon"]) => {
   if (fullWidth && statusIcon) {
@@ -145,6 +145,10 @@ const IconContainer = styled.div<{ iconAmount: number; right: number }>`
   justify-content: center;
 `
 
+const UniqueIdIcon = styled(IDIcon)`
+  color: ${({ theme }) => theme.color.text.lightest};
+`
+
 const InputField: React.FC<InputProps> = ({
   id,
   hint,
@@ -226,7 +230,7 @@ const InputField: React.FC<InputProps> = ({
               <NoIcon />
             </ClearButton>
           )}
-          {isUniqueId && <ServiceAccountIcon />}
+          {isUniqueId && <UniqueIdIcon />}
         </IconContainer>
         {Boolean(statusIcon) && (
           <IconContainer data-cy="operational-ui__Input-status-icon" iconAmount={1} right={-iconBoxSize}>

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -4,11 +4,8 @@ import { FormFieldError, inputFocus, setAlpha } from "../utils"
 import styled from "../utils/styled"
 import { InputProps } from "./Input"
 import InputButton from "./Input.Button"
-import { height } from "./Input.constants"
+import { height, iconBoxSize, width } from "./Input.constants"
 import { NoIcon, ServiceAccountIcon } from "../Icon/Icon"
-
-const width = 360
-const iconBoxSize = height // Fit icons into the square with the side of the input height
 
 const getMaxWidth = (fullWidth: InputProps["fullWidth"], statusIcon: InputProps["statusIcon"]) => {
   if (fullWidth && statusIcon) {

--- a/src/Input/Input.constants.ts
+++ b/src/Input/Input.constants.ts
@@ -1,2 +1,5 @@
 // Rendered height taking into account paddings, font-sizes and line-height
 export const height = 36
+
+export const width = 360
+export const iconBoxSize = height // Fit icons into the square with the side of the input height

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -53,6 +53,8 @@ export interface BaseProps extends DefaultProps, DefaultInputProps, Omit<React.I
   errorComponent?: React.FC<{ errorMessage: string }>
   /** Is the input read-only? */
   readOnly?: boolean
+  /** Should this input has Id input style */
+  idStyle?: boolean
 }
 
 export interface BasePropsWithCopy extends BaseProps {
@@ -81,6 +83,7 @@ const Input: React.SFC<InputProps> = ({
   onToggle,
   disabled,
   errorComponent,
+  idStyle,
   ...props
 }) => {
   const uniqueId = useUniqueId(id)
@@ -97,6 +100,7 @@ const Input: React.SFC<InputProps> = ({
       aria-describedby={hint ? `input-hint-${uniqueId}` : undefined}
       aria-label={label}
       errorComponent={errorComponent}
+      idStyle={idStyle}
       {...props}
     />
   )

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -54,7 +54,7 @@ export interface BaseProps extends DefaultProps, DefaultInputProps, Omit<React.I
   /** Is the input read-only? */
   readOnly?: boolean
   /** Should this input get Id input style */
-  idStyle?: boolean
+  isUniqueId?: boolean
   /** Status icon on the right side of the Input */
   statusIcon?: React.ReactNode
 }
@@ -85,7 +85,7 @@ const Input: React.FC<InputProps> = ({
   onToggle,
   disabled,
   errorComponent,
-  idStyle,
+  isUniqueId,
   statusIcon,
   ...props
 }) => {
@@ -103,7 +103,7 @@ const Input: React.FC<InputProps> = ({
       aria-describedby={hint ? `input-hint-${uniqueId}` : undefined}
       aria-label={label}
       errorComponent={errorComponent}
-      idStyle={idStyle}
+      isUniqueId={isUniqueId}
       statusIcon={statusIcon}
       {...props}
     />

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -53,7 +53,7 @@ export interface BaseProps extends DefaultProps, DefaultInputProps, Omit<React.I
   errorComponent?: React.FC<{ errorMessage: string }>
   /** Is the input read-only? */
   readOnly?: boolean
-  /** Should this input has Id input style */
+  /** Should this input get Id input style */
   idStyle?: boolean
   /** Status icon on the right side of the Input */
   statusIcon?: React.FC

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -56,7 +56,7 @@ export interface BaseProps extends DefaultProps, DefaultInputProps, Omit<React.I
   /** Should this input get Id input style */
   idStyle?: boolean
   /** Status icon on the right side of the Input */
-  statusIcon?: React.FC
+  statusIcon?: React.ReactNode
 }
 
 export interface BasePropsWithCopy extends BaseProps {

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -55,6 +55,8 @@ export interface BaseProps extends DefaultProps, DefaultInputProps, Omit<React.I
   readOnly?: boolean
   /** Should this input has Id input style */
   idStyle?: boolean
+  /** Status icon on the right side of the Input */
+  statusIcon?: React.FC
 }
 
 export interface BasePropsWithCopy extends BaseProps {
@@ -73,7 +75,7 @@ export interface BasePropsWithoutCopy extends BaseProps {
 
 export type InputProps = BasePropsWithCopy | BasePropsWithoutCopy
 
-const Input: React.SFC<InputProps> = ({
+const Input: React.FC<InputProps> = ({
   id,
   tabIndex,
   fullWidth,
@@ -84,6 +86,7 @@ const Input: React.SFC<InputProps> = ({
   disabled,
   errorComponent,
   idStyle,
+  statusIcon,
   ...props
 }) => {
   const uniqueId = useUniqueId(id)
@@ -101,6 +104,7 @@ const Input: React.SFC<InputProps> = ({
       aria-label={label}
       errorComponent={errorComponent}
       idStyle={idStyle}
+      statusIcon={statusIcon}
       {...props}
     />
   )

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -9,7 +9,15 @@ const [value, setValue] = React.useState("MyTable_01")
 ;<Form>
   <Input idStyle label="Enter Table name" value={value} onChange={setValue} />
   <Input idStyle clear={() => setValue("")} label="Also clearable" value={value} onChange={setValue} />
-  <Input idStyle label="Enter Table name" value={value} onChange={setValue} statusIcon={<SyncIcon color="pri />} />
+  <Input idStyle label="Enter Table name" value={value} onChange={setValue} statusIcon={<SyncIcon color="primary" />} />
+  <Input
+    idStyle
+    fullWidth
+    label="Can be full width too"
+    value={value}
+    onChange={setValue}
+    statusIcon={<SyncIcon color="primary" />}
+  />
 </Form>
 ```
 

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -1,26 +1,3 @@
-### Id style
-
-```jsx
-import * as React from "react"
-import { Input, Form, SyncIcon, UnlockIcon } from "@operational/components"
-
-const [value, setValue] = React.useState("MyTable_01")
-
-;<Form>
-  <Input idStyle label="Enter Table name" value={value} onChange={setValue} />
-  <Input idStyle clear={() => setValue("")} label="Also clearable" value={value} onChange={setValue} />
-  <Input idStyle label="Enter Table name" value={value} onChange={setValue} statusIcon={<SyncIcon color="primary" />} />
-  <Input
-    idStyle
-    fullWidth
-    label="Can be full width too"
-    value={value}
-    onChange={setValue}
-    statusIcon={<SyncIcon color="primary" />}
-  />
-</Form>
-```
-
 ### Usage
 
 ```jsx
@@ -200,4 +177,47 @@ import { Input } from "@operational/components"
 import * as React from "react"
 import { Input } from "@operational/components"
 ;<Input fullWidth value="Dave the Sheep" label="Hi, My Name is" />
+```
+
+### Id style
+
+```jsx
+import * as React from "react"
+import { Input, Form } from "@operational/components"
+
+const [value, setValue] = React.useState("MyTable_01")
+
+;<Form>
+  <Input idStyle label="Enter Table name" value={value} onChange={setValue} />
+  <Input idStyle label="Also clearable" value={value} onChange={setValue} clear={() => setValue("")} />
+</Form>
+```
+
+### Custom status icon
+
+```jsx
+import * as React from "react"
+import { Input, Form, SyncIcon, TimeIcon, SchemaIcon, WarningIcon } from "@operational/components"
+
+const [value, setValue] = React.useState("MyTable_01")
+
+;<Form>
+  <Input label="With a status icon" value={value} onChange={setValue} statusIcon={<SyncIcon color="primary" />} />
+  <Input idStyle label="Status icon with Id style" value={value} onChange={setValue} statusIcon={<SchemaIcon />} />
+  <Input
+    idStyle
+    label="Enter Table name, can also be cleared"
+    value={value}
+    onChange={setValue}
+    clear={() => setValue("")}
+    statusIcon={<TimeIcon color="primary" />}
+  />
+  <Input
+    fullWidth
+    label="Can be full width too"
+    value={value}
+    onChange={setValue}
+    statusIcon={<WarningIcon color="error" />}
+  />
+</Form>
 ```

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -1,3 +1,14 @@
+### ID style
+
+```jsx
+import * as React from "react"
+import { Input } from "@operational/components"
+
+const [value, setValue] = React.useState("MyTable_01")
+
+;<Input idStyle label="Name" value={value} onChange={setValue} />
+```
+
 ### Usage
 
 ```jsx

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -179,7 +179,7 @@ import { Input } from "@operational/components"
 ;<Input fullWidth value="Dave the Sheep" label="Hi, My Name is" />
 ```
 
-### Id style
+### Can server as a unique Id input
 
 ```jsx
 import * as React from "react"
@@ -188,10 +188,10 @@ import { Input, Form } from "@operational/components"
 const [value, setValue] = React.useState("MyTable_01")
 
 ;<Form>
-  <Input idStyle label="Enter Table name" value={value} onChange={setValue} />
+  <Input isUniqueId label="Enter Table name" value={value} onChange={setValue} />
   <Input
     data-cy="clearable-input-with-id-style"
-    idStyle
+    isUniqueId
     label="Also clearable"
     value={value}
     onChange={setValue}
@@ -200,7 +200,7 @@ const [value, setValue] = React.useState("MyTable_01")
 </Form>
 ```
 
-### Custom status icon
+### Can have a custom status icon
 
 ```jsx
 import * as React from "react"
@@ -210,9 +210,9 @@ const [value, setValue] = React.useState("MyTable_01")
 
 ;<Form>
   <Input label="With a status icon" value={value} onChange={setValue} statusIcon={<SyncIcon color="primary" />} />
-  <Input idStyle label="Status icon with Id style" value={value} onChange={setValue} statusIcon={<SchemaIcon />} />
+  <Input isUniqueId label="Status icon with Id style" value={value} onChange={setValue} statusIcon={<SchemaIcon />} />
   <Input
-    idStyle
+    isUniqueId
     label="Enter Table name, can also be cleared"
     value={value}
     onChange={setValue}

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -1,12 +1,15 @@
-### ID style
+### Id style
 
 ```jsx
 import * as React from "react"
-import { Input } from "@operational/components"
+import { Input, Form } from "@operational/components"
 
 const [value, setValue] = React.useState("MyTable_01")
 
-;<Input idStyle label="Name" value={value} onChange={setValue} />
+;<Form>
+  <Input idStyle label="Name" value={value} onChange={setValue} />
+  <Input idStyle clear={() => setValue("")} label="Name" value={value} onChange={setValue} />
+</Form>
 ```
 
 ### Usage

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -189,7 +189,14 @@ const [value, setValue] = React.useState("MyTable_01")
 
 ;<Form>
   <Input idStyle label="Enter Table name" value={value} onChange={setValue} />
-  <Input idStyle label="Also clearable" value={value} onChange={setValue} clear={() => setValue("")} />
+  <Input
+    data-cy="clearable-input-with-id-style"
+    idStyle
+    label="Also clearable"
+    value={value}
+    onChange={setValue}
+    clear={() => setValue("")}
+  />
 </Form>
 ```
 

--- a/src/Input/README.md
+++ b/src/Input/README.md
@@ -2,13 +2,14 @@
 
 ```jsx
 import * as React from "react"
-import { Input, Form } from "@operational/components"
+import { Input, Form, SyncIcon, UnlockIcon } from "@operational/components"
 
 const [value, setValue] = React.useState("MyTable_01")
 
 ;<Form>
-  <Input idStyle label="Name" value={value} onChange={setValue} />
-  <Input idStyle clear={() => setValue("")} label="Name" value={value} onChange={setValue} />
+  <Input idStyle label="Enter Table name" value={value} onChange={setValue} />
+  <Input idStyle clear={() => setValue("")} label="Also clearable" value={value} onChange={setValue} />
+  <Input idStyle label="Enter Table name" value={value} onChange={setValue} statusIcon={<SyncIcon color="pri />} />
 </Form>
 ```
 


### PR DESCRIPTION
# ToDo:
- [x] Add tests
- [x] Swap the id Icon to use the new one 

# Summary
1. Adds Id input style with an icon
1. Ensures that the icon still works with the clear callback and the button layout
1. Adds the possibility to display user-defined status icon 
1. Ensures the status icon still with fullWidth option

<img width="1093" alt="Screenshot 2019-06-19 at 13 45 48" src="https://user-images.githubusercontent.com/639406/59763241-790c1f80-9299-11e9-85e4-94fe1fea6eb6.png">


# Related issue
https://contiamo.atlassian.net/browse/UI-43

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
- [ ] No regressions can be found

Tester 2
- [ ] Things look good on the demo.
- [ ] No regressions can be found
