### PR TITLE
**Fix:** Add hover state to Tabs

### DIFF
--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -64,10 +64,7 @@ export const TabHeader = styled(SectionHeader, {
   ${({ condensed }) =>
     condensed ? `max-width: ${buttonWidth}px; min-width: ${buttonWidth}px;` : "max-width: 180px;"}
   flex-grow: 1;
-  & svg {
-    ${({ condensed }) => (condensed ? "pointer-events: none;" : "")}
-    cursor: pointer;
-  }
+  transition: background-color 0.2s;
   :focus {
     outline: none;
     box-shadow: ${({ theme }) => theme.shadows.insetFocus};
@@ -78,6 +75,9 @@ export const TabHeader = styled(SectionHeader, {
   :disabled {
     color: ${({ theme }) => theme.color.disabled};
     cursor: not-allowed;
+  }
+  :hover {
+    background-color: ${({ theme }) => theme.color.separators.default};
   }
   margin: 0;
 `
@@ -128,6 +128,7 @@ export const TitleWrapper = styled.span`
 
 export const TabIcon = styled.span`
   margin-right: ${({ theme }) => theme.space.small}px;
+  pointer-events: none;
 `
 
 export const ScrollButtons = styled.div`

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -65,6 +65,12 @@ export const TabHeader = styled(SectionHeader, {
     condensed ? `max-width: ${buttonWidth}px; min-width: ${buttonWidth}px;` : "max-width: 180px;"}
   flex-grow: 1;
   transition: background-color 0.2s;
+
+  /* Fix the cursor on the "add tab" button */
+  & svg {
+    ${({ condensed }) => (condensed ? "pointer-events: none;" : "")}
+    cursor: pointer;
+  }
   :focus {
     outline: none;
     box-shadow: ${({ theme }) => theme.shadows.insetFocus};

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -160,7 +160,7 @@ const Tabs: React.FC<TabsProps> = ({
                   <NoIcon
                     right
                     size={9}
-                    onMouseDown={e => {
+                    onClick={e => {
                       e.stopPropagation()
                       onClose(i)
                     }}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add a simple hover state to Tabs and fix the pointer cursor on icons (tab icon and close icon)

# Related issue

https://contiamo.atlassian.net/browse/CON-296

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060` (it's sadly red, but let fix this later… It's not introduce in this PR)

Tester 1

- [ ] Things look good on the demo.
- [ ] We have a hover state on tab
- [ ] We have a nice cursor on the tab icon and close icon
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
- [ ] Things look good on the demo.
- [ ] We have a hover state on tab
- [ ] We have a nice cursor on the tab icon and close icon
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
