### PR TITLE
**Fix:** Remove sidenav border in dark mode.

### DIFF
--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -28,12 +28,10 @@ const Container = styled("div")<SidenavProps>(({ theme, compact, dark }) => {
     overflow: "auto",
     width: compact ? theme.compactSidebarWidth : theme.sidebarWidth,
     height: "100%",
-    ...(dark
-      ? {}
-      : {
-          borderRight: "1px solid",
-          borderRightColor: theme.color.separators.default,
-        }),
+    ...(!dark && {
+      borderRight: "1px solid",
+      borderRightColor: theme.color.separators.default,
+    }),
 
     ".operational-ui__sidenav-item_end": {
       marginTop: "auto",

--- a/src/Sidenav/Sidenav.tsx
+++ b/src/Sidenav/Sidenav.tsx
@@ -28,8 +28,12 @@ const Container = styled("div")<SidenavProps>(({ theme, compact, dark }) => {
     overflow: "auto",
     width: compact ? theme.compactSidebarWidth : theme.sidebarWidth,
     height: "100%",
-    borderRight: "1px solid",
-    borderRightColor: theme.color.separators.default,
+    ...(dark
+      ? {}
+      : {
+          borderRight: "1px solid",
+          borderRightColor: theme.color.separators.default,
+        }),
 
     ".operational-ui__sidenav-item_end": {
       marginTop: "auto",


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

https://contiamo.atlassian.net/browse/PLAT-811

Grey border on the right of the sidebar is now only there if the sidenav has a white background - in dark mode, it is gone.

![image](https://user-images.githubusercontent.com/14272822/62859210-c9818580-bcfc-11e9-8a63-5871b2d06ea6.png)

![image](https://user-images.githubusercontent.com/14272822/62859202-bf5f8700-bcfc-11e9-94c6-ea6d823431b3.png)

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
