### PR TITLE
**Fix:** Make Table actions accessible

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -184,9 +184,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         onKeyDown={e => {
           switch (e.key) {
             case "Enter":
-              if (keepOpenOnItemClick) {
-                e.stopPropagation()
-              }
+              e.stopPropagation()
               handleSelect()
               break
           }

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -121,7 +121,7 @@ const Actions = styled(Td)(({ theme }) => ({
    * the box model of the Td while opacity does not.
    */
   opacity: 0,
-  "tr:hover &, :hover": {
+  "tr:hover &, :hover, tr:focus &, :focus-within, &:focus": {
     opacity: 1,
   },
 
@@ -174,6 +174,19 @@ function Table<T>({
 
   const hasIcons = Boolean(data[0] && icon && icon(data[0]))
 
+  const handleKeyDownOnRow = React.useCallback(
+    (entry, index) => (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+      if (!onRowClick) {
+        return
+      }
+      switch (e.key) {
+        case "Enter":
+          onRowClick(entry, index)
+      }
+    },
+    [onRowClick],
+  )
+
   return (
     <Container fixedLayout={fixedLayout} {...props}>
       {!headless && (
@@ -224,6 +237,9 @@ function Table<T>({
             })()
             return (
               <Tr
+                onKeyDown={handleKeyDownOnRow(dataEntry, dataEntryIndex)}
+                tabIndex={onRowClick ? 0 : undefined}
+                role={onRowClick ? "button" : undefined}
                 hover={Boolean(onRowClick)}
                 key={dataEntryIndex}
                 clickable={Boolean(onRowClick)}


### PR DESCRIPTION
This PR fixes #971. All table rows with an `onRowClick` can now be tabbed to and highlight their respective `ActionMenu`.