### PR TITLE
**Fix:** show focus for keyboard users only

### DIFF
--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -31,11 +31,12 @@ const Header = styled(SectionHeader)<{ expanded: boolean }>(({ theme, expanded }
   borderTop: `1px solid ${theme.color.separators.default}`,
   borderBottom: `1px solid ${expanded ? theme.color.separators.default : theme.color.background.lighter}`,
   // disable browser focus to customise focus state
-  ".no-focus &:focus": {
-    outline: "none",
-  },
   ":focus": {
+    outline: "none",
     background: theme.color.border.select,
+  },
+  ".no-focus &:focus": {
+    background: theme.color.background.lighter,
   },
   paddingRight: 0,
   userSelect: "none",

--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -31,8 +31,11 @@ const Header = styled(SectionHeader)<{ expanded: boolean }>(({ theme, expanded }
   borderTop: `1px solid ${theme.color.separators.default}`,
   borderBottom: `1px solid ${expanded ? theme.color.separators.default : theme.color.background.lighter}`,
   // disable browser focus to customise focus state
-  ":focus": {
+  ".no-focus :focus": {
     outline: "none",
+  },
+  ":focus": {
+    background: theme.color.border.select,
   },
   paddingRight: 0,
   userSelect: "none",

--- a/src/AccordionSection/AccordionSection.tsx
+++ b/src/AccordionSection/AccordionSection.tsx
@@ -31,7 +31,7 @@ const Header = styled(SectionHeader)<{ expanded: boolean }>(({ theme, expanded }
   borderTop: `1px solid ${theme.color.separators.default}`,
   borderBottom: `1px solid ${expanded ? theme.color.separators.default : theme.color.background.lighter}`,
   // disable browser focus to customise focus state
-  ".no-focus :focus": {
+  ".no-focus &:focus": {
     outline: "none",
   },
   ":focus": {

--- a/src/ActionMenu/ActionMenu.tsx
+++ b/src/ActionMenu/ActionMenu.tsx
@@ -24,6 +24,7 @@ const StyledContextMenu = styled(ContextMenu)(({ theme }) => ({
   },
   " [role='option']": {
     border: `1px solid ${theme.color.separators.light}`,
+    height: "36px;",
   },
   " [role='option']:not(:last-of-type)": {
     borderBottom: 0,
@@ -34,7 +35,7 @@ const StyledContextMenu = styled(ContextMenu)(({ theme }) => ({
   },
 }))
 
-const Container = styled("div")<{ isOpen: boolean }>(({ theme, isOpen }) => ({
+const Container = styled.div<{ isOpen: boolean }>(({ theme, isOpen }) => ({
   height: 36,
   width: 36,
   /**

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -119,9 +119,12 @@ const BaseButton = styled<"button" | "a">("button")<{
       //Higher zIndex will make right border appear on ButtonGroup Focus.
       zIndex: theme.zIndex.confirm,
     },
+    ".no-focus &:focus": {
+      boxShadow: "none",
+    },
     ...(!disabled
       ? {
-          ":hover": {
+          ":hover, .no-focus &:hover:focus": {
             backgroundColor: darken(backgroundColor, 5),
             zIndex: theme.zIndex.confirm,
           },

--- a/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   >
     <button
       aria-label="Hello"
-      class="css-epr7ni"
+      class="css-1mr8tso"
       role="button"
     >
       Hello

--- a/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonGroup Component Should initialize properly 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Chip Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
+++ b/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Code Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DatePicker Component Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/DropdownButton/DropdownButton.tsx
+++ b/src/DropdownButton/DropdownButton.tsx
@@ -35,7 +35,7 @@ const BaseDropdownButton = styled(Button)<{ isOpen: boolean }>(({ isOpen, theme 
   }),
 }))
 
-const CaretContainer = styled("div")<{ isOpen: boolean; color: string }>(({ isOpen, theme, color }) => {
+const CaretContainer = styled.div<{ isOpen: boolean; color: string }>(({ isOpen, theme, color }) => {
   const { background: backgroundColor, border: borderColor } = makeColors(theme, color)
   return {
     width: 36,
@@ -46,7 +46,7 @@ const CaretContainer = styled("div")<{ isOpen: boolean; color: string }>(({ isOp
   }
 })
 
-const ItemWithChevron = styled("div")`
+const ItemWithChevron = styled.div`
   width: 100%;
   display: flex;
   align-items: center;

--- a/src/Grid/__tests__/__snapshots__/Grid.test.tsx.snap
+++ b/src/Grid/__tests__/__snapshots__/Grid.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Grid Component Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Icon/_base.tsx
+++ b/src/Icon/_base.tsx
@@ -47,10 +47,14 @@ export const Svg = styled.svg<IconProps>`
     padding: ${theme.space.base}px;
     cursor: pointer;
     outline: none;
-    &:hover, &:focus {
+    :hover, :focus, .no-focus &:hover:focus {
       background: ${theme.color.separators.default};
       /* we need to set it here, because otherwise icon takes shape of ellipse at least in Chrome, for unknown reason */
       border-radius: 100%;
+    }
+    .no-focus &:focus {
+      background: initial;
+      border-radius: 0;
     }
     `
       : ""}

--- a/src/Internals/Message/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/src/Internals/Message/__tests__/__snapshots__/Message.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Message Component Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -50,6 +50,7 @@ export interface State {
   }>
   isLoading: boolean
   error?: Error
+  focus: boolean
 }
 
 const baseStylesheet = (theme: OperationalStyleConstants) => `
@@ -89,7 +90,7 @@ ul, ol {
 }
 `
 
-const Container = styled("div")`
+const Container = styled.div`
   position: relative;
   min-height: 60px;
   height: 100%;
@@ -115,6 +116,7 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
   public state: State = {
     messages: [],
     isLoading: false,
+    focus: false,
   }
 
   /**
@@ -159,6 +161,23 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
     if (this.messageTimerInterval) {
       clearInterval(this.messageTimerInterval)
     }
+    document.removeEventListener("keydown", this.onKeyDown)
+    document.removeEventListener("click", this.onClick)
+  }
+
+  public componentDidMount() {
+    document.addEventListener("keydown", this.onKeyDown.bind(this))
+    document.addEventListener("click", this.onClick.bind(this))
+  }
+
+  private onKeyDown(e: KeyboardEvent) {
+    if (e.key === "Tab") {
+      this.setState({ focus: true })
+    }
+  }
+
+  private onClick() {
+    this.setState({ focus: false })
   }
 
   public render() {
@@ -179,7 +198,7 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
             }}
           >
             {!this.props.noBaseStyles && <Global styles={baseStylesheet(merge(constants, theme))} />}
-            <Container>
+            <Container className={this.state.focus ? undefined : "no-focus"}>
               {this.state.isLoading && <Progress />}
               <Messages>
                 {this.state.messages.map(({ message, count }, index) => (

--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -119,6 +119,12 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
     focus: false,
   }
 
+  constructor(props: OperationalUIProps) {
+    super(props)
+    this.onKeyDown = this.onKeyDown.bind(this)
+    this.onClick = this.onClick.bind(this)
+  }
+
   /**
    *  The interval responsible for periodically checking
    *  whether any messages need to be removed from state
@@ -166,8 +172,8 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
   }
 
   public componentDidMount() {
-    document.addEventListener("keydown", this.onKeyDown.bind(this))
-    document.addEventListener("click", this.onClick.bind(this))
+    document.addEventListener("keydown", this.onKeyDown)
+    document.addEventListener("click", this.onClick)
   }
 
   private onKeyDown(e: KeyboardEvent) {

--- a/src/Progress/__tests__/__snapshots__/Progress.test.tsx.snap
+++ b/src/Progress/__tests__/__snapshots__/Progress.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Progress Component Should initialize properly 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
+++ b/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProgressPanel Component Should initialize properly 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
+++ b/src/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Spinner Component Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/src/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Switch Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Table Component Should render 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -108,8 +108,8 @@ export const TabHeader = styled(SectionHeader, {
     color: ${({ theme }) => theme.color.disabled};
     cursor: not-allowed;
   }
-  .no-focus &:hover,
-  :hover {
+  :hover,
+  .no-focus &:hover:focus {
     background-color: ${({ theme, color }) => (color ? darken(expandColor(theme, color)!, 20) : "#e4e9eb")};
   }
 `

--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -94,7 +94,12 @@ export const TabHeader = styled(SectionHeader, {
     cursor: pointer;
   }
   :focus {
+    background-color: ${({ theme, color }) => (color ? darken(expandColor(theme, color)!, 20) : "#e4e9eb")};
     outline: none;
+  }
+  .no-focus &:focus {
+    background-color: ${({ theme, color }) =>
+      color ? darken(expandColor(theme, color)!, 10) : theme.color.background.light};
   }
   ::-moz-focus-inner {
     border: none;
@@ -103,6 +108,7 @@ export const TabHeader = styled(SectionHeader, {
     color: ${({ theme }) => theme.color.disabled};
     cursor: not-allowed;
   }
+  .no-focus &:hover,
   :hover {
     background-color: ${({ theme, color }) => (color ? darken(expandColor(theme, color)!, 20) : "#e4e9eb")};
   }

--- a/src/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltip Component Should intialize without problems 1`] = `
 <div
-  class="css-ftf61z"
+  class="no-focus css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/TopbarButton/TopbarButton.tsx
+++ b/src/TopbarButton/TopbarButton.tsx
@@ -44,7 +44,7 @@ const TopbarButtonContainer = styled.button<{ disabled?: boolean; flavor: Topbar
   .no-focus &:focus {
     background: none;
   }
-  .no-focus &:hover, :hover {
+  :hover, .no-focus &:hover:focus {
     background: ${({ flavor, disabled }) =>
       disabled || flavor === "outline" || flavor === "filled" ? undefined : "#e4e9eb"};
   }

--- a/src/TopbarButton/TopbarButton.tsx
+++ b/src/TopbarButton/TopbarButton.tsx
@@ -41,7 +41,10 @@ const TopbarButtonContainer = styled.button<{ disabled?: boolean; flavor: Topbar
     background: ${({ flavor, theme }) =>
       flavor === "outline" || flavor === "filled" ? undefined : theme.color.border.select};
   }
-  :hover {
+  .no-focus &:focus {
+    background: none;
+  }
+  .no-focus &:hover, :hover {
     background: ${({ flavor, disabled }) =>
       disabled || flavor === "outline" || flavor === "filled" ? undefined : "#e4e9eb"};
   }

--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -5,7 +5,7 @@ import styled from "../utils/styled"
 
 type Props = TreeProps["trees"][-1] & { searchWords?: string[]; level: number; hasIconOffset: boolean }
 
-const Container = styled("div")<{ hasChildren: boolean; disabled: boolean }>`
+const Container = styled.div<{ hasChildren: boolean; disabled: boolean }>`
   opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   pointer-events: ${({ disabled }) => (disabled ? "none" : "inherit")};
   user-select: none;

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -37,15 +37,16 @@ const Header = styled.div<{
   position: relative;
   align-items: center;
   cursor: ${({ onClick, cursor }) => cursor || (onClick ? "pointer" : "inherit")};
-  background-color: ${({ highlight, theme }) => (highlight ? theme.color.highlight : "none")};
+  background: ${({ highlight, theme }) => (highlight ? theme.color.highlight : "none")};
   margin: 0 -${({ theme }) => theme.space.element}px;
   padding: ${({ theme }) => `${theme.space.base}px ${theme.space.element}px`};
   padding-left: ${({ theme, level, hasIconOffset }) =>
     theme.space.element * (level + 1) + (hasIconOffset ? theme.space.base + theme.space.element : 0)}px;
   color: ${({ theme }) => theme.color.text.dark};
 
-  :hover {
-    background-color: ${({ theme, highlight }) =>
+  :hover,
+  .no-focus &:hover:focus {
+    background: ${({ theme, highlight }) =>
       highlight ? darken(theme.color.highlight, 20) : theme.color.background.lighter};
 
     /* Show ActionsContainer on hover */
@@ -57,11 +58,18 @@ const Header = styled.div<{
   :focus {
     outline: none;
     color: ${({ theme }) => theme.color.primary};
-    background-color: ${({ theme }) => lighten(theme.color.primary, 50)};
+    background: ${({ theme }) => lighten(theme.color.primary, 50)};
 
     /* Show ActionsContainer on hover */
     div:last-of-type {
       opacity: 1;
+    }
+  }
+  .no-focus &:focus {
+    color: ${({ theme }) => theme.color.text.dark};
+    background: ${({ highlight, theme }) => (highlight ? theme.color.highlight : "none")};
+    div:last-of-type {
+      opacity: 0;
     }
   }
 `
@@ -152,7 +160,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       onKeyDown={handleKeyDown}
       highlight={Boolean(highlight)}
       cursor={cursor}
-      tabIndex={0}
+      tabIndex={0} // TODO: tabIndex -1 for disabled items
     >
       {viewMorePopup && (
         <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x}>

--- a/src/utils/mixins.ts
+++ b/src/utils/mixins.ts
@@ -3,34 +3,37 @@ import { keyframes } from "@emotion/core"
 import { lighten } from "../utils"
 import styled from "../utils/styled"
 import { OperationalStyleConstants } from "./constants"
+import memoize from "lodash/memoize"
 
-export const customScrollbar = ({ theme, dark = false }: { theme: OperationalStyleConstants; dark?: boolean }) => ({
-  /** Give people a slightly nicer experience on Chrome/Safari/Edge */
-  "::-webkit-scrollbar": {
-    width: 6,
-    height: 6,
-  },
+export const customScrollbar = memoize(
+  ({ theme, dark = false }: { theme: OperationalStyleConstants; dark?: boolean }) => ({
+    /** Give people a slightly nicer experience on Chrome/Safari/Edge */
+    "::-webkit-scrollbar": {
+      width: 6,
+      height: 6,
+    },
 
-  "::-webkit-scrollbar-track": {
-    background: "transparent",
-  },
+    "::-webkit-scrollbar-track": {
+      background: "transparent",
+    },
 
-  "::-webkit-scrollbar-thumb": {
-    background: dark ? "rgba(255, 255, 255, 0.3)" : theme.color.background.light,
-    cursor: "grab",
-  },
+    "::-webkit-scrollbar-thumb": {
+      background: dark ? "rgba(255, 255, 255, 0.3)" : theme.color.background.light,
+      cursor: "grab",
+    },
 
-  "::-webkit-scrollbar-thumb:hover": {
-    background: theme.color.primary,
-  },
-})
+    "::-webkit-scrollbar-thumb:hover": {
+      background: theme.color.primary,
+    },
+  }),
+)
 
-export const inputFocus = ({ theme, isError }: { theme: OperationalStyleConstants; isError?: boolean }) => ({
+export const inputFocus = memoize(({ theme, isError }: { theme: OperationalStyleConstants; isError?: boolean }) => ({
   outline: "none",
   boxShadow: `0 0 0 1px ${isError ? theme.color.error : theme.color.primary}`,
-})
+}))
 
-export const Label = styled("label")<{ fullWidth?: boolean; left?: boolean }>(({ fullWidth, theme, left }) => ({
+export const Label = styled.label<{ fullWidth?: boolean; left?: boolean }>(({ fullWidth, theme, left }) => ({
   display: "inline-block",
   position: "relative",
   width: "100%",
@@ -38,13 +41,13 @@ export const Label = styled("label")<{ fullWidth?: boolean; left?: boolean }>(({
   marginRight: left ? theme.space.small : 0,
 }))
 
-export const FormFieldControls = styled("div")({
+export const FormFieldControls = styled.div({
   position: "absolute",
   top: -2,
   right: 0,
 })
 
-export const FormFieldControl = styled("div")(({ theme }) => ({
+export const FormFieldControl = styled.div(({ theme }) => ({
   cursor: "pointer",
   position: "relative",
   verticalAlign: "middle",
@@ -64,7 +67,7 @@ export const FormFieldControl = styled("div")(({ theme }) => ({
   },
 }))
 
-export const FormFieldError = styled("div")(({ theme }) => ({
+export const FormFieldError = styled.div(({ theme }) => ({
   fontSize: theme.font.size.fineprint,
   color: theme.color.error,
   padding: `${theme.space.base / 2}px ${theme.space.medium}px`,


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Shows focus only when user navigate with Tab. If user navigates with mouse it doesn't show focus state.

Affected components: Button, DropdownButton, Tree, Accordion, Icon, Tabs

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
