### PR TITLE
**Fix:** Make Accordion icons smaller

### DIFF
--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -99,7 +99,7 @@ const AccordionSection: React.FC<AccordionSectionProps> = ({
         onBlur={() => setFocusFlag(false)}
       >
         {title}
-        {_expanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+        {_expanded ? <ChevronUpIcon size={12} /> : <ChevronDownIcon size={12} />}
       </Header>
       <Panel id={contentId} aria-labelledby={titleId} hidden={!_expanded}>
         {_expanded && isFunction(children) ? children() : children}


### PR DESCRIPTION
18x18 was a bit too big. Let's make the chevrons smaller.

**Before**
![image](https://user-images.githubusercontent.com/9947422/61144397-15aa9180-a4d5-11e9-8a37-84ff97b0ef0f.png)

**After**
![image](https://user-images.githubusercontent.com/9947422/61144404-1a6f4580-a4d5-11e9-8b26-4480ec83fed9.png)
