### PR TITLE
**Fix:** the max-height of the modal

### DIFF
--- a/src/Modal/Modal.styled.ts
+++ b/src/Modal/Modal.styled.ts
@@ -55,13 +55,16 @@ export const ModalCard = styled(Card)`
   overflow: hidden;
 `
 
-export const ModalContent = styled.div<{ anchor: boolean; actions: boolean }>`
+export const ModalContent = styled("div", {
+  shouldForwardProp: prop => !["top", "action", "anchor"].includes(prop),
+})<{ anchor: boolean; actions: boolean; top: number }>`
   display: grid;
   grid-template-rows: ${({ actions }) => (actions ? "minmax(auto, 100%) max-content" : "auto")};
   height: 100%;
   max-height: calc(
     /* card title + bottom padding + bottom margin + border */ 100vh -
-      ${({ theme }) => cardHeaderHeight + theme.space.element + theme.space.element + theme.space.element + 1}px
+      ${({ theme, top }) =>
+        cardHeaderHeight + theme.space.element + theme.space.element + theme.space.element + 1 + top * 2}px
   );
   overflow: auto;
   row-gap: ${({ theme }) => theme.space.element}px;

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -100,7 +100,7 @@ const Modal: React.RefForwardingComponent<HTMLDivElement, ModalProps> = (
         anchorHeight={typeof size[3] === "number" && size[3]}
       >
         <ModalCard ref={ref} fullSize title={title} action={fullSize ? <NoIcon onClick={onClickOutside} /> : undefined}>
-          <ModalContent actions={Boolean(actions)} anchor={Boolean(anchor)}>
+          <ModalContent actions={Boolean(actions)} anchor={Boolean(anchor)} top={size[0]}>
             <ContentWrapper>{children}</ContentWrapper>
             {actions && <Actions childCount={actions.length}>{actions}</Actions>}
           </ModalContent>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->
![image](https://user-images.githubusercontent.com/1761469/63752860-40e51680-c8b2-11e9-9792-bb8dce1e43d5.png)

The max-height was not correct, so the action button can be outside of the screen.


# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
