### PR TITLE
**Fix:** ContextMenuItem default width

### DIFF
--- a/src/ContextMenu/ContextMenu.Item.tsx
+++ b/src/ContextMenu/ContextMenu.Item.tsx
@@ -35,6 +35,7 @@ const Container = styled("div")<Props>(({ align, theme, isActive, condensed, wid
     userSelect: "none",
     label: "contextmenuitem",
     width: width || (condensed ? 160 : "100%"),
+    minWidth: "100%",
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -211,7 +211,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
               condensed={condensed}
               align={align}
               iconLocation={iconLocation}
-              width={width || "100%"}
+              width={width || "min-content"}
               item={item}
               onClick={e => {
                 e.stopPropagation()


### PR DESCRIPTION
This PR fixes #1071 where `ContextMenuItem`s received an incorrect initial width.