### PR TITLE
**Fix:** Allow using a react component as a DataTable cell

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -40,6 +40,10 @@ export interface DataTableProps<Columns, Rows> {
   className?: string
 }
 
+const stringifyIfNeeded = (value: any) => {
+  return typeof value === "boolean" ? String(value) : value
+}
+
 export function DataTable<Columns extends any[][], Rows extends any[][]>({
   columns,
   rows,
@@ -121,7 +125,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
                 cell={cellIndex + 1}
                 height={rowHeight}
               >
-                {truncate(maxCharactersInCell)(String(cell))}
+                {truncate(maxCharactersInCell)(stringifyIfNeeded(cell))}
               </Cell>
             ))}
         </Row>

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -41,6 +41,7 @@ export interface DataTableProps<Columns, Rows> {
 }
 
 const stringifyIfNeeded = (value: any) => {
+  // We compare booleans like this and without typeof for perf
   return value === true || value === false ? String(value) : value
 }
 

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -41,7 +41,7 @@ export interface DataTableProps<Columns, Rows> {
 }
 
 const stringifyIfNeeded = (value: any) => {
-  return typeof value === "boolean" ? String(value) : value
+  return value === true || value === false ? String(value) : value
 }
 
 export function DataTable<Columns extends any[][], Rows extends any[][]>({

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -10,6 +10,7 @@ Supply a `height` prop to limit the height of the table.
 Additionally, you can supply a component as a cell to customize the styling and functionality.
 
 ```jsx
+import * as React from "react"
 import { DataTable, DataTableSelect, DataTableInput, Checkbox, styled } from "@operational/components"
 
 const CustomCell = styled.span`
@@ -29,7 +30,7 @@ const CustomCell = styled.span`
     [String(Math.random()).repeat(1000), "Imogen Mason", "Good Stuff", true],
     [String(Math.random()).repeat(1000), "Fabien Bernard", "🥖🥐🧀🍷", false],
     [String(Math.random()).repeat(1000), "STEREO BOOSTER", "☕️", true],
-    [String(Math.random()).repeat(1000), <CustomCell>{"Mischa Potomin"}</CustomCell>, "null", false],
+    [String(Math.random()).repeat(1000), <CustomCell>Mischa Potomin</CustomCell>, "null", false],
     [String(Math.random()).repeat(1000), "Tejas Kumar", "🍗🍖🥓🥩", true],
   ]}
 />
@@ -40,6 +41,7 @@ const CustomCell = styled.span`
 Sometimes, we wish to render a _lot_ more data and have more of it visible. For this, we set `rowHeight="compact"` to enable compact mode.
 
 ```jsx
+import * as React from "react"
 import { DataTable, DataTableSelect, DataTableInput, Checkbox } from "@operational/components"
 ;<DataTable
   height={225}

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -5,10 +5,17 @@ Our DataTable is used to render tabular data structures. For a basic use case, g
 - `columns` is an array (X) of arrays (Y), where X contains a column, and Y contains a stack of headers in each column.
 - `rows` is an array (A) of arrays (B), where A is the entire row, and B is a single cell.
 
-Additionally, supply a `height` prop to limit the height of the table.
+Supply a `height` prop to limit the height of the table.
+
+Additionally, you can supply a component as a cell to customize the styling and functionality.
 
 ```jsx
-import { DataTable, DataTableSelect, DataTableInput, Checkbox } from "@operational/components"
+import { DataTable, DataTableSelect, DataTableInput, Checkbox, styled } from "@operational/components"
+
+const CustomCell = styled.span`
+  color: red;
+`
+
 ;<DataTable
   columns={[
     [
@@ -22,7 +29,7 @@ import { DataTable, DataTableSelect, DataTableInput, Checkbox } from "@operation
     [String(Math.random()).repeat(1000), "Imogen Mason", "Good Stuff", true],
     [String(Math.random()).repeat(1000), "Fabien Bernard", "🥖🥐🧀🍷", false],
     [String(Math.random()).repeat(1000), "STEREO BOOSTER", "☕️", true],
-    [String(Math.random()).repeat(1000), "Mischa Potomin", "null", false],
+    [String(Math.random()).repeat(1000), <CustomCell>{"Mischa Potomin"}</CustomCell>, "null", false],
     [String(Math.random()).repeat(1000), "Tejas Kumar", "🍗🍖🥓🥩", true],
   ]}
 />


### PR DESCRIPTION
# Summary
Fixes the regression, introduced by https://github.com/contiamo/operational-ui/pull/1132/ and allows back using a React component as a custom cell for the `<DataTable/>` instead of getting `[object Object]`

# Related issue
https://contiamo.atlassian.net/browse/PLAT-732

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
