### PR TITLE
**Fix:** Adjust close button on Tabs component

### DIFF
--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -59,6 +59,7 @@ export const TabHeader = styled(SectionHeader, {
   border: solid 1px ${({ theme }) => theme.color.separators.default};
   border-top: none;
   border-left: none;
+  padding-right: ${({ theme }) => theme.space.base}px;
   ${props =>
     props["aria-selected"]
       ? `border-bottom: 1px solid ${expandColor(props.theme, props.color) || props.theme.color.background.lighter}; 
@@ -72,11 +73,6 @@ export const TabHeader = styled(SectionHeader, {
          }
          & svg {
           color: ${props.theme.color.text.action};
-         }
-         /* close icon */
-         > svg {
-          color: ${props.theme.color.text.dark};
-          pointer-events: all;
          }
          `
       : ""}
@@ -156,6 +152,23 @@ export const TitleWrapper = styled.span`
 export const TabIcon = styled.span`
   margin-right: ${({ theme }) => theme.space.small}px;
   pointer-events: none;
+`
+
+export const CloseIcon = styled.span`
+  pointer-events: all;
+  &:hover {
+    background: ${({ theme }) => theme.color.separators.default};
+  }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  min-width: 32px;
+  border-radius: 32px;
+  & svg {
+    color: ${({ theme }) => theme.color.text.default} !important;
+    cursor: pointer !important;
+  }
 `
 
 export const ScrollButtons = styled.div`

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -14,6 +14,7 @@ import {
   TabScroll,
   TitleIconWrapper,
   TitleWrapper,
+  CloseIcon,
 } from "./Tabs.styled"
 
 export interface Tab {
@@ -162,14 +163,14 @@ const Tabs: React.FC<TabsProps> = ({
                   <TitleWrapper title={title}>{title}</TitleWrapper>
                 </TitleIconWrapper>
                 {onClose && (
-                  <NoIcon
-                    right
-                    size={9}
+                  <CloseIcon
                     onClick={e => {
                       e.stopPropagation()
                       onClose(i)
                     }}
-                  />
+                  >
+                    <NoIcon size={9} />
+                  </CloseIcon>
                 )}
               </TabHeader>
             )


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Fix click area for close button for tabs

<img width="264" alt="Screenshot 2019-08-07 at 17 31 53" src="https://user-images.githubusercontent.com/179534/62636159-4dbcbd00-b939-11e9-9526-7d7817a8ecc9.png">

# Related issue

https://contiamo.atlassian.net/browse/UI-113

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
