### PR TITLE
**Fix:** Fix negative margin issue

### DIFF
--- a/src/AvatarGroup/AvatarGroup.tsx
+++ b/src/AvatarGroup/AvatarGroup.tsx
@@ -22,6 +22,7 @@ export interface AvatarGroupProps extends DefaultProps {
 
 const Container = styled("div")({
   display: "flex",
+  marginLeft: 12,
 })
 
 const GroupedAvatar = styled(Avatar)({


### PR DESCRIPTION
# Summary

Added a positive marginLeft 12px to div element 

Problem: Negative margin of Avatars breaking composition
![Screen Shot 2019-06-24 at 1 07 01 PM](https://user-images.githubusercontent.com/32997409/60001695-a0416300-9684-11e9-875c-a16d92bee4ff.png)

Solution: Positive marginLeft value of div solves for it
![Screen Shot 2019-06-24 at 1 07 47 PM](https://user-images.githubusercontent.com/32997409/60001715-a8999e00-9684-11e9-9bb4-358455149112.png)


# Related issue

AvatarGroup negative margin breaks design #1076

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
 

Tester 2

- [ ] Things look good on the demo.
  
