### PR TITLE
**Feature:** improve ContextMenu API

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -8,7 +8,10 @@ import { useUniqueId } from "../useUniqueId"
 import { useListbox } from "../useListbox"
 
 export interface ContextMenuProps extends DefaultProps {
-  children: React.ReactNode | ((isActive: boolean) => React.ReactNode)
+  /** Optional reference for the menu container  */
+  containerRef?: React.RefObject<HTMLDivElement>
+  /** Children of the component  */
+  children?: React.ReactNode | ((isActive: boolean) => React.ReactNode)
   /** Specify whether the menu items are visible. Overrides internal open state that triggers on click. */
   open?: boolean
   /** Condensed mode */
@@ -46,7 +49,7 @@ export interface State {
 const isChildAFunction = (children: ContextMenuProps["children"]): children is (isActive: boolean) => React.ReactNode =>
   typeof children === "function"
 
-const Container = styled("div")<{ side: ContextMenuProps["align"]; isOpen: boolean }>(
+const Container = styled.div<{ side: ContextMenuProps["align"]; isOpen: boolean }>(
   ({ isOpen, theme, side: align }) => ({
     label: "contextmenu",
     cursor: "pointer",
@@ -60,7 +63,7 @@ const Container = styled("div")<{ side: ContextMenuProps["align"]; isOpen: boole
   }),
 )
 
-const MenuContainer = styled("div")<{
+const MenuContainer = styled.div<{
   embedChildrenInMenu?: ContextMenuProps["embedChildrenInMenu"]
   numRows: number
   align: ContextMenuProps["align"]
@@ -94,6 +97,7 @@ const InvisibleOverlay = styled("div")(({ theme }) => ({
 }))
 
 const ContextMenu: React.FC<ContextMenuProps> = ({
+  containerRef,
   id,
   align = "left",
   embedChildrenInMenu = false,
@@ -200,6 +204,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         </div>
         <MenuContainer
           {...listboxProps}
+          ref={containerRef}
           isOpen={Boolean(isOpen)}
           condensed={Boolean(condensed)}
           numRows={items.length}

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -154,22 +154,28 @@ It is possible to retrieve the rect dimensions of the ContextMenu container when
 import * as React from "react"
 import { Button, ContextMenu, ContextMenuProps, Code } from "@operational/components"
 
-const menuRef = React.createRef<HTMLDivElement>();
-const [rect, setRect] = React.useState<DOMRect>()
-
-React.useEffect(() => {
-  if (menuRef.current) {
-    setRect(menuRef.current.getBoundingClientRect());
-  }
-});
-
 const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
-; <>
-    <Code>
-        {`Rect: ${JSON.stringify(rect, null, 2)}`}
-    </Code>
-    <ContextMenu containerRef={menuRef} items={menuItems} onClick={() => alert("clicked")}>
-    <Button>Click here</Button>
-    </ContextMenu>
-  </>
+
+const Wrapper = () => {
+  const menuRef = React.createRef<HTMLDivElement>();
+  const [rect, setRect] = React.useState<DOMRect>();
+
+  React.useLayoutEffect(() => {
+    if (menuRef.current) {
+      setRect(menuRef.current.getBoundingClientRect());
+    }
+  }, [menuRef.current]);
+
+  return (
+    <>
+      <Code>
+          {`Rect: ${JSON.stringify(rect, null, 2)}`}
+      </Code>
+      <ContextMenu open containerRef={menuRef} items={menuItems} onClick={() => alert("clicked")}>
+        <Button>Click here</Button>
+      </ContextMenu>
+    </>
+  )
+}
+;<Wrapper/>
 ```

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -145,3 +145,31 @@ const menuItems = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(it
   <div>Long list of options here</div>
 </ContextMenu>
 ```
+
+#### Retrieve the size and position of the context menu container
+
+It is possible to retrieve the rect dimensions of the ContextMenu container when it is rendered on the screen
+
+```jsx
+import * as React from "react"
+import { Button, ContextMenu, ContextMenuProps, Code } from "@operational/components"
+
+const menuRef = React.createRef<HTMLDivElement>();
+const [rect, setRect] = React.useState<DOMRect>()
+
+React.useEffect(() => {
+  if (menuRef.current) {
+    setRect(menuRef.current.getBoundingClientRect());
+  }
+}, [menuRef.current, rect]);
+
+const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
+; <>
+    <Code>
+        {`Rect: ${JSON.stringify(rect, null, 2)}`}
+    </Code>
+    <ContextMenu containerRef={menuRef} items={menuItems} onClick={() => alert("clicked")}>
+    <Button>Click here</Button>
+    </ContextMenu>
+  </>
+```

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -155,16 +155,16 @@ import * as React from "react"
 import { Button, ContextMenu, ContextMenuProps, Code } from "@operational/components"
 
 const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
+const menuRef = React.createRef<HTMLDivElement>();
 
 const Wrapper = () => {
-  const menuRef = React.createRef<HTMLDivElement>();
   const [rect, setRect] = React.useState<DOMRect>();
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     if (menuRef.current) {
       setRect(menuRef.current.getBoundingClientRect());
     }
-  }, [menuRef.current]);
+  }, []);
 
   return (
     <>

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -161,7 +161,7 @@ React.useEffect(() => {
   if (menuRef.current) {
     setRect(menuRef.current.getBoundingClientRect());
   }
-}, [menuRef.current, rect]);
+});
 
 const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
 ; <>


### PR DESCRIPTION
# Summary
Improves the API of the <ContextMenu> component by:
1. Making children of the component option (can be useful for a context menu fully controlled externally)
1. providing an option ref for a menu items container (can be used to measure the size of the menu, rendered on the screen, for better positioning)

# To do: 
- [ ] rebase on master after merging https://github.com/contiamo/operational-ui/pull/1128 to avoid conflicts

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
