### PR TITLE
**Fix:** strange bug with state on operational ui

### DIFF
--- a/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonGroup Component Should initialize properly 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Chip Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
+++ b/src/Code/__tests__/__snapshots__/Code.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Code Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DatePicker Component Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Grid/__tests__/__snapshots__/Grid.test.tsx.snap
+++ b/src/Grid/__tests__/__snapshots__/Grid.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Grid Component Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Internals/Message/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/src/Internals/Message/__tests__/__snapshots__/Message.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Message Component Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -50,7 +50,6 @@ export interface State {
   }>
   isLoading: boolean
   error?: Error
-  focus: boolean
 }
 
 const baseStylesheet = (theme: OperationalStyleConstants) => `
@@ -116,7 +115,6 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
   public state: State = {
     messages: [],
     isLoading: false,
-    focus: false,
   }
 
   constructor(props: OperationalUIProps) {
@@ -176,14 +174,15 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
     document.addEventListener("click", this.onClick)
   }
 
-  private onKeyDown(e: KeyboardEvent) {
-    if (e.key === "Tab") {
-      this.setState({ focus: true })
-    }
+  // We tried to use state instead of directly accessing DOM but it breaks
+  private onClick() {
+    document.body.classList.add("no-focus")
   }
 
-  private onClick() {
-    this.setState({ focus: false })
+  private onKeyDown(e: KeyboardEvent) {
+    if (e.key === "Tab") {
+      document.body.classList.remove("no-focus")
+    }
   }
 
   public render() {
@@ -204,7 +203,7 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
             }}
           >
             {!this.props.noBaseStyles && <Global styles={baseStylesheet(merge(constants, theme))} />}
-            <Container className={this.state.focus ? undefined : "no-focus"}>
+            <Container>
               {this.state.isLoading && <Progress />}
               <Messages>
                 {this.state.messages.map(({ message, count }, index) => (

--- a/src/Progress/__tests__/__snapshots__/Progress.test.tsx.snap
+++ b/src/Progress/__tests__/__snapshots__/Progress.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Progress Component Should initialize properly 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
+++ b/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProgressPanel Component Should initialize properly 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
+++ b/src/Spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Spinner Component Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/src/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Switch Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Table Component Should render 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"

--- a/src/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltip Component Should intialize without problems 1`] = `
 <div
-  class="no-focus css-ftf61z"
+  class="css-ftf61z"
 >
   <div
     class="css-p29iif"


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

When we use state to track focus it breaks tree and dropdown button in some cases, we wasn't able to find why, instead we decided to manipulate HTML directly. This is hacky we will investigate the issue later

# Related issue

N/A

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
