### PR TITLE
**Fix:** Allow overflow on Modal

### DIFF
--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -45,7 +45,6 @@ export const ModalContainer = styled(Card)<{ fullSize: boolean; type?: Controlle
     zIndex: type === "confirm" ? theme.zIndex.confirm : theme.zIndex.modal,
     maxWidth: `calc(100% - ${theme.space.element * 2}px)`, // don't go past the screen!
     maxHeight: `calc(100% - ${theme.space.element * 2}px)`, // don't go past the page!
-    overflow: "hidden",
 
     ...(fullSize
       ? // Full-size specific rules


### PR DESCRIPTION
Currently, the Modal hides overflow, which clips any dropdowns inside (see #1054). This PR fixes #1054.