### PR TITLE
**Fix:** Make default cellWidth on DataTable minmax(200px, 1fr)

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -42,7 +42,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
   footer = null,
   height = 500,
   width = "100%",
-  cellWidth = "1fr",
+  cellWidth = "minmax(200px, 1fr)",
   maxCharactersInCell = 30,
   className,
 }: DataTableProps<Columns, Rows>) {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Make minmax(200px, 1fr) the default cellWidth on DataTable

# Related issue
#1104 

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`
- [ ] No TS errors.
- [ ] Default cellWidth on DataTable with one column should be 200px.

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->
- [ ] No TS errors.
- [ ] Default cellWidth on DataTable with one column should be 200px.

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
- [ ] No TS errors.
- [ ] Default cellWidth on DataTable with one column should be 200px.
