### PR TITLE
**Fix**: Add hover state to the plus tab button

### DIFF
--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -116,7 +116,7 @@ TabHeader.defaultProps = {
 }
 
 export const TabButton = styled(SectionHeader, {
-  shouldForwardProp: prop => !(prop === "leftMargin" || prop === "as"),
+  shouldForwardProp: prop => !(prop === "leftMargin" || prop === "as" || prop === "isPlusButton"),
 })<{ as?: React.FC<any> | string; isPlusButton?: boolean }>`
   justify-content: center;
   cursor: pointer;

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -196,7 +196,13 @@ const Tabs: React.FC<TabsProps> = ({
             }}
           >
             <IconButton>
-              <PlusIcon size={14} color="primary" />
+              <PlusIcon
+                size={20}
+                color="primary"
+                onClick={() => {
+                  /* Just for the hover style */
+                }}
+              />
             </IconButton>
           </TabButton>
         )}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add hover state to the plus button on Tabs

![image](https://user-images.githubusercontent.com/1761469/63267701-f0a6fc80-c292-11e9-8b77-9ab1fd2f0fde.png)


# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
