### PR TITLE
**Breaking:** Update basic components for new design

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -104,8 +104,7 @@ export interface State {
 
 const Container = styled("div")(({ theme }) => ({
   marginBottom: theme.space.element,
-  borderTop: `1px solid ${theme.color.separators.light}`,
-  boxShadow: theme.shadows.card,
+  border: `1px solid ${theme.color.separators.light}`,
   backgroundColor: theme.color.white,
   wordWrap: "break-word",
   "& > img": {

--- a/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Card Should render 1`] = `
     class="css-p29iif"
   />
   <div
-    class="css-s8e5me"
+    class="css-1ebnovx"
   >
     <div
       class="css-dj0vfm"

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -44,11 +44,11 @@ exports[`DatePicker Component Should render 1`] = `
             fill="currentColor"
             height="12"
             style="margin-left:0;margin-right:0;cursor:default;transition:fill .075s ease"
-            viewBox="0 0 6.71 12.41"
+            viewBox="0 0 6.83 16.41"
             width="12"
           >
             <path
-              d="M6.21 12.41a.54.54 0 0 1-.36-.14L.15 6.56a.5.5 0 0 1 0-.71l5.7-5.7a.5.5 0 0 1 .71 0 .5.5 0 0 1 0 .7L1.21 6.21l5.35 5.35a.51.51 0 0 1 0 .71.54.54 0 0 1-.35.14z"
+              d="M6.33 16.41a.51.51 0 0 1-.4-.2L0 8.21 5.93.2a.5.5 0 1 1 .8.6L1.24 8.21l5.49 7.4a.5.5 0 0 1-.4.8z"
             />
           </svg>
         </div>
@@ -62,11 +62,11 @@ exports[`DatePicker Component Should render 1`] = `
             fill="currentColor"
             height="12"
             style="margin-left:0;margin-right:0;cursor:default;transition:fill .075s ease"
-            viewBox="0 0 6.71 12.41"
+            viewBox="0 0 6.83 16.41"
             width="12"
           >
             <path
-              d="M.5 12.41a.5.5 0 0 1-.35-.85L5.5 6.21.15.85a.48.48 0 0 1 0-.7.48.48 0 0 1 .7 0l5.71 5.7a.51.51 0 0 1 0 .71L.85 12.27a.5.5 0 0 1-.35.14z"
+              d="M.5 16.41a.5.5 0 0 1-.4-.8l5.48-7.4L.1.8A.5.5 0 0 1 .2.1a.5.5 0 0 1 .7.1l5.93 8-5.93 8a.51.51 0 0 1-.4.21z"
             />
           </svg>
         </div>

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -40,7 +40,6 @@ const TabsBar = styled("div")(({ theme }) => ({
   alignItems: "flex-end",
   height: theme.tabsBarHeight,
   position: "relative",
-  margin: `0 ${theme.space.element}px`,
   // This draws the line underneath the tabs
   "&::before": {
     content: "''",

--- a/src/Layout/Layout.tsx
+++ b/src/Layout/Layout.tsx
@@ -47,10 +47,12 @@ const Main = styled("div")<{ hasHeader: boolean }>(({ theme, hasHeader }) => ({
   gridColumn: "2",
   height: hasHeader ? `calc(100% - ${theme.titleHeight}px)` : "100%", // FORCE a height that is the page - the logo so that children with 100% have context
   backgroundColor: theme.color.white,
+  padding: "50px 35px 35px",
 }))
 
 const Side = styled(Main)({
   gridColumn: "1",
+  padding: 0,
 })
 
 const Header = styled("div")({

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -86,7 +86,6 @@ const Container = styled("div")<{ hasTitle: boolean; hasTabs: boolean }>(({ them
 const TitleContainer = styled("div")<{ fill: boolean }>(({ theme, fill }) => ({
   display: "flex",
   alignItems: "center",
-  padding: theme.space.element,
   height: theme.titleHeight,
   fontWeight: theme.font.weight.medium,
   minWidth: theme.pageSize.min,
@@ -113,7 +112,6 @@ const FixedProgress = styled(Progress)`
 `
 
 const TabsContainer = styled.div<{ fill: boolean }>`
-  padding: 0 ${({ theme }) => theme.space.element}px;
   min-width: ${({ theme }) => theme.pageSize.min};
   max-width: ${({ theme, fill }) => (fill ? "100%" : `${theme.pageSize.max}px`)};
 `
@@ -121,7 +119,7 @@ const TabsContainer = styled.div<{ fill: boolean }>`
 const Page: React.FC<PageProps> = ({
   actions,
   activeTabName,
-  areas,
+  areas = "main",
   children,
   fill,
   loading,

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -58,8 +58,8 @@ const StyledPageContent = styled("div", {
     gridGap: props.theme.space.element,
     width: "100%",
     height: "100%",
-    minWidth: 800,
-    maxWidth: props.fill ? "none" : 1150,
+    minWidth: props.theme.pageSize.min,
+    maxWidth: props.fill ? "none" : props.theme.pageSize.max,
     padding: props.noPadding ? 0 : `${props.theme.space[props.padding || "element"]}px`,
 
     /**

--- a/src/PageContent/PageContent.tsx
+++ b/src/PageContent/PageContent.tsx
@@ -60,7 +60,6 @@ const StyledPageContent = styled("div", {
     height: "100%",
     minWidth: props.theme.pageSize.min,
     maxWidth: props.fill ? "none" : props.theme.pageSize.max,
-    padding: props.noPadding ? 0 : `${props.theme.space[props.padding || "element"]}px`,
 
     /**
      * Since PageContent is in a scrollable context,

--- a/src/Paginator/__tests__/__snapshots__/Paginator.test.tsx.snap
+++ b/src/Paginator/__tests__/__snapshots__/Paginator.test.tsx.snap
@@ -27,11 +27,11 @@ exports[`Paginator Component Should initialize properly 1`] = `
         fill="currentColor"
         height="11"
         style="margin-left:0;margin-right:0;cursor:default;transition:fill .075s ease"
-        viewBox="0 0 6.71 12.41"
+        viewBox="0 0 6.83 16.41"
         width="11"
       >
         <path
-          d="M6.21 12.41a.54.54 0 0 1-.36-.14L.15 6.56a.5.5 0 0 1 0-.71l5.7-5.7a.5.5 0 0 1 .71 0 .5.5 0 0 1 0 .7L1.21 6.21l5.35 5.35a.51.51 0 0 1 0 .71.54.54 0 0 1-.35.14z"
+          d="M6.33 16.41a.51.51 0 0 1-.4-.2L0 8.21 5.93.2a.5.5 0 1 1 .8.6L1.24 8.21l5.49 7.4a.5.5 0 0 1-.4.8z"
         />
       </svg>
       <span>
@@ -58,11 +58,11 @@ exports[`Paginator Component Should initialize properly 1`] = `
         fill="currentColor"
         height="11"
         style="margin-left:0;margin-right:0;cursor:default;transition:fill .075s ease"
-        viewBox="0 0 6.71 12.41"
+        viewBox="0 0 6.83 16.41"
         width="11"
       >
         <path
-          d="M.5 12.41a.5.5 0 0 1-.35-.85L5.5 6.21.15.85a.48.48 0 0 1 0-.7.48.48 0 0 1 .7 0l5.71 5.7a.51.51 0 0 1 0 .71L.85 12.27a.5.5 0 0 1-.35.14z"
+          d="M.5 16.41a.5.5 0 0 1-.4-.8l5.48-7.4L.1.8A.5.5 0 0 1 .2.1a.5.5 0 0 1 .7.1l5.93 8-5.93 8a.51.51 0 0 1-.4.21z"
         />
       </svg>
     </button>

--- a/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
+++ b/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
@@ -110,11 +110,11 @@ exports[`ProgressPanel Component Should initialize properly 1`] = `
           fill="currentColor"
           height="18"
           style="margin-left:0;margin-right:8px;cursor:default;transition:fill .075s ease"
-          viewBox="0 0 12.81 12.81"
+          viewBox="0 0 12.8 12.8"
           width="18"
         >
           <path
-            d="M6.4 12.81a6.41 6.41 0 1 1 6.41-6.41 6.41 6.41 0 0 1-6.41 6.41zM6.4 1a5.41 5.41 0 1 0 5.41 5.4A5.4 5.4 0 0 0 6.4 1z"
+            d="M6.4 12.8C2.9 12.8 0 9.9 0 6.4 0 2.9 2.9 0 6.4 0c3.5 0 6.4 2.9 6.4 6.4s-2.9 6.4-6.4 6.4zM6.4 1C3.4 1 1 3.4 1 6.4c0 3 2.4 5.4 5.4 5.4s5.4-2.4 5.4-5.4c0-3-2.4-5.4-5.4-5.4zm0 2.3v3.6m.2.1l1.2 1.6"
           />
         </svg>
         Something

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -243,7 +243,6 @@ const shadows = {
   focus: "inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6)",
   insetFocus: "inset 0 0 0px 2px #1499ce",
   popup: "0 3px 12px rgba(0, 0, 0, .15)",
-  card: "0 1px 3px 0 rgba(191, 203, 210, 0.9)",
 }
 
 const constants = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -263,6 +263,10 @@ const constants = {
   topbarHeight: 48,
   titleHeight: 50,
   tabsBarHeight: 48,
+  pageSize: {
+    min: 800,
+    max: 1000,
+  },
 }
 
 /*


### PR DESCRIPTION
Per @kemal-contiamo, 

- we need `Page` to have a `min-width` of 800, and a `max-width` of 1000. This also affects Tabs. 
- Layouts have more space.
- `Card`s look a little different (no shadow, only border) ([ref](https://app.zeplin.io/project/5cc31fad6f17562d6dac9a53/screen/5d010a6e7bb35419d6be656e))

This PR implements the new design requirements.

**NB:** The `Page` now has a `min-width` of 800px so it will never shrink below this and will never grow >1000px.

To test (me):
- [x] no regression on `Page`
- [x] no regression on `Card`
- [x] no regression on `Layout`
- [x] no regression on `ProgressPanel`
- [x] no regression on `DatePicker`
- [x] no regression on `Paginator`
- [x] no regression on `Table`

To test:
- [ ] no regression on `Page`
- [ ] no regression on `Card`
- [ ] no regression on `Layout`
- [ ] no regression on `ProgressPanel`
- [ ] no regression on `DatePicker`
- [ ] no regression on `Paginator`
- [ ] no regression on `Table`

Internal link: https://contiamo.atlassian.net/browse/UI-82

## Notes
Here are things I found in review:

### Card with tabs
This isn't a regression. It looks odd on `master`. Let's fix this in another PR: 

**This branch**
![image](https://user-images.githubusercontent.com/9947422/59823816-a0d8a300-92ec-11e9-87eb-daebb7bb8bd1.png)

**`master`**
![image](https://user-images.githubusercontent.com/9947422/59823830-ab933800-92ec-11e9-82cf-9d1fa33036a1.png)
