### PR TITLE
**Fix:** tab focus steal

### DIFF
--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -105,3 +105,34 @@ const MyComponent = () => {
 
 ;<MyComponent />
 ```
+
+### Focusability
+
+The Tabs should be keyboard accessible, but _not_ steal focus away from an text areas they contain. To test this, type in one text area, change tabs a few times, and try to type again. The tabs should not steal focus from the textarea.
+
+```jsx
+import * as React from "react"
+import { styled, Tabs, Textarea, OlapIcon } from "@operational/components"
+
+const MyComponent = () => {
+  const [activeTab, setActiveTab] = React.useState(0)
+  const [textareaValue, setTextareaValue] = React.useState("")
+  const tabContents = [
+    <Textarea fullWidth height={250} onChange={setTextareaValue} value={textareaValue} />,
+    <Textarea fullWidth height={250} onChange={setTextareaValue} value={textareaValue} />,
+  ]
+
+  return (
+    <Tabs
+      scroll={false}
+      tabs={[{ title: "OLAP", icon: <OlapIcon /> }, { title: "Inventory" }]}
+      active={activeTab}
+      onActivate={setActiveTab}
+    >
+      <>{tabContents[activeTab]}</>
+    </Tabs>
+  )
+}
+
+;<MyComponent />
+```

--- a/src/Tabs/README.md
+++ b/src/Tabs/README.md
@@ -6,9 +6,10 @@ Tabs component implemented according to [WAI-ARIA specification](https://www.w3.
 
 ```jsx
 import * as React from "react"
-import { Tabs, OlapIcon } from "@operational/components"
+import { Tabs, OlapIcon, Textarea } from "@operational/components"
 
 const MyComponent = () => {
+  const [textareaValue, setTextareaValue] = React.useState("")
   const [tabs, setTabs] = React.useState([
     {
       title: "tab 1 tab 1 tab 1 tab 1 tab 1 tab 1 tab 1 tab 1",
@@ -60,13 +61,8 @@ const MyComponent = () => {
   return (
     <div style={{ height: "200px" }}>
       <Tabs tabs={tabs} active={active} onActivate={setActive} onClose={onClose} onInsert={onInsert}>
-        <p>Lorem ipsum {active + 1}</p>
-        <p>Lorem ipsum {active + 1}</p>
-        <p>Lorem ipsum {active + 1}</p>
-        <p>Lorem ipsum {active + 1}</p>
-        <p>Lorem ipsum {active + 1}</p>
-        <p>Lorem ipsum {active + 1}</p>
-        <p>Lorem ipsum {active + 1}</p>
+        Tab {active + 1}
+        <Textarea fullWidth height={143} onChange={setTextareaValue} value={textareaValue} />
       </Tabs>
     </div>
   )
@@ -100,37 +96,6 @@ const MyComponent = () => {
         <>Tab {activeTab}</>
       </Tabs>
     </Sidebar>
-  )
-}
-
-;<MyComponent />
-```
-
-### Focusability
-
-The Tabs should be keyboard accessible, but _not_ steal focus away from an text areas they contain. To test this, type in one text area, change tabs a few times, and try to type again. The tabs should not steal focus from the textarea.
-
-```jsx
-import * as React from "react"
-import { styled, Tabs, Textarea, OlapIcon } from "@operational/components"
-
-const MyComponent = () => {
-  const [activeTab, setActiveTab] = React.useState(0)
-  const [textareaValue, setTextareaValue] = React.useState("")
-  const tabContents = [
-    <Textarea fullWidth height={250} onChange={setTextareaValue} value={textareaValue} />,
-    <Textarea fullWidth height={250} onChange={setTextareaValue} value={textareaValue} />,
-  ]
-
-  return (
-    <Tabs
-      scroll={false}
-      tabs={[{ title: "OLAP", icon: <OlapIcon /> }, { title: "Inventory" }]}
-      active={activeTab}
-      onActivate={setActiveTab}
-    >
-      <>{tabContents[activeTab]}</>
-    </Tabs>
   )
 }
 

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -181,6 +181,7 @@ const Tabs: React.FC<TabsProps> = ({
               aria-selected={false}
               condensed={true}
               onMouseDown={e => {
+                userAction.current = true
                 e.preventDefault()
                 onInsert(tabs.length - 1)
               }}

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -65,9 +65,9 @@ const Tabs: React.FC<TabsProps> = ({
 
   const onKeyDown = React.useCallback(
     (event: React.KeyboardEvent) => {
-      userAction.current = true
       switch (event.key) {
         case "ArrowRight":
+          userAction.current = true
           event.preventDefault()
           if (active + 1 >= tabs.length) {
             onActivate(0)
@@ -76,6 +76,7 @@ const Tabs: React.FC<TabsProps> = ({
           }
           break
         case "ArrowLeft":
+          userAction.current = true
           event.preventDefault()
           if (active - 1 < 0) {
             onActivate(tabs.length - 1)
@@ -84,20 +85,24 @@ const Tabs: React.FC<TabsProps> = ({
           }
           break
         case "Home":
+          userAction.current = true
           event.preventDefault()
           onActivate(0)
           break
         case "End":
+          userAction.current = true
           event.preventDefault()
           onActivate(tabs.length - 1)
           break
         case "Delete":
+          userAction.current = true
           event.preventDefault()
           if (onClose) {
             onClose(active)
           }
           break
         case "Enter":
+          userAction.current = true
           // There is no insert on some modern keyboards.
           // You can use `fn` + `enter` to get it on Mac keyboard, it will be reported as Enter.
           // Can be differentiated from enter using this check `e.nativeEvent.code === "NumpadEnter"`
@@ -136,7 +141,6 @@ const Tabs: React.FC<TabsProps> = ({
         <TabScroll ref={tabScrollRef}>
           {tabs.map(({ title, icon }, i) => {
             const onClick = () => {
-              userAction.current = true
               onActivate(i)
             }
             return (
@@ -178,7 +182,6 @@ const Tabs: React.FC<TabsProps> = ({
               condensed={true}
               onMouseDown={e => {
                 e.preventDefault()
-                userAction.current = true
                 onInsert(tabs.length - 1)
               }}
             >


### PR DESCRIPTION
This PR fixes this:

![Contiamo](https://user-images.githubusercontent.com/9947422/61127224-f4cf4580-a4ae-11e9-892c-a7fc52593251.gif)

# [Click Here for Demo](https://deploy-preview-1131--operational-ui.netlify.com/#!/Tabs/5)