### PR TITLE
**Fix:** TopBarSelect is off by some pixels

### DIFF
--- a/src/TopbarSelect/TopbarSelect.tsx
+++ b/src/TopbarSelect/TopbarSelect.tsx
@@ -36,7 +36,7 @@ const TopbarSelectContainer = styled("div")<{ isActive: boolean }>`
 
 const TopbarSelectValue = styled("div")`
   padding: 0px ${props => props.theme.space.base}px;
-  font-size: ${props => props.theme.font.size.fineprint}px;
+  font-size: ${props => props.theme.font.size.small}px;
   display: flex;
   align-items: center;
 `
@@ -47,7 +47,7 @@ const TopbarSelectValueSpan = styled("span")`
 
 const TopbarSelectLabel = styled("p")`
   margin: 0px ${props => props.theme.space.element}px 0px 0px;
-  font-size: ${props => props.theme.font.size.fineprint}px;
+  font-size: ${props => props.theme.font.size.small}px;
   font-weight: ${props => props.theme.font.weight.medium};
 `
 
@@ -83,7 +83,7 @@ const TopbarSelect = ({ label, selected, items, onChange, ...props }: TopbarSele
           <TopbarSelectValue>
             {Icon && <Icon left />}
             <TopbarSelectValueSpan>{selected}</TopbarSelectValueSpan>
-            {React.createElement(isActive ? CaretUpIcon : CaretDownIcon, { size: 10, color: "color.text.lightest" })}
+            {React.createElement(isActive ? CaretUpIcon : CaretDownIcon, { size: 5, color: "color.text.lightest" })}
           </TopbarSelectValue>
         </TopbarSelectContainer>
       )}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fixes: https://github.com/contiamo/operational-ui/issues/1100

Changed `font-size` to `small` for `TopbarSelectValue` and `TopbarSelectLabel`.
Changed icon size to 5.

__Fixed:__
<img width="513" alt="image" src="https://user-images.githubusercontent.com/8292471/60452976-d3906e80-9bfd-11e9-8e9f-e7d8ce5f50e9.png">

__Design:__
<img width="267" alt="image" src="https://user-images.githubusercontent.com/179534/60261490-5357c980-98dc-11e9-861c-41d362a71f50.png">


# Related issue

https://github.com/contiamo/operational-ui/issues/1100

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] Looks closer to the provided design example

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
