### PR TITLE
**Fix:** Fix DataTable cell overflow.

### DIFF
--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -48,6 +48,7 @@ export const Cell = styled.div<{
   color: ${({ theme }) => theme.color.text.default};
   grid-column: ${({ cell }) => cell};
   background-color: ${({ theme, isEvenRow }) => (isEvenRow ? theme.color.background.almostWhite : theme.color.white)};
+  overflow: hidden;
 `
 
 export const HeaderRow = styled.div<{


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

The cell borders in `DataTableInput` were broken. 

I noticed an additional problem of text overflowing the cells: 
![image](https://user-images.githubusercontent.com/14272822/62946112-6406c500-bde0-11e9-84e2-efe5241f0a11.png)

Fixing this fixed the other issues as well.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
