### PR TITLE
**Fix:** Tree icon shrinkage

### DIFF
--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -105,7 +105,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       React.createElement(icon, {
         size: 12,
         color: iconColor || "color.text.lighter",
-        style: { marginLeft: 0, marginRight: 8 },
+        style: { marginLeft: 0, marginRight: 8, flex: "0 0 15px" },
       })}
     <Label hasChildren={hasChildren}>
       <Highlighter


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
When there's a really long label in `TreeItem`, the icon used to shrink because flexbox. Let's fix it.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
Fixes #1155 

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No new error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
