### PR TITLE
**Fix** Trigger top-level onClick even if handler assigned for the item itself

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -229,7 +229,6 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
                 }
                 if (!isString(item) && item.onClick) {
                   item.onClick(makeItem(item))
-                  return
                 }
                 if (onClick) {
                   onClick(makeItem(item))


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Triggers the menu-level onClick for the `<ContextMenu/>` even if the `onClick` handler is assigned to the menu item itself.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
