### PR TITLE
**Feature:** Expose `align` on `DropdownButton`

### DIFF
--- a/src/DropdownButton/DropdownButton.tsx
+++ b/src/DropdownButton/DropdownButton.tsx
@@ -23,6 +23,8 @@ export interface DropdownButtonProps extends DefaultProps {
   /** onItemClick method for all menu items */
   onItemClick?: (item: IContextMenuItem) => void
   children?: React.ReactNode
+  /** Alignment */
+  align?: "left" | "right"
 }
 
 const BaseDropdownButton = styled(Button)<{ isOpen: boolean; textColor: string }>(({ isOpen, textColor, theme }) => ({
@@ -47,6 +49,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
   items,
   onItemClick,
   color = "primary",
+  align,
   children,
   ...props
 }) => {
@@ -65,7 +68,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
   })
 
   return (
-    <ContextMenu {...props} onClick={onItemClick} iconLocation="right" items={itemsWithCarets}>
+    <ContextMenu {...props} onClick={onItemClick} iconLocation="right" items={itemsWithCarets} align={align}>
       {isOpen => {
         return (
           <BaseDropdownButton

--- a/src/DropdownButton/README.md
+++ b/src/DropdownButton/README.md
@@ -31,7 +31,7 @@ import { DropdownButton, DatabaseIcon } from "@operational/components"
 const MyLabelContainer = ({ title, children }) => (
   <div style={{ display: "flex", alignItems: "center", width: "300px", whiteSpace: "normal" }}>
     <DatabaseIcon left />
-    <div style={{ lineHeight: 1, width: "100%", margin: "8px 0" }}>
+    <div style={{ lineHeight: 1, width: "100%", margin: "8px 0", textAlign: "left" }}>
       <p style={{ fontWeight: "bold", margin: "0 0 4px 0" }}>{title}</p>
       {children}
     </div>
@@ -65,7 +65,7 @@ const menuItems = [
   },
 ]
 
-;<>
+;<div style={{ display: "flex", justifyContent: "space-around" }}>
   <DropdownButton
     items={menuItems}
     onClick={() => {
@@ -74,5 +74,14 @@ const menuItems = [
   >
     Add data source
   </DropdownButton>
-</>
+  <DropdownButton
+    align="right"
+    items={menuItems}
+    onClick={() => {
+      console.log("Button clicked")
+    }}
+  >
+    Add data source
+  </DropdownButton>
+</div>
 ```


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add `align` prop to `DropdownButton` to be able to do this:

![image](https://user-images.githubusercontent.com/1761469/60178837-a23e2a00-981c-11e9-8ba8-6dc4f8765892.png)


# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
