### PR TITLE
**Breaking:** Remove spacing hacks from CardColumn(s)

### DIFF
--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -11,8 +11,6 @@ export interface BaseCardColumnProps extends DefaultProps {
   contentRight?: boolean
   /** Force the column to be full with */
   fullWidth?: boolean
-  /** Remove padding */
-  noPadding?: boolean
   /** Component containing buttons/links/actions assigned to the card */
   action?: React.ReactNode
 }
@@ -37,19 +35,16 @@ export interface CardColumnPropsWithoutTabs extends BaseCardColumnProps {
 
 export type CardColumnProps = CardColumnPropsWithTabs | CardColumnPropsWithoutTabs
 
-const Container = styled("div")<Pick<CardColumnProps, "contentRight" | "fullWidth" | "noPadding">>(
-  ({ theme, contentRight, fullWidth, noPadding }) => ({
-    label: "card-column",
-    height: "min-content",
-    minWidth: 280 / 2,
-    padding: noPadding ? 0 : theme.space.element / 2,
-    ...(fullWidth ? { flex: "1 1 100%", maxWidth: "100%" } : {}),
-    img: {
-      maxWidth: "100%",
-    },
-    textAlign: contentRight ? "right" : "left",
-  }),
-)
+const Container = styled("div")<Pick<CardColumnProps, "contentRight" | "fullWidth">>(({ contentRight, fullWidth }) => ({
+  label: "card-column",
+  height: "min-content",
+  minWidth: 280 / 2,
+  ...(fullWidth ? { flex: "1 1 100%", maxWidth: "100%" } : {}),
+  img: {
+    maxWidth: "100%",
+  },
+  textAlign: contentRight ? "right" : "left",
+}))
 
 const Action = styled("div")`
   margin-left: auto;

--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -35,7 +35,7 @@ export interface CardColumnPropsWithoutTabs extends BaseCardColumnProps {
 
 export type CardColumnProps = CardColumnPropsWithTabs | CardColumnPropsWithoutTabs
 
-const Container = styled("div")<Pick<CardColumnProps, "contentRight" | "fullWidth">>(({ contentRight, fullWidth }) => ({
+const Container = styled.div<Pick<CardColumnProps, "contentRight" | "fullWidth">>(({ contentRight, fullWidth }) => ({
   label: "card-column",
   height: "min-content",
   minWidth: 280 / 2,

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -9,13 +9,9 @@ export type CardColumnsProps = React.Props<{}> & {
 export const CardColumns = styled("div")<CardColumnsProps>(({ children, theme, columns }) => {
   columns = columns === undefined ? React.Children.count(children) : columns
   return {
-    display: "flex",
-    flexWrap: "wrap",
-    margin: -(theme.space.element / 2),
-    "& > *": {
-      flex: `1 1 calc(100% / ${columns})`,
-      maxWidth: `calc(100% / ${columns})`,
-    },
+    display: "grid",
+    gridTemplateColumns: `repeat(${columns}, 1fr)`,
+    gridGap: theme.space.element,
   }
 })
 

--- a/src/CardColumns/README.md
+++ b/src/CardColumns/README.md
@@ -124,21 +124,3 @@ import { Card, CardColumns, CardColumn, AvatarGroup, Avatar, Chip } from "@opera
   </CardColumns>
 </Card>
 ```
-
-Columns will always wrap and overflow if their containing element is not wide enough for them.
-
-```jsx
-import { Card, AvatarGroup, CardColumn, Avatar, Chip } from "@operational/components"
-;<Card title="Bundle information">
-  <p>Here is the information available about this bundle.</p>
-  <CardColumns columns={3} style={{ width: "200px" }}>
-    <CardColumn title="Contributors">
-      <AvatarGroup avatars={[{ name: "Alice Bernoulli" }, { name: "Clarence Dermot" }]} />
-    </CardColumn>
-    <CardColumn title="Tags">
-      <Chip>agent-view</Chip>
-      <Chip>production</Chip>
-    </CardColumn>
-  </CardColumns>
-</Card>
-```


### PR DESCRIPTION
This PR fixes #1070 and removes weird negative margin hacks from CardColumn(s) and hoists the concerns of:

- spacing
- padding
- wrapping columns

to the parent component. This allows more control and predictability in these components.