### PR TITLE
Don't trigger hotkeys for buttons

### DIFF
--- a/styleguide/ComponentsListRenderer.tsx
+++ b/styleguide/ComponentsListRenderer.tsx
@@ -82,7 +82,7 @@ const ComponentsListRenderer: React.FC<ComponentsListRendererProps> = ({ items }
 
   React.useEffect(() => {
     const handleArrow = (e: KeyboardEvent) => {
-      if (["INPUT", "TEXTAREA"].includes(document.activeElement.tagName)) {
+      if (["INPUT", "TEXTAREA", "BUTTON"].includes(document.activeElement.tagName)) {
         return
       }
       if (e.key === "ArrowLeft") {

--- a/styleguide/TableOfContentsRenderer.tsx
+++ b/styleguide/TableOfContentsRenderer.tsx
@@ -43,7 +43,7 @@ const TableOfContentsRenderer: React.SFC<TableOfContentsRendererProps> = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (["INPUT", "TEXTAREA"].includes(document.activeElement.tagName)) {
+      if (["INPUT", "TEXTAREA", "BUTTON"].includes(document.activeElement.tagName)) {
         return
       }
       if (e.key === "/" && inputRef.current) {


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Don't trigger hotkeys in styleguidist for buttons

# Related issue

N/A

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
