### PR TITLE
**Feature:** UI-78  sidebar tabs 1

### DIFF
--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -92,7 +92,7 @@ const MyComponent = () => {
   return (
     <Sidebar>
       <Tabs
-        noScroll
+        scroll={false}
         tabs={[{ title: "OLAP", icon: <OlapIcon /> }, { title: "Inventory" }]}
         active={activeTab}
         onActivate={setActiveTab}

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -59,23 +59,14 @@ const MyComponent = () => {
 
   return (
     <div style={{ height: "200px" }}>
-      <Tabs
-        tabs={tabs}
-        active={active}
-        onActivate={setActive}
-        onClose={onClose}
-        onInsert={onInsert}
-        style={{ height: "100%", width: "100%" }}
-      >
-        <div style={{ padding: 20 }}>
-          <p>Lorem ipsum {active + 1}</p>
-          <p>Lorem ipsum {active + 1}</p>
-          <p>Lorem ipsum {active + 1}</p>
-          <p>Lorem ipsum {active + 1}</p>
-          <p>Lorem ipsum {active + 1}</p>
-          <p>Lorem ipsum {active + 1}</p>
-          <p>Lorem ipsum {active + 1}</p>
-        </div>
+      <Tabs tabs={tabs} active={active} onActivate={setActive} onClose={onClose} onInsert={onInsert}>
+        <p>Lorem ipsum {active + 1}</p>
+        <p>Lorem ipsum {active + 1}</p>
+        <p>Lorem ipsum {active + 1}</p>
+        <p>Lorem ipsum {active + 1}</p>
+        <p>Lorem ipsum {active + 1}</p>
+        <p>Lorem ipsum {active + 1}</p>
+        <p>Lorem ipsum {active + 1}</p>
       </Tabs>
     </div>
   )

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -48,7 +48,7 @@ const MyComponent = () => {
             <div>
               <p>Lorem ipsum {tabs.length + 1}</p>
             </div>
-          )
+          ),
         },
       ]
       setTabs(newTabs)
@@ -78,6 +78,37 @@ const MyComponent = () => {
         </div>
       </Tabs>
     </div>
+  )
+}
+
+;<MyComponent />
+```
+
+### Usage in a Sidebar
+
+```jsx
+import * as React from "react"
+import { styled, Tabs, OlapIcon } from "@operational/components"
+
+const Sidebar = styled.div`
+  width: 240px;
+  height: 400px;
+`
+
+const MyComponent = () => {
+  const [activeTab, setActiveTab] = React.useState(0)
+
+  return (
+    <Sidebar>
+      <Tabs
+        noScroll
+        tabs={[{ title: "OLAP", icon: <OlapIcon /> }, { title: "Inventory" }]}
+        active={activeTab}
+        onActivate={setActiveTab}
+      >
+        <>Tab {activeTab}</>
+      </Tabs>
+    </Sidebar>
   )
 }
 

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -1,0 +1,141 @@
+import styled from "../utils/styled"
+import { SectionHeader } from "../Internals/SectionHeader"
+
+const buttonWidth = 55
+
+export const Container = styled.div`
+  label: Tabs;
+  display: grid;
+  grid-template-rows: ${({ theme }) => `${theme.space.element * 2}px 1fr`};
+  position: relative;
+  height: 100%;
+`
+
+export const TabList = styled.div<{ noScroll: boolean }>`
+  display: flex;
+  height: ${({ theme }) => theme.space.element * 2}px;
+  overflow-x: auto;
+  max-width: ${({ noScroll }) => (noScroll ? "none" : `calc(100% - ${buttonWidth * 2}px)`)};
+  scroll-behavior: smooth;
+  border-left: solid 1px ${({ theme }) => theme.color.separators.default};
+  overflow-y: hidden;
+  /* magic number to hide scroll bar underneath tabpanel */
+  height: ${({ theme }) => theme.space.element * 2 + 20}px;
+  -webkit-overflow-scrolling: auto;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  z-index: 1;
+`
+
+TabList.defaultProps = {
+  role: "tablist",
+}
+
+export const TabScroll = styled.div`
+  display: flex;
+  width: 100%;
+`
+
+export const TabHeader = styled(SectionHeader, {
+  shouldForwardProp: prop => !(prop === "first" || prop === "aria-selected" || prop === "condensed" || prop === "as"),
+})<{
+  first: boolean
+  "aria-selected": boolean
+  condensed?: boolean
+  as?: React.FC<any> | string
+  center?: boolean
+}>`
+  justify-content: ${({ center }) => (center ? "center" : "space-between")};
+  cursor: pointer;
+  font-weight: normal;
+  background-color: ${({ theme }) => theme.color.background.light};
+  border: solid 1px ${({ theme }) => theme.color.separators.default};
+  border-left: none;
+  ${props =>
+    props["aria-selected"]
+      ? `border-bottom: 1px solid ${props.theme.color.background.lighter}; 
+         background-color: ${props.theme.color.background.lighter};
+         color: ${props.theme.color.primary};
+         font-weight: bold;`
+      : ""}
+
+  ${({ condensed }) =>
+    condensed ? `max-width: ${buttonWidth}px; min-width: ${buttonWidth}px;` : "max-width: 180px;"}
+  flex-grow: 1;
+  & svg {
+    ${({ condensed }) => (condensed ? "pointer-events: none;" : "")}
+    cursor: pointer;
+  }
+  :focus {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadows.insetFocus};
+  }
+  ::-moz-focus-inner {
+    border: none;
+  }
+  :disabled {
+    color: ${({ theme }) => theme.color.disabled};
+    cursor: not-allowed;
+  }
+  margin: 0;
+`
+
+TabHeader.defaultProps = {
+  role: "tab",
+  as: "button",
+}
+
+export const TabContainer = styled.div`
+  border: solid 1px ${({ theme }) => theme.color.separators.default};
+  margin-top: -1px;
+  overflow: hidden;
+  background-color: ${({ theme }) => theme.color.background.lighter};
+`
+
+export const TabPanel = styled.div`
+  z-index: 2;
+  :focus {
+    outline: none;
+    ${({ theme }) => `box-shadow: ${theme.shadows.insetFocus};`}
+  }
+  ::-moz-focus-inner {
+    border: none;
+  }
+  height: 100%;
+  overflow: auto;
+`
+
+TabPanel.defaultProps = {
+  role: "tabpanel",
+  tabIndex: 0,
+}
+
+// We need this one so that icon and title both would be aligned to the left
+export const TitleIconWrapper = styled.div`
+  display: flex;
+  max-width: 120px;
+  justify-content: center;
+  align-items: center;
+`
+
+// we need this one to show ellipsis if title is to long
+export const TitleWrapper = styled.span`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`
+
+export const TabIcon = styled.span`
+  margin-right: ${({ theme }) => theme.space.small}px;
+`
+
+export const ScrollButtons = styled.div`
+  position: absolute;
+  right: 1px;
+  width: ${buttonWidth * 2}px;
+  display: flex;
+  border-left: solid 1px ${({ theme }) => theme.color.separators.default};
+  border-right: solid 1px ${({ theme }) => theme.color.separators.default};
+  z-index: 1;
+`

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -11,11 +11,11 @@ export const Container = styled.div`
   height: 100%;
 `
 
-export const TabList = styled.div<{ noScroll: boolean }>`
+export const TabList = styled.div<{ scroll: boolean }>`
   display: flex;
   height: ${({ theme }) => theme.space.element * 2}px;
   overflow-x: auto;
-  max-width: ${({ noScroll }) => (noScroll ? "none" : `calc(100% - ${buttonWidth * 2}px)`)};
+  max-width: ${({ scroll }) => (scroll ? `calc(100% - ${buttonWidth * 2}px)` : "none")};
   scroll-behavior: smooth;
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
   overflow-y: hidden;
@@ -138,8 +138,4 @@ export const ScrollButtons = styled.div`
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
   border-right: solid 1px ${({ theme }) => theme.color.separators.default};
   z-index: 1;
-`
-
-export const TabContent = styled.div`
-  padding: ${({ theme }) => theme.space.content}px;
 `

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -139,3 +139,7 @@ export const ScrollButtons = styled.div`
   border-right: solid 1px ${({ theme }) => theme.color.separators.default};
   z-index: 1;
 `
+
+export const TabContent = styled.div`
+  padding: ${({ theme }) => theme.space.content}px;
+`

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -97,7 +97,6 @@ export const TabPanel = styled.div`
   z-index: 2;
   :focus {
     outline: none;
-    ${({ theme }) => `box-shadow: ${theme.shadows.insetFocus};`}
   }
   ::-moz-focus-inner {
     border: none;

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -38,7 +38,8 @@ export const TabScroll = styled.div`
 `
 
 export const TabHeader = styled(SectionHeader, {
-  shouldForwardProp: prop => !(prop === "first" || prop === "aria-selected" || prop === "condensed" || prop === "as"),
+  shouldForwardProp: prop =>
+    !(prop === "first" || prop === "center" || prop === "aria-selected" || prop === "condensed" || prop === "as"),
 })<{
   first: boolean
   "aria-selected": boolean

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -56,7 +56,7 @@ export const TabHeader = styled(SectionHeader, {
     props["aria-selected"]
       ? `border-bottom: 1px solid ${props.theme.color.background.lighter}; 
          background-color: ${props.theme.color.background.lighter};
-         color: ${props.theme.color.primary};
+         color: ${props.theme.color.text.dark};
          font-weight: bold;`
       : ""}
 

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -14,6 +14,7 @@ import {
   TabScroll,
   TitleIconWrapper,
   TitleWrapper,
+  TabContent,
 } from "./Tabs.styled"
 
 export interface Tab {
@@ -216,7 +217,7 @@ const Tabs: React.FC<TabsProps> = ({
       <TabContainer>
         {tabs.map((_, i) => (
           <TabPanel hidden={i !== active} id={`TabPanel-${uid}-${i}`} aria-labelledby={`TabHeader-${uid}-${i}`} key={i}>
-            {i === active && children}
+            <TabContent>{i === active && children}</TabContent>
           </TabPanel>
         ))}
       </TabContainer>

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -14,7 +14,6 @@ import {
   TabScroll,
   TitleIconWrapper,
   TitleWrapper,
-  TabContent,
 } from "./Tabs.styled"
 
 export interface Tab {
@@ -26,7 +25,7 @@ export interface TabsProps extends DefaultProps {
   tabs: Tab[]
   active: number
   onActivate: (tabIndex: number) => void
-  noScroll?: boolean
+  scroll?: boolean
   onClose?: (tabIndex: number) => void
   onInsert?: (tabIndex: number) => void
   label?: string
@@ -36,7 +35,7 @@ export interface TabsProps extends DefaultProps {
 
 const Tabs: React.FC<TabsProps> = ({
   tabs,
-  noScroll,
+  scroll,
   active,
   onClose,
   onActivate,
@@ -133,7 +132,7 @@ const Tabs: React.FC<TabsProps> = ({
 
   return (
     <Container data-cy="operational-ui__Tabs" style={style}>
-      <TabList noScroll={Boolean(noScroll)} aria-label={label} onKeyDown={onKeyDown} ref={tabListRef}>
+      <TabList scroll={Boolean(scroll)} aria-label={label} onKeyDown={onKeyDown} ref={tabListRef}>
         <TabScroll ref={tabScrollRef}>
           {tabs.map(({ title, icon }, i) => {
             const onClick = () => {
@@ -142,7 +141,7 @@ const Tabs: React.FC<TabsProps> = ({
             }
             return (
               <TabHeader
-                center={Boolean(noScroll)}
+                center={!scroll}
                 tabIndex={i === active ? 0 : -1}
                 first={i === 0}
                 aria-selected={i === active}
@@ -188,7 +187,7 @@ const Tabs: React.FC<TabsProps> = ({
           )}
         </TabScroll>
       </TabList>
-      {noScroll !== true && (
+      {scroll && (
         <ScrollButtons>
           <TabHeader
             aria-hidden={true}
@@ -217,12 +216,16 @@ const Tabs: React.FC<TabsProps> = ({
       <TabContainer>
         {tabs.map((_, i) => (
           <TabPanel hidden={i !== active} id={`TabPanel-${uid}-${i}`} aria-labelledby={`TabHeader-${uid}-${i}`} key={i}>
-            <TabContent>{i === active && children}</TabContent>
+            {i === active && children}
           </TabPanel>
         ))}
       </TabContainer>
     </Container>
   )
+}
+
+Tabs.defaultProps = {
+  scroll: true,
 }
 
 export default Tabs

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -1,12 +1,20 @@
 import * as React from "react"
-import { SectionHeader } from "../Internals/SectionHeader"
 import { DefaultProps } from "../types"
-import styled from "../utils/styled"
 import { useUniqueId } from "../useUniqueId"
 import { NoIcon, PlusIcon, ChevronLeftIcon, ChevronRightIcon } from "../Icon/Icon"
 import { ScrollButton } from "./ScrollButton"
-
-const buttonWidth = 55
+import {
+  Container,
+  ScrollButtons,
+  TabContainer,
+  TabHeader,
+  TabIcon,
+  TabList,
+  TabPanel,
+  TabScroll,
+  TitleIconWrapper,
+  TitleWrapper,
+} from "./Tabs.styled"
 
 export interface Tab {
   title: string
@@ -17,6 +25,7 @@ export interface TabsProps extends DefaultProps {
   tabs: Tab[]
   active: number
   onActivate: (tabIndex: number) => void
+  noScroll?: boolean
   onClose?: (tabIndex: number) => void
   onInsert?: (tabIndex: number) => void
   label?: string
@@ -24,139 +33,18 @@ export interface TabsProps extends DefaultProps {
   id?: string
 }
 
-const Container = styled.div`
-  label: Tabs;
-  display: grid;
-  grid-template-rows: ${({ theme }) => `${theme.space.element * 2}px 1fr`};
-  position: relative;
-`
-
-const TabList = styled.div`
-  display: flex;
-  height: ${({ theme }) => theme.space.element * 2}px;
-  overflow-x: auto;
-  max-width: calc(100% - ${buttonWidth * 2}px);
-  scroll-behavior: smooth;
-  border-left: solid 1px ${({ theme }) => theme.color.separators.default};
-  overflow-y: hidden;
-  /* magic number to hide scroll bar underneath tabpanel */
-  height: ${({ theme }) => theme.space.element * 2 + 20}px;
-  -webkit-overflow-scrolling: auto;
-  ::-webkit-scrollbar {
-    display: none;
-  }
-  z-index: 1;
-`
-
-TabList.defaultProps = {
-  role: "tablist",
-}
-
-const TabScroll = styled.div`
-  display: flex;
-`
-
-const TabHeader = styled(SectionHeader, {
-  shouldForwardProp: prop => !(prop === "first" || prop === "aria-selected" || prop === "condensed" || prop === "as" ),
-})<{
-  first: boolean
-  "aria-selected": boolean
-  condensed?: boolean
-  as?: React.FC<any> | string
-}>`
-  cursor: pointer;
-  font-weight: normal;
-  background-color: ${({ theme }) => theme.color.background.light};
-  border: solid 1px ${({ theme }) => theme.color.separators.default};
-  border-left: none;
-  ${props =>
-    props["aria-selected"]
-      ? `border-bottom: 1px solid ${props.theme.color.background.lighter}; 
-         background-color: ${props.theme.color.background.lighter};
-         color: ${props.theme.color.primary};
-         font-weight: bold;`
-      : ""}
-
-  ${({ condensed }) =>
-    condensed ? `max-width: ${buttonWidth}px; min-width: ${buttonWidth}px;` : "max-width: 180px;"}
-  flex-grow: 1;
-  & svg {
-    ${({ condensed }) => (condensed ? "pointer-events: none;" : "")}
-    cursor: pointer;
-  }
-  :focus {
-    outline: none;
-    box-shadow: ${({ theme }) => theme.shadows.insetFocus};
-  }
-  ::-moz-focus-inner {
-    border: none;
-  }
-  :disabled {
-    color: ${({ theme }) => theme.color.disabled};
-    cursor: not-allowed;
-  }
-  margin: 0;
-`
-
-TabHeader.defaultProps = {
-  role: "tab",
-  as: "button",
-}
-
-const TabContainer = styled.div`
-  border: solid 1px ${({ theme }) => theme.color.separators.default};
-  margin-top: -1px;
-  overflow: hidden;
-  background-color: ${({ theme }) => theme.color.background.lighter};
-`
-
-const TabPanel = styled.div`
-  z-index: 2;
-  :focus {
-    outline: none;
-    ${({ theme }) => `box-shadow: ${theme.shadows.insetFocus};`}
-  }
-  ::-moz-focus-inner {
-    border: none;
-  }
-  height: 100%;
-  overflow: auto;
-`
-
-TabPanel.defaultProps = {
-  role: "tabpanel",
-  tabIndex: 0,
-}
-
-// We need this one so that icon and title both would be aligned to the left
-const TitleIconWrapper = styled.div`
-  display: flex;
-  max-width: 120px;
-`
-
-// we need this one to show ellipsis if title is to long
-const TitleWrapper = styled.span`
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  margin-right: ${({ theme }) => theme.space.small}px;
-`
-
-const TabIcon = styled.span`
-  margin-right: ${({ theme }) => theme.space.small}px;
-`
-
-const ScrollButtons = styled.div`
-  position: absolute;
-  right: 1px;
-  width: ${buttonWidth * 2}px;
-  display: flex;
-  border-left: solid 1px ${({ theme }) => theme.color.separators.default};
-  border-right: solid 1px ${({ theme }) => theme.color.separators.default};
-  z-index: 1;
-`
-
-const Tabs: React.FC<TabsProps> = ({ tabs, active, onClose, onActivate, onInsert, label, style, id, children }) => {
+const Tabs: React.FC<TabsProps> = ({
+  tabs,
+  noScroll,
+  active,
+  onClose,
+  onActivate,
+  onInsert,
+  label,
+  style,
+  id,
+  children,
+}) => {
   if (!Number.isInteger(active) || active < 0 || active >= tabs.length) {
     active = active > 0 ? tabs.length - 1 : 0
     if (process.env.NODE_ENV !== "production")
@@ -244,7 +132,7 @@ const Tabs: React.FC<TabsProps> = ({ tabs, active, onClose, onActivate, onInsert
 
   return (
     <Container data-cy="operational-ui__Tabs" style={style}>
-      <TabList aria-label={label} onKeyDown={onKeyDown} ref={tabListRef}>
+      <TabList noScroll={Boolean(noScroll)} aria-label={label} onKeyDown={onKeyDown} ref={tabListRef}>
         <TabScroll ref={tabScrollRef}>
           {tabs.map(({ title, icon }, i) => {
             const onClick = () => {
@@ -253,6 +141,7 @@ const Tabs: React.FC<TabsProps> = ({ tabs, active, onClose, onActivate, onInsert
             }
             return (
               <TabHeader
+                center={Boolean(noScroll)}
                 tabIndex={i === active ? 0 : -1}
                 first={i === 0}
                 aria-selected={i === active}
@@ -269,6 +158,7 @@ const Tabs: React.FC<TabsProps> = ({ tabs, active, onClose, onActivate, onInsert
                 </TitleIconWrapper>
                 {onClose && (
                   <NoIcon
+                    right
                     size={9}
                     onMouseDown={e => {
                       e.stopPropagation()
@@ -297,30 +187,32 @@ const Tabs: React.FC<TabsProps> = ({ tabs, active, onClose, onActivate, onInsert
           )}
         </TabScroll>
       </TabList>
-      <ScrollButtons>
-        <TabHeader
-          aria-hidden={true}
-          as={ScrollButton}
-          tabIndex={-1}
-          first={true}
-          aria-selected={false}
-          condensed={true}
-          onClick={scrollLeft}
-        >
-          <ChevronLeftIcon size={14} />
-        </TabHeader>
-        <TabHeader
-          aria-hidden={true}
-          as={ScrollButton}
-          tabIndex={-1}
-          first={false}
-          aria-selected={false}
-          condensed={true}
-          onClick={scrollRight}
-        >
-          <ChevronRightIcon size={14} />
-        </TabHeader>
-      </ScrollButtons>
+      {noScroll !== true && (
+        <ScrollButtons>
+          <TabHeader
+            aria-hidden={true}
+            as={ScrollButton}
+            tabIndex={-1}
+            first={true}
+            aria-selected={false}
+            condensed={true}
+            onClick={scrollLeft}
+          >
+            <ChevronLeftIcon size={14} />
+          </TabHeader>
+          <TabHeader
+            aria-hidden={true}
+            as={ScrollButton}
+            tabIndex={-1}
+            first={false}
+            aria-selected={false}
+            condensed={true}
+            onClick={scrollRight}
+          >
+            <ChevronRightIcon size={14} />
+          </TabHeader>
+        </ScrollButtons>
+      )}
       <TabContainer>
         {tabs.map((_, i) => (
           <TabPanel hidden={i !== active} id={`TabPanel-${uid}-${i}`} aria-labelledby={`TabHeader-${uid}-${i}`} key={i}>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

This feature adds functionality to use Tabs without a scrollbar in case we want to use it in a sidebar or something. 😋

Update version of https://github.com/contiamo/operational-ui/pull/1049
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
