### PR TITLE
**Fix:** PLAT-764 Prevent scrolls for the content of the anchored Modal

### DIFF
--- a/src/Modal/Modal.styled.ts
+++ b/src/Modal/Modal.styled.ts
@@ -73,5 +73,6 @@ export const Actions = styled.div<{ childCount: number }>`
 export const ContentWrapper = styled.div`
   overflow: auto;
   height: 100%;
+  display: grid;
   ${({ theme }) => customScrollbar({ theme })}
 `


### PR DESCRIPTION
# Summary
Allows making the content container the only scrollable part of the Modal

<img width="669" alt="Screenshot 2019-08-06 at 18 02 25" src="https://user-images.githubusercontent.com/639406/62556090-775fe080-b874-11e9-9207-44fce8ec32d8.png">


# Related issue
https://contiamo.atlassian.net/browse/PLAT-764

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
