### PR TITLE
**Fix:** Fix unfiltered props in styled-components

### DIFF
--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -119,7 +119,7 @@ const Container = styled("div")(({ theme }) => ({
   },
 }))
 
-const Content = styled("div")<{ fullSize?: boolean }>`
+const Content = styled("div", { shouldForwardProp: prop => prop !== "fullSize" })<{ fullSize?: boolean }>`
   padding: ${({ theme }) => theme.space.element}px;
   height: ${props => (props.fullSize ? "100%" : "auto")};
   white-space: pre-wrap;

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -119,7 +119,7 @@ const Container = styled("div")(({ theme }) => ({
   },
 }))
 
-const Content = styled("div", { shouldForwardProp: prop => prop !== "fullSize" })<{ fullSize?: boolean }>`
+const Content = styled.div<{ fullSize?: boolean }>`
   padding: ${({ theme }) => theme.space.element}px;
   height: ${props => (props.fullSize ? "100%" : "auto")};
   white-space: pre-wrap;

--- a/src/Card/README.md
+++ b/src/Card/README.md
@@ -17,13 +17,13 @@ import { Card } from "@operational/components"
 
 ```jsx
 import * as React from "react"
-import { Card, SimpleLink } from "@operational/components"
+import { Card, SimpleLink, OpenIcon } from "@operational/components"
 ;<Card
   title="Functions"
   action={
     <>
       Learn more at the
-      <SimpleLink right icon="Open" to="https://github.com">
+      <SimpleLink right icon={OpenIcon} to="https://github.com">
         Configuration page
       </SimpleLink>
     </>
@@ -124,7 +124,7 @@ These features are shown in the example below:
 
 ```jsx
 import * as React from "react"
-import { Card, Button } from "@operational/components"
+import { Card, Button, YesIcon } from "@operational/components"
 
 const MyComponent = () => {
   const [activeTab, setActiveTab] = React.useState("Results")
@@ -152,7 +152,7 @@ const MyComponent = () => {
           children: isTab1Loading ? "" : "The answer is 42",
           loading: isTab1Loading,
           // The icon is replaced by a spinner when loading.
-          icon: "Yes",
+          icon: YesIcon,
           iconColor: "success",
         },
         {

--- a/src/CardColumns/README.md
+++ b/src/CardColumns/README.md
@@ -65,7 +65,7 @@ import { Card, CardColumns, CardColumn, Chip } from "@operational/components"
 
 ```jsx
 import * as React from "react"
-import { Card, CardColumns, CardColumn, Textarea, Code, Button } from "@operational/components"
+import { Card, CardColumns, CardColumn, Textarea, Code, Button, OpenIcon } from "@operational/components"
 ;<Card title="Playground">
   <CardColumns>
     <CardColumn title="Input">
@@ -88,7 +88,7 @@ import { Card, CardColumns, CardColumn, Textarea, Code, Button } from "@operatio
       <Button color="primary">Send Request</Button>
     </CardColumn>
     <CardColumn contentRight>
-      <Button color="grey" icon="Open">
+      <Button color="grey" icon={OpenIcon}>
         curl/code
       </Button>
     </CardColumn>

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -23,7 +23,9 @@ export const Row = styled("div")<{ numCells: number; cellWidth: string }>`
   grid-template-columns: repeat(${({ numCells, cellWidth }) => `${numCells}, ${cellWidth}`});
 `
 
-export const Cell = styled("div", { shouldForwardProp: prop => !["isEvenRow", "height", "cell"].includes(prop) })<{
+export const Cell = styled("div", {
+  shouldForwardProp: prop => !["isEvenRow", "height", "cell", "rowIndex"].includes(prop),
+})<{
   height: number
   cell: number
   rowIndex: number
@@ -46,7 +48,7 @@ export const Cell = styled("div", { shouldForwardProp: prop => !["isEvenRow", "h
   background-color: ${({ theme, isEvenRow }) => (isEvenRow ? theme.color.background.almostWhite : theme.color.white)};
 `
 
-export const HeaderRow = styled("div")<{
+export const HeaderRow = styled("div", { shouldForwardProp: prop => prop !== "rowHeight" })<{
   rowHeight: DataTableProps<any, any>["rowHeight"]
 }>`
   left: 0;
@@ -58,7 +60,9 @@ export const HeaderRow = styled("div")<{
   height: ${({ rowHeight }) => getHeaderRowHeight(rowHeight)}px;
 `
 
-export const HeaderCell = styled(Cell)<{
+export const HeaderCell = styled(Cell, {
+  shouldForwardProp: prop => !["rowHeight", "rowIndex"].includes(prop),
+})<{
   rowHeight: DataTableProps<any, any>["rowHeight"]
   rowIndex: number
 }>`

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -23,9 +23,7 @@ export const Row = styled("div")<{ numCells: number; cellWidth: string }>`
   grid-template-columns: repeat(${({ numCells, cellWidth }) => `${numCells}, ${cellWidth}`});
 `
 
-export const Cell = styled("div", {
-  shouldForwardProp: prop => !["isEvenRow", "height", "cell", "rowIndex"].includes(prop),
-})<{
+export const Cell = styled.div<{
   height: number
   cell: number
   rowIndex: number
@@ -48,7 +46,7 @@ export const Cell = styled("div", {
   background-color: ${({ theme, isEvenRow }) => (isEvenRow ? theme.color.background.almostWhite : theme.color.white)};
 `
 
-export const HeaderRow = styled("div", { shouldForwardProp: prop => prop !== "rowHeight" })<{
+export const HeaderRow = styled.div<{
   rowHeight: DataTableProps<any, any>["rowHeight"]
 }>`
   left: 0;
@@ -60,9 +58,7 @@ export const HeaderRow = styled("div", { shouldForwardProp: prop => prop !== "ro
   height: ${({ rowHeight }) => getHeaderRowHeight(rowHeight)}px;
 `
 
-export const HeaderCell = styled(Cell, {
-  shouldForwardProp: prop => !["rowHeight", "rowIndex"].includes(prop),
-})<{
+export const HeaderCell = styled(Cell)<{
   rowHeight: DataTableProps<any, any>["rowHeight"]
   rowIndex: number
 }>`

--- a/src/Group/README.md
+++ b/src/Group/README.md
@@ -4,8 +4,8 @@ Groups are little bits of content that group relevant data together. They can be
 
 ```jsx
 import * as React from "react"
-import { Group, Autocomplete } from "@operational/components"
-;<Group icon="User" iconColor="primary" title="Users">
+import { Group, Autocomplete, UserIcon } from "@operational/components"
+;<Group icon={UserIcon} iconColor="primary" title="Users">
   <Autocomplete
     value="Hello"
     onChange={() => console.log("changed")}

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -85,16 +85,18 @@ const Container = styled("div")<{ hasTitle: boolean; hasTabs: boolean }>(({ them
   overflow: "auto",
 }))
 
-const TitleContainer = styled("div")<{ fill: boolean }>(({ theme, fill }) => ({
-  display: "flex",
-  alignItems: "center",
-  height: theme.titleHeight,
-  fontWeight: theme.font.weight.medium,
-  minWidth: theme.pageSize.min,
-  maxWidth: fill ? "100%" : `${theme.pageSize.max}px`,
-}))
+const TitleContainer = styled("div", { shouldForwardProp: prop => prop !== "fill" })<{ fill: boolean }>(
+  ({ theme, fill }) => ({
+    display: "flex",
+    alignItems: "center",
+    height: theme.titleHeight,
+    fontWeight: theme.font.weight.medium,
+    minWidth: theme.pageSize.min,
+    maxWidth: fill ? "100%" : `${theme.pageSize.max}px`,
+  }),
+)
 
-const ViewContainer = styled("div")<{ fill: boolean }>`
+const ViewContainer = styled("div", { shouldForwardProp: prop => prop !== "fill" })<{ fill: boolean }>`
   outline: none;
   min-width: ${({ theme }) => theme.pageSize.min}px;
   max-width: ${({ fill, theme }) => (fill ? "100%" : `${theme.pageSize.max}px`)};
@@ -115,7 +117,7 @@ const FixedProgress = styled(Progress)`
   width: 100vw;
 `
 
-const TabsContainer = styled.div<{ fill: boolean }>`
+const TabsContainer = styled("div", { shouldForwardProp: prop => prop !== "fill" })<{ fill: boolean }>`
   min-width: ${({ theme }) => theme.pageSize.min}px;
   max-width: ${({ theme, fill }) => (fill ? "100%" : `${theme.pageSize.max}px`)};
 `

--- a/src/ProgressPanel/ProgressPanel.tsx
+++ b/src/ProgressPanel/ProgressPanel.tsx
@@ -64,7 +64,7 @@ const Item = styled("div")`
   padding: 6px 0;
 `
 
-const Body = styled("div", { shouldForwardProp: prop => prop !== "status" })<{ status: Status }>`
+const Body = styled.div<{ status: Status }>`
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/src/ProgressPanel/ProgressPanel.tsx
+++ b/src/ProgressPanel/ProgressPanel.tsx
@@ -64,7 +64,7 @@ const Item = styled("div")`
   padding: 6px 0;
 `
 
-const Body = styled("div")<{ status: Status }>`
+const Body = styled("div", { shouldForwardProp: prop => prop !== "status" })<{ status: Status }>`
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/src/ProgressPanel/README.md
+++ b/src/ProgressPanel/README.md
@@ -60,8 +60,7 @@ import { ProgressPanel } from "@operational/components"
 
 ```jsx
 import * as React from "react"
-import { Card, ProgressPanel, CardColumns, CardColumn, Button } from "@operational/components"
-
+import { Card, ProgressPanel, CardColumns, CardColumn, Button, RemoveIcon } from "@operational/components"
 ;<>
   <Card title="Progress panel">
     <ProgressPanel
@@ -74,7 +73,7 @@ import { Card, ProgressPanel, CardColumns, CardColumn, Button } from "@operation
     />
     <CardColumns>
       <CardColumn title="Danger zone">
-        <Button color="error" icon="Remove">
+        <Button color="error" icon={RemoveIcon}>
           Destroy Editor
         </Button>
       </CardColumn>

--- a/src/SimpleLink/SimpleLink.tsx
+++ b/src/SimpleLink/SimpleLink.tsx
@@ -27,7 +27,9 @@ export interface SimpleLinkProps extends DefaultProps {
   children?: React.ReactNode
 }
 
-const BaseSimpleLink = styled<"a" | "button">("button")<{
+const BaseSimpleLink = styled<"a" | "button">("button", {
+  shouldForwardProp: prop => !["color_", "left_", "right_"].includes(prop),
+})<{
   color_?: string
   left_?: boolean
   right_?: boolean


### PR DESCRIPTION
fix icons import and use in playgrounds

<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fixes https://github.com/contiamo/operational-ui/issues/1117

Fix unfiltered props in styled-components
Fix icons import and use in playgrounds

# Related issue

https://github.com/contiamo/operational-ui/issues/1117

# To be tested

Me
- [ ] No more error or warning in the console on `localhost:6060` about props

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
