### PR TITLE
**Fix:** Trigger the top-level onClick if Context Menu item has own handler

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -157,7 +157,6 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   const handleSelect = React.useCallback(() => {
     if (currentItem && currentItem.onClick) {
       currentItem.onClick(currentItem)
-      return
     }
     if (currentItem && onClick) {
       onClick(currentItem)


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Implements triggering the menu-level `onClick` handler in case if the menu item has own `onClick` handler

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
