### PR TITLE
**Fix:** Accordion panel overflow.

### DIFF
--- a/src/Accordion/README.md
+++ b/src/Accordion/README.md
@@ -44,3 +44,82 @@ const MyComponent = () => {
 
 ;<MyComponent />
 ```
+
+### With tree
+
+```jsx
+import * as React from "react"
+import { Accordion, AccordionSection, Tree, OlapIcon } from "@operational/components"
+
+const MyComponent = () => {
+  const [expanded, setExpanded] = React.useState([true, false, false])
+  const onToggle = index => {
+    const newExpanded = [...expanded]
+    newExpanded[index] = !newExpanded[index]
+    setExpanded(newExpanded)
+  }
+  return (
+    <div style={{ height: 400, width: 200 }}>
+      <Accordion expanded={expanded} onToggle={onToggle}>
+        <AccordionSection title="Section 1">
+          <Tree
+            trees={[
+              {
+                label: "ERP",
+                tag: "OR",
+                childNodes: [
+                  {
+                    label: "Region",
+                    initiallyOpen: true,
+                    onDoubleClick: () => alert("woah you double clicked region amazing"),
+                    childNodes: [
+                      {
+                        label: "City",
+                        icon: OlapIcon,
+                        iconColor: "primary",
+                        disabled: true,
+                        childNodes: [],
+                      },
+                      {
+                        label: "Country",
+                        color: "primary",
+                        onClick: () => alert("country was clicked"),
+                        onContextMenu: () => alert("country was right-clicked"),
+                        onRemove: () => alert("node is removed"),
+                        icon: OlapIcon,
+                        childNodes: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                label: "Legal Entity (with some more text to check overflow)",
+                tag: "D2",
+                initiallyOpen: true,
+                childNodes: [
+                  {
+                    label: "Limited Liability Company",
+                    icon: OlapIcon,
+                    childNodes: [],
+                  },
+                  {
+                    label: "Inc.",
+                    icon: OlapIcon,
+                    color: "#2C363F",
+                    childNodes: [],
+                  },
+                ],
+              },
+            ]}
+          />
+        </AccordionSection>
+        <AccordionSection title="Section 2">Content 2</AccordionSection>
+        <AccordionSection title="Section 3">Content 3</AccordionSection>
+      </Accordion>
+    </div>
+  )
+}
+
+;<MyComponent />
+```

--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -42,7 +42,7 @@ Header.defaultProps = { role: "button", "aria-disabled": false }
 const Panel = styled.div`
   label: AccordionPanel;
   /* we need it because of overflow: hidden; above */
-  overflow: unset;
+  overflow: auto;
   height: 100%;
   padding: ${({ theme }) => theme.space.element}px;
   background-color: ${({ theme }) => theme.color.white};

--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -42,7 +42,7 @@ Header.defaultProps = { role: "button", "aria-disabled": false }
 const Panel = styled.div`
   label: AccordionPanel;
   /* we need it because of overflow: hidden; above */
-  overflow: auto;
+  overflow: unset;
   height: 100%;
   padding: ${({ theme }) => theme.space.element}px;
   background-color: ${({ theme }) => theme.color.white};

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -132,12 +132,15 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       cursor={cursor}
       tabIndex={0}
     >
-      {hasChildren &&
-        React.createElement(isOpen ? ChevronDownIcon : ChevronRightIcon, {
-          size: 11,
-          left: true,
-          color: "color.text.action",
-        })}
+      {hasChildren && (
+        <div style={{ flexShrink: 0 }}>
+          {React.createElement(isOpen ? ChevronDownIcon : ChevronRightIcon, {
+            size: 11,
+            left: true,
+            color: "color.text.action",
+          })}
+        </div>
+      )}
       {tag && (
         <NameTag condensed left color={color}>
           {tag}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Strange behaviour in the workbench sidebar datasources tree traced back to the `overflow` CSS property in the AccordionSection.


# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
