### PR TITLE
**Fix:** for TypeError: Cannot read property 'length' of null

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -146,7 +146,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
         >
           {rows[index] &&
             rows[index].map((cell, cellIndex) => {
-              const cellString = stringifyIfNeeded(cell)
+              const cellMaybeString = stringifyIfNeeded(cell)
               return (
                 <Cell
                   rowIndex={index}
@@ -155,10 +155,10 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
                   cell={cellIndex + 1}
                   height={rowHeight}
                 >
-                  {truncate(maxCharactersInCell)(cellString)}
-                  {cellString.length > maxCharactersInCell && (
+                  {truncate(maxCharactersInCell)(cellMaybeString)}
+                  {typeof cellMaybeString === "string" && cellMaybeString.length > maxCharactersInCell && (
                     /* we don't want this to cover the border-bottom */
-                    <ViewMoreToggle height={rowHeight - 1} onClick={openViewMore(cellString)}>
+                    <ViewMoreToggle height={rowHeight - 1} onClick={openViewMore(cellMaybeString)}>
                       <ChevronDownIcon color={Boolean(viewMorePopup) ? "primary" : undefined} size={10} />
                     </ViewMoreToggle>
                   )}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

The problem is that data in Row is any, and this any flows through throw the whole code of DataTable and TypeScript will not help. Can we restrict DataTable to `string | number | null | boolean`?

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
