### PR TITLE
**Fix:** Offset pseudo-borders in inputs

### DIFF
--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -101,6 +101,7 @@ const Label = styled("label")<{ condensed: CheckboxProps["condensed"] }>`
     border-radius: ${props => props.theme.borderRadius}px;
     background-color: #f2f2f2;
     box-shadow: 0 0 0 1px ${props => props.theme.color.border.default};
+    margin: 0 1px; /* offset box shadow */
     border: none;
   }
 `

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -91,6 +91,7 @@ const Field = styled("input")<{
     opacity: disabled ? 0.6 : 1.0,
     border: "none",
     boxShadow: `0 0 0 1px ${isError ? theme.color.error : theme.color.border.default}`,
+    margin: "0 1px", // offset box-shadow like a border
     outline: "none",
     appearance: "none",
     color: preset ? theme.color.text.dark : theme.color.text.default,


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR fixes odd cases where inputs are cut on the left side because the `box-shadow` is _under_ the parent wrapper.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
#1157 

<!-- Paste the github issue here -->

# To be tested
- [ ] No regression on `Input`
- [ ] No regression on `Checkbox`

Me
- [x] No related error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
