### PR TITLE
**Feature:** Handle onContextMenu on tree node

### DIFF
--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -24,6 +24,7 @@ const ChildTree: React.SFC<Props> = ({
   childNodes = [],
   droppableProps,
   onClick,
+  onContextMenu,
   onRemove,
   cursor,
   searchWords,
@@ -45,12 +46,24 @@ const ChildTree: React.SFC<Props> = ({
         }
       : undefined
 
+  const onNodeContextMenu = React.useMemo(
+    () =>
+      !disabled && onContextMenu
+        ? (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+            event.preventDefault()
+            onContextMenu(event)
+          }
+        : undefined,
+    [disabled, onContextMenu],
+  )
+
   return (
     <Container ref={forwardRef} disabled={Boolean(disabled)} hasChildren={hasChildren} {...props}>
       <TreeItem
         level={level}
         searchWords={searchWords}
         onNodeClick={onNodeClick}
+        onNodeContextMenu={onNodeContextMenu}
         highlight={Boolean(highlight)}
         hasChildren={hasChildren}
         isOpen={isOpen}

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -1,4 +1,4 @@
-The tree component renders a tree structure with collapsable nodes in a filetree-like design.
+The tree component renders a tree structure with collapsable nodes in a filetree-like design. Defined items in the tree can have a custom click and a context-click handler.
 
 ### Usage
 
@@ -26,6 +26,7 @@ import { Tree, OlapIcon } from "@operational/components"
               label: "Country",
               color: "primary",
               onClick: () => alert("country was clicked"),
+              onContextMenu: () => alert("country was right-clicked"),
               onRemove: () => alert("node is removed"),
               icon: OlapIcon,
               childNodes: [],

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -15,6 +15,7 @@ interface BaseTree {
   icon?: IconComponentType
   iconColor?: string
   onClick?: () => void
+  onContextMenu?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   cursor?: string
   onRemove?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   forwardRef?: (element?: HTMLElement | null) => any

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -63,6 +63,7 @@ interface TreeItemProps {
   color?: string
   cursor?: string
   onNodeClick?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onNodeContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void
   onRemove?: (e: React.MouseEvent<HTMLDivElement>) => void
 }
 
@@ -74,6 +75,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
   label,
   color,
   onNodeClick,
+  onNodeContextMenu,
   onRemove,
   hasChildren,
   isOpen,
@@ -81,7 +83,13 @@ const TreeItem: React.SFC<TreeItemProps> = ({
   cursor,
   searchWords = [],
 }) => (
-  <Header level={level} onClick={onNodeClick} highlight={Boolean(highlight)} cursor={cursor}>
+  <Header
+    level={level}
+    onClick={onNodeClick}
+    onContextMenu={onNodeContextMenu}
+    highlight={Boolean(highlight)}
+    cursor={cursor}
+  >
     {hasChildren &&
       React.createElement(isOpen ? ChevronDownIcon : ChevronRightIcon, {
         size: 11,


### PR DESCRIPTION
# Summary
Adds optional handling of `onContextMenu` event on a tree node

# Related issue
https://contiamo.atlassian.net/browse/PLAT-688

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
