### PR TITLE
**Fix:** SectionHeader height

### DIFF
--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -3,6 +3,7 @@ import { DefaultProps } from "../types"
 import styled from "../utils/styled"
 import AccordionSection, { AccordionSectionProps } from "../AccordionSection/AccordionSection"
 import { useUniqueId } from "../useUniqueId"
+import { headerHeight } from "../utils/constants"
 
 type AccordionSectionElement = React.ReactElement<AccordionSectionProps, typeof AccordionSection>
 
@@ -16,7 +17,7 @@ const Container = styled("div")<{ sections: boolean[] }>`
   label: Accordion;
   height: 100%;
   display: grid;
-  grid-template-rows: ${({ sections }) => sections.map(expanded => (expanded ? "1fr" : "36px")).join(" ")};
+  grid-template-rows: ${({ sections }) => sections.map(expanded => (expanded ? "1fr" : `${headerHeight}px`)).join(" ")};
   border: solid 1px ${({ theme }) => theme.color.separators.default};
   border-top: none;
 `

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -16,8 +16,7 @@ const Container = styled("div")<{ sections: boolean[] }>`
   label: Accordion;
   height: 100%;
   display: grid;
-  grid-template-rows: ${({ theme, sections }) =>
-    sections.map(expanded => (expanded ? "1fr" : `${theme.space.element * 2}px`)).join(" ")};
+  grid-template-rows: ${({ sections }) => sections.map(expanded => (expanded ? "1fr" : "36px")).join(" ")};
   border: solid 1px ${({ theme }) => theme.color.separators.default};
   border-top: none;
 `

--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -21,10 +21,7 @@ const Container = styled.div<{ expanded: boolean }>`
   overflow: hidden;
   /* to fix overflow: hidden above, otherwise header can disappear */
   display: grid;
-  grid-template-rows: ${({ theme }) => {
-    const headerHeight = theme.space.element * 2
-    return `${headerHeight}px calc(100% - ${headerHeight}px)`
-  }};
+  grid-template-rows: 36px calc(100% - 36px);
   /* for Focus */
   position: relative;
 `

--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -4,6 +4,7 @@ import styled from "../utils/styled"
 import { ChevronUpIcon, ChevronDownIcon } from "../Icon/Icon"
 import { DefaultProps } from "../types"
 import isFunction from "lodash/isFunction"
+import { headerHeight } from "../utils/constants"
 
 export interface AccordionSectionProps extends DefaultProps {
   title: React.ReactNode
@@ -21,7 +22,7 @@ const Container = styled.div<{ expanded: boolean }>`
   overflow: hidden;
   /* to fix overflow: hidden above, otherwise header can disappear */
   display: grid;
-  grid-template-rows: 36px calc(100% - 36px);
+  grid-template-rows: ${headerHeight}px calc(100% - ${headerHeight}px);
   /* for Focus */
   position: relative;
 `

--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -39,7 +39,7 @@ const Container = styled("div")<{
   lineHeight: 1,
   padding: `${theme.space.content / 2}px ${theme.space.content}px`,
   height: "100%",
-  [align === "left" ? "paddingRight" : "paddingLeft"]: theme.space.element * 2, // leave room for the caret
+  [align === "left" ? "paddingRight" : "paddingLeft"]: 36, // leave room for the caret
   color: isOpen ? theme.color.white : "#ffffffcc",
   backgroundColor: isOpen ? backgroundColor : "transparent",
   boxShadow: isOpen ? boxShadow : "none",

--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -5,6 +5,7 @@ import * as React from "react"
 import ContextMenu, { ContextMenuProps } from "../ContextMenu/ContextMenu"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
+import { headerHeight } from "../utils/constants"
 
 export interface HeaderMenuProps extends DefaultProps {
   /** Clickable component(s) from which menu appears  */
@@ -39,7 +40,7 @@ const Container = styled("div")<{
   lineHeight: 1,
   padding: `${theme.space.content / 2}px ${theme.space.content}px`,
   height: "100%",
-  [align === "left" ? "paddingRight" : "paddingLeft"]: 36, // leave room for the caret
+  [align === "left" ? "paddingRight" : "paddingLeft"]: headerHeight, // leave room for the caret
   color: isOpen ? theme.color.white : "#ffffffcc",
   backgroundColor: isOpen ? backgroundColor : "transparent",
   boxShadow: isOpen ? boxShadow : "none",

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -3,6 +3,7 @@ import * as React from "react"
 import Card, { CardProps } from "../Card/Card"
 import Overlay from "../Internals/Overlay"
 import styled from "../utils/styled"
+import { headerHeight } from "../utils/constants"
 
 export interface ControlledModalProps {
   id?: string
@@ -43,8 +44,8 @@ export const ModalContainer = styled(Card)<{ fullSize: boolean; type?: Controlle
     position: "absolute",
     minWidth: 600,
     zIndex: type === "confirm" ? theme.zIndex.confirm : theme.zIndex.modal,
-    maxWidth: "calc(100% - 36px)", // don't go past the screen!
-    maxHeight: "calc(100% - 36px)", // don't go past the page!
+    maxWidth: `calc(100% - ${headerHeight}px)`, // don't go past the screen!
+    maxHeight: `calc(100% - ${headerHeight}px)`, // don't go past the page!
 
     ...(fullSize
       ? // Full-size specific rules

--- a/src/Internals/ControlledModal.tsx
+++ b/src/Internals/ControlledModal.tsx
@@ -43,8 +43,8 @@ export const ModalContainer = styled(Card)<{ fullSize: boolean; type?: Controlle
     position: "absolute",
     minWidth: 600,
     zIndex: type === "confirm" ? theme.zIndex.confirm : theme.zIndex.modal,
-    maxWidth: `calc(100% - ${theme.space.element * 2}px)`, // don't go past the screen!
-    maxHeight: `calc(100% - ${theme.space.element * 2}px)`, // don't go past the page!
+    maxWidth: "calc(100% - 36px)", // don't go past the screen!
+    maxHeight: "calc(100% - 36px)", // don't go past the page!
 
     ...(fullSize
       ? // Full-size specific rules

--- a/src/Internals/SectionHeader.tsx
+++ b/src/Internals/SectionHeader.tsx
@@ -1,4 +1,5 @@
 import styled from "../utils/styled"
+import { headerHeight } from "../utils/constants"
 
 export const SectionHeader = styled("div")(({ theme }) => ({
   fontFamily: theme.font.family.main,
@@ -12,7 +13,7 @@ export const SectionHeader = styled("div")(({ theme }) => ({
 
   // This ensures that the card header text and card controls are placed in opposite corners.
   justifyContent: "space-between",
-  height: "36px",
+  height: headerHeight,
   padding: `0 ${theme.space.element}px`,
   lineHeight: 1,
 }))

--- a/src/Internals/SectionHeader.tsx
+++ b/src/Internals/SectionHeader.tsx
@@ -12,7 +12,7 @@ export const SectionHeader = styled("div")(({ theme }) => ({
 
   // This ensures that the card header text and card controls are placed in opposite corners.
   justifyContent: "space-between",
-  height: theme.space.element * 2,
+  height: "36px",
   padding: `0 ${theme.space.element}px`,
   lineHeight: 1,
 }))

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -6,21 +6,20 @@ const buttonWidth = 55
 export const Container = styled.div`
   label: Tabs;
   display: grid;
-  grid-template-rows: ${({ theme }) => `${theme.space.element * 2}px 1fr`};
+  grid-template-rows: 36px 1fr;
   position: relative;
   height: 100%;
 `
 
 export const TabList = styled.div<{ scroll: boolean }>`
   display: flex;
-  height: ${({ theme }) => theme.space.element * 2}px;
   overflow-x: auto;
   max-width: ${({ scroll }) => (scroll ? `calc(100% - ${buttonWidth * 2}px)` : "none")};
   scroll-behavior: smooth;
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
   overflow-y: hidden;
   /* magic number to hide scroll bar underneath tabpanel */
-  height: ${({ theme }) => theme.space.element * 2 + 20}px;
+  height: 56px;
   -webkit-overflow-scrolling: auto;
   ::-webkit-scrollbar {
     display: none;

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -1,5 +1,6 @@
 import styled from "../utils/styled"
 import { SectionHeader } from "../Internals/SectionHeader"
+import { headerHeight } from "../utils/constants"
 
 const buttonWidth = 55
 
@@ -19,7 +20,7 @@ export const TabList = styled.div<{ scroll: boolean }>`
   border-left: solid 1px ${({ theme }) => theme.color.separators.default};
   overflow-y: hidden;
   /* magic number to hide scroll bar underneath tabpanel */
-  height: 56px;
+  height: ${headerHeight + 20}px;
   -webkit-overflow-scrolling: auto;
   ::-webkit-scrollbar {
     display: none;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -268,6 +268,8 @@ const constants = {
   },
 }
 
+export const headerHeight: number = 36
+
 /*
  * Expands a color expressed either as a custom hex value
  * or a color key to pick from within the style constants object.


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Fixes #1087.
I changed all occurrences of `theme.space.element * 2` to `36px`.
Also in this file https://github.com/contiamo/operational-ui/blob/master/src/Tabs/Tabs.styled.ts#L23 I changed it to `56px` because the code was `height: ${({ theme }) => theme.space.element * 2 + 20}px` and remove the overwritten `height` property above.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue

https://github.com/contiamo/operational-ui/issues/1087

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] Tabs component looks and works the same
- [x] Accordion component looks and works the same
- [x] HeaderBar component looks and works the same
- [x] Check other components that use HeaderMenu or SectionHeader

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
