### PR TITLE
**Fix:** Datepicker component: open the datepicker component on the correct month and year

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -7,7 +7,7 @@ import { Label } from "../utils/mixins"
 import { keyCodes } from "../utils"
 import Month from "./DatePicker.Month"
 import { Container, DatePickerCard, IconContainer, Input, MonthNav, Toggle } from "./DatePicker.styles"
-import { changeMonth, months, toDate, toYearMonthDay, validateDateString } from "./DatePicker.utils"
+import { changeMonth, months, toDate, validateDateString, getStartMonthYearInWidget } from "./DatePicker.utils"
 
 export interface DatePickerProps extends DefaultProps {
   id?: string
@@ -43,7 +43,7 @@ class DatePicker extends React.Component<DatePickerProps, State> {
     this.validate(props) // Start year month is either based on the start date
     // or the current month if no start date is specified.
 
-    const startYearMonthInWidget = this.getStartMonthYearInWidget(props)
+    const startYearMonthInWidget = getStartMonthYearInWidget(props)
 
     this.state = {
       ...startYearMonthInWidget,
@@ -69,36 +69,6 @@ class DatePicker extends React.Component<DatePickerProps, State> {
     if (validatedProps.end) {
       validateDateString(validatedProps.end)
     }
-  }
-
-  public getStartMonthYearInWidget(props?: DatePickerProps) {
-    // set start month and year of the widget based on the availability of start, end, max, or min props.
-    // if none of the props are available, set it to the current month and year.
-    const validatedProps = props || this.props
-    return validatedProps.start
-      ? {
-          year: toYearMonthDay(validatedProps.start).year,
-          month: toYearMonthDay(validatedProps.start).month,
-        }
-      : validatedProps.end
-      ? {
-          year: toYearMonthDay(validatedProps.end).year,
-          month: toYearMonthDay(validatedProps.end).month,
-        }
-      : validatedProps.min
-      ? {
-          year: toYearMonthDay(validatedProps.min).year,
-          month: toYearMonthDay(validatedProps.min).month,
-        }
-      : validatedProps.max
-      ? {
-          year: toYearMonthDay(validatedProps.max).year,
-          month: toYearMonthDay(validatedProps.max).month,
-        }
-      : {
-          year: new Date().getFullYear(),
-          month: new Date().getMonth(),
-        }
   }
 
   public changeMonth(diff: number) {

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -43,15 +43,8 @@ class DatePicker extends React.Component<DatePickerProps, State> {
     this.validate(props) // Start year month is either based on the start date
     // or the current month if no start date is specified.
 
-    const startYearMonthInWidget = props.start
-      ? {
-          year: toYearMonthDay(props.start).year,
-          month: toYearMonthDay(props.start).month,
-        }
-      : {
-          year: new Date().getFullYear(),
-          month: new Date().getMonth(),
-        }
+    const startYearMonthInWidget = this.getStartMonthYearInWidget(props)
+
     this.state = {
       ...startYearMonthInWidget,
       isExpanded: false,
@@ -76,6 +69,36 @@ class DatePicker extends React.Component<DatePickerProps, State> {
     if (validatedProps.end) {
       validateDateString(validatedProps.end)
     }
+  }
+
+  public getStartMonthYearInWidget(props?: DatePickerProps) {
+    // set start month and year of the widget based on the availability of start, end, max, or min props.
+    // if none of the props are available, set it to the current month and year.
+    const validatedProps = props || this.props
+    return validatedProps.start
+      ? {
+          year: toYearMonthDay(validatedProps.start).year,
+          month: toYearMonthDay(validatedProps.start).month,
+        }
+      : validatedProps.end
+      ? {
+          year: toYearMonthDay(validatedProps.end).year,
+          month: toYearMonthDay(validatedProps.end).month,
+        }
+      : validatedProps.min
+      ? {
+          year: toYearMonthDay(validatedProps.min).year,
+          month: toYearMonthDay(validatedProps.min).month,
+        }
+      : validatedProps.max
+      ? {
+          year: toYearMonthDay(validatedProps.max).year,
+          month: toYearMonthDay(validatedProps.max).month,
+        }
+      : {
+          year: new Date().getFullYear(),
+          month: new Date().getMonth(),
+        }
   }
 
   public changeMonth(diff: number) {

--- a/src/DatePicker/DatePicker.utils.ts
+++ b/src/DatePicker/DatePicker.utils.ts
@@ -1,4 +1,5 @@
 import moment from "moment"
+import { DatePickerProps } from "./DatePicker"
 
 export const months: string[] = [
   "January",
@@ -75,4 +76,40 @@ export const monthStartDay = (year: number, month: number): number => moment(toD
 
 export const daysInMonth = (month: number, year: number): number => {
   return moment(toDate(year, month, 2)).daysInMonth()
+}
+
+export const getStartMonthYearInWidget = (props?: DatePickerProps) => {
+  // set start month and year of the widget based on the availability of start, end, max, or min props.
+  // if none of the props are available or if there are no props, set it to the current month and year.
+  if (props) {
+    return props.start
+      ? {
+          year: toYearMonthDay(props.start).year,
+          month: toYearMonthDay(props.start).month,
+        }
+      : props.end
+      ? {
+          year: toYearMonthDay(props.end).year,
+          month: toYearMonthDay(props.end).month,
+        }
+      : props.min
+      ? {
+          year: toYearMonthDay(props.min).year,
+          month: toYearMonthDay(props.min).month,
+        }
+      : props.max
+      ? {
+          year: toYearMonthDay(props.max).year,
+          month: toYearMonthDay(props.max).month,
+        }
+      : {
+          year: new Date().getFullYear(),
+          month: new Date().getMonth(),
+        }
+  } else {
+    return {
+      year: new Date().getFullYear(),
+      month: new Date().getMonth(),
+    }
+  }
 }

--- a/src/DatePicker/__tests__/DatePicker.test.tsx
+++ b/src/DatePicker/__tests__/DatePicker.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "enzyme"
 import * as React from "react"
-import { changeMonth, toYearMonthDay } from "../../DatePicker/DatePicker.utils"
+import { changeMonth, toYearMonthDay, getStartMonthYearInWidget } from "../../DatePicker/DatePicker.utils"
 import { DatePicker as ThemelessDatePicker } from "../../index"
 import wrapDefaultTheme from "../../utils/wrap-default-theme"
 
@@ -24,5 +24,20 @@ describe("DatePicker Component", () => {
   })
   it("Changes the current month, going into the previous year", () => {
     expect(changeMonth(-1, { year: 2018, month: 0 })).toEqual({ year: 2017, month: 11 })
+  })
+  it("Returns current month and year for datepicker to open on initially, if no props are available", () => {
+    expect(getStartMonthYearInWidget()).toEqual({ year: new Date().getFullYear(), month: new Date().getMonth() })
+  })
+  it("Returns current month and year for datepicker to open on initially, if start, end, max and min are not available in props", () => {
+    expect(getStartMonthYearInWidget({ placeholder: "Pick a date" })).toEqual({
+      year: new Date().getFullYear(),
+      month: new Date().getMonth(),
+    })
+  })
+  it("Returns month and date of start/end/min/max for datepicker to open on initially, if it is available", () => {
+    expect(getStartMonthYearInWidget({ start: "1996-06-18" })).toEqual({ year: 1996, month: 6 })
+    expect(getStartMonthYearInWidget({ end: "1995-02-26" })).toEqual({ year: 1995, month: 2 })
+    expect(getStartMonthYearInWidget({ max: "1972-05-27" })).toEqual({ year: 1972, month: 5 })
+    expect(getStartMonthYearInWidget({ min: "1963-03-23" })).toEqual({ year: 1963, month: 3 })
   })
 })


### PR DESCRIPTION

Add the getStartMonthYearInWidget(props) method to Datepicker.tsx to set start month, year the datepicker should be opened to, based on the availability of start, end, max, min props. If no props are available, the current date is used.
Fixes #909

<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fixes #909

The datepicker component always opens on the current month and year when the start props is not available. Ideally, it should open on the month and year of any one of the props available, and should fallback to the current month and year only when none of the props are available.
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#909 
<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
