### PR TITLE
**Fix** Tabs onActive callback called twice for each action

### DIFF
--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -153,7 +153,6 @@ const Tabs: React.FC<TabsProps> = ({
                 id={`TabHeader-${uid}-${i}`}
                 key={i}
                 onClick={onClick}
-                onFocus={onClick}
                 ref={i === active ? activeTab : undefined}
               >
                 <TitleIconWrapper>


### PR DESCRIPTION
I'm super lazy today. I don't understand why checks for previous PR failed https://github.com/contiamo/operational-ui/pull/1122. **I will simply open new PR to run tests and deploy preview.**

---

Remove onFocus prop in TabHeader component

<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Fixes #1113
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#1113
<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
- [ ] Paste this code and check if action calls once
```
<Tabs tabs={tabs} active={active} onActivate={(x) => { console.log(`onActivate ${x}`); setActive(x);} } onClose={onClose} onInsert={onInsert}>
```



Tester 2

- [ ] Things look good on the demo.
- [ ] Paste this code and check if action calls once
```
<Tabs tabs={tabs} active={active} onActivate={(x) => { console.log(`onActivate ${x}`); setActive(x);} } onClose={onClose} onInsert={onInsert}>
```
