### PR TITLE
Add hover behaviour to chevrons in accordion section headers.

### DIFF
--- a/src/Accordion/README.md
+++ b/src/Accordion/README.md
@@ -6,7 +6,7 @@ Accordion component implemented (mostly) according to [WAI-ARIA specification](h
 
 ```jsx
 import * as React from "react"
-import { Accordion, AccordionSection } from "@operational/components"
+import { Accordion, AccordionSection, AddIcon } from "@operational/components"
 
 const MyComponent = () => {
   const [expanded, setExpanded] = React.useState([true, false, false])
@@ -15,10 +15,32 @@ const MyComponent = () => {
     newExpanded[index] = !newExpanded[index]
     setExpanded(newExpanded)
   }
+
+  const Title = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    padding-right: 32px;
+    align-items: center;
+  `
+
   return (
     <div style={{ height: 400 }}>
       <Accordion expanded={expanded} onToggle={onToggle}>
-        <AccordionSection title="Section 1">
+        <AccordionSection
+          title={
+            <Title>
+              Section 1
+              <AddIcon
+                size={16}
+                color="primary"
+                onClick={() => {
+                  console.log("Add")
+                }}
+              />
+            </Title>
+          }
+        >
           Content 1<br />
           Content 1<br />
           Content 1<br />

--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -108,7 +108,13 @@ const AccordionSection: React.FC<AccordionSectionProps> = ({
         onBlur={() => setFocusFlag(false)}
       >
         {title}
-        <IconWrapper>{_expanded ? <ChevronUpIcon size={12} /> : <ChevronDownIcon size={12} />}</IconWrapper>
+        <IconWrapper>
+          {_expanded ? (
+            <ChevronUpIcon size={12} onClick={() => _toggleSection(_index)} />
+          ) : (
+            <ChevronDownIcon size={12} onClick={() => _toggleSection(_index)} />
+          )}
+        </IconWrapper>
       </Header>
       <Panel id={contentId} aria-labelledby={titleId} hidden={!_expanded}>
         {_expanded && isFunction(children) ? children() : children}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add hover behaviour to chevrons in accordion section headers.
https://contiamo.atlassian.net/browse/UI-114

Relies on #1195 

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
