### PR TITLE
**Fix:** Select component background color

### DIFF
--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -236,16 +236,27 @@ const MyComponent = () => {
   const [value, setValue] = React.useState("one")
 
   return (
-    <div style={{ width: "100%", background: "#666" }}>
-      <Select
-        color="white"
-        value={value}
-        naked
-        options={options}
-        filterable
-        placeholder="Choose an option"
-        onChange={newValue => setValue(newValue as string)}
-      />
+    <div style={{ width: "100%", display:"grid", gridGap: "10px"}}>
+      <div style={{ width: "100%", background: "#666", display: "" }}>
+        <Select
+          value={value}
+          options={options}
+          filterable
+          placeholder="Choose an option"
+          onChange={newValue => setValue(newValue as string)}
+        />
+      </div>
+      <div style={{ width: "100%", background: "#666", display: "" }}>
+        <Select
+          color="white"
+          value={value}
+          naked
+          options={options}
+          filterable
+          placeholder="Choose an option"
+          onChange={newValue => setValue(newValue as string)}
+        />
+      </div>
     </div>
   )
 }

--- a/src/Select/Select.styled.ts
+++ b/src/Select/Select.styled.ts
@@ -26,7 +26,7 @@ export const Combobox = styled("div")<{ naked: boolean; isOpen: boolean; hasCust
       !hasCustomOption && isOpen ? theme.color.primary : theme.color.border.select};
   border-width: ${({ naked }) => (naked ? 0 : 1)}px;
   border-radius: ${({ theme }) => theme.borderRadius}px;
-  background-color: ${({ isOpen, naked }) => (!naked && isOpen ? "white" : "transparent")};
+  background-color: ${({ naked }) => (naked ? "transparent" : "white")};
 
   :focus {
     ${({ theme }) => inputFocus({ theme })}


### PR DESCRIPTION
# Summary
This fix ensures, that the `Select` component always gets the default white background, unless configured as naked

Updated the related example with Naked component to demo the difference:

<img width="911" alt="Screenshot 2019-08-28 at 10 39 54" src="https://user-images.githubusercontent.com/639406/63839777-31340380-c980-11e9-8a7a-62beafca2e58.png">

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
