### PR TITLE
**Fix:** trigger onOutsideClick for ContextMenu

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -103,6 +103,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   children,
   items,
   onClick,
+  onOutsideClick,
   disabled,
   width,
   open,
@@ -166,6 +167,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
           onClick={e => {
             e.stopPropagation()
             setIsOpen && setIsOpen(false)
+            if (onOutsideClick) {
+              onOutsideClick()
+            }
           }}
         />
       )}

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -7,12 +7,26 @@ import * as React from "react"
 import { ContextMenu, ContextMenuProps } from "@operational/components"
 
 const menuItems = [{ label: "Menu 1", onClick: () => alert("Menu 1 uses custom onClick function") }, "Menu 2", "Menu 3"]
+;<ContextMenu items={menuItems} onClick={item => alert(`clicked ${item.label}`)}>
+  <span>Click here</span>
+</ContextMenu>
+```
+
+It is also possible to detect a click outside the Context menu with a callback
+
+### Get a callback triggered on click outside of the Context menu
+
+```jsx
+import * as React from "react"
+import { Button, ContextMenu, ContextMenuProps } from "@operational/components"
+
+const menuItems = ["Item 1", "Item 2", "Item 3"]
 ;<ContextMenu
   items={menuItems}
   onClick={item => alert(`clicked ${item.label}`)}
   onOutsideClick={() => alert("Clicked outside the menu!")}
 >
-  <span>Click here</span>
+  <Button color="primary">Click here</Button>
 </ContextMenu>
 ```
 

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -7,7 +7,11 @@ import * as React from "react"
 import { ContextMenu, ContextMenuProps } from "@operational/components"
 
 const menuItems = [{ label: "Menu 1", onClick: () => alert("Menu 1 uses custom onClick function") }, "Menu 2", "Menu 3"]
-;<ContextMenu items={menuItems} onClick={item => alert(`clicked ${item.label}`)}>
+;<ContextMenu
+  items={menuItems}
+  onClick={item => alert(`clicked ${item.label}`)}
+  onOutsideClick={() => alert("Clicked outside the menu!")}
+>
   <span>Click here</span>
 </ContextMenu>
 ```

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -12,9 +12,9 @@ const menuItems = [{ label: "Menu 1", onClick: () => alert("Menu 1 uses custom o
 </ContextMenu>
 ```
 
-It is also possible to detect a click outside the Context menu with a callback
+### Trigger a Callback on Outside Click
 
-### Get a callback triggered on click outside of the Context menu
+It is also possible to detect a click outside the `ContextMenu` and do something as below. Open the context menu and click outside to see this behavior.
 
 ```jsx
 import * as React from "react"


### PR DESCRIPTION
# Summary
This PR fixes `onOutsideClick` callback not being triggered by the `<ContextMenu/>` even if assigned by the library consumer

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
