### PR TITLE
**Fix:** Select menu not closing

### DIFF
--- a/src/ActionMenu/README.md
+++ b/src/ActionMenu/README.md
@@ -5,8 +5,7 @@ A single `onClick` action common to all items in the `ActionMenu` can be passed 
 ```jsx
 import * as React from "react"
 import { ActionMenu } from "@operational/components"
-
-;<ActionMenu items={["Open editor", "Stop", "Destroy"]} onClick={item => alert(`"${item}" clicked`)} />
+;<ActionMenu items={["Open editor", "Stop", "Destroy"]} onClick={item => alert(`${item.label} clicked`)} />
 ```
 
 ### Different actions on click

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -163,7 +163,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
       {isOpen && (
         <InvisibleOverlay
           onClick={e => {
-            e.stopPropagation() //clicking on an item should not trigger the parent's onClick
+            e.stopPropagation()
             setIsOpen && setIsOpen(false)
           }}
         />

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -163,7 +163,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
       {isOpen && (
         <InvisibleOverlay
           onClick={e => {
-            e.stopPropagation()
+            e.stopPropagation() //clicking on an item should not trigger the parent's onClick
             setIsOpen && setIsOpen(false)
           }}
         />
@@ -214,7 +214,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
               width={width || "100%"}
               item={item}
               onClick={e => {
-                e.stopPropagation()
+                e.stopPropagation() //clicking on an item should not trigger the parent's onClick
                 if (!keepOpenOnItemClick && setIsOpen) {
                   setIsOpen(false)
                 }

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -217,10 +217,16 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
                 e.stopPropagation()
                 if (!isString(item) && item.onClick) {
                   item.onClick(makeItem(item))
+                  if (!keepOpenOnItemClick && setIsOpen) {
+                    setIsOpen(false)
+                  }
                   return
                 }
                 if (onClick) {
                   onClick(makeItem(item))
+                  if (!keepOpenOnItemClick && setIsOpen) {
+                    setIsOpen(false)
+                  }
                 }
               }}
               {...(getChildProps ? getChildProps(index) : {})}

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -215,18 +215,15 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
               item={item}
               onClick={e => {
                 e.stopPropagation()
+                if (!keepOpenOnItemClick && setIsOpen) {
+                  setIsOpen(false)
+                }
                 if (!isString(item) && item.onClick) {
                   item.onClick(makeItem(item))
-                  if (!keepOpenOnItemClick && setIsOpen) {
-                    setIsOpen(false)
-                  }
                   return
                 }
                 if (onClick) {
                   onClick(makeItem(item))
-                  if (!keepOpenOnItemClick && setIsOpen) {
-                    setIsOpen(false)
-                  }
                 }
               }}
               {...(getChildProps ? getChildProps(index) : {})}

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -123,7 +123,7 @@ import * as React from "react"
 import { ContextMenu, ContextMenuProps } from "@operational/components"
 
 const menuItems = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(item => `Menu ${item}`)
-;<ContextMenu keepOpenOnItemClick condensed items={menuItems} onClick={() => alert("clicked")}>
-  <div>Many options may be selected here</div>
+;<ContextMenu condensed items={menuItems} onClick={() => alert("clicked")}>
+  <div>Long list of options here</div>
 </ContextMenu>
 ```

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -123,7 +123,7 @@ import * as React from "react"
 import { ContextMenu, ContextMenuProps } from "@operational/components"
 
 const menuItems = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(item => `Menu ${item}`)
-;<ContextMenu condensed items={menuItems} onClick={() => alert("clicked")}>
+;<ContextMenu keepOpenOnItemClick condensed items={menuItems} onClick={() => alert("clicked")}>
   <div>Many options may be selected here</div>
 </ContextMenu>
 ```


### PR DESCRIPTION
# Summary
Fixes #1056 – the regression, introduced  by https://github.com/contiamo/operational-ui/pull/1047
The context menu should close now as soon as an item within the menu is selected. It should still stay opened if `keepOpenOnItemClick` was provided


# Related issue
https://github.com/contiamo/operational-ui/issues/1056

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1
- [ ] Context menu works as expected in all README.md cases (including multi-select cases)
- [ ] Select works as expected in all README.md cases (including multi-select functionalitfy)
- [ ] Action menu works as expected in all README.md cases
