### PR TITLE
WIP **Breaking:** UI-130 Re-open the context menu for Autocomplete if the list of items changes

### DIFF
--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -153,10 +153,10 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     }
   }, [items])
 
-  const [cachedItems, setCachedItems] = React.useState(items)
+  const itemsRef = React.useRef<IContextMenuItem<any>[]>([])
   React.useEffect(() => {
-    if (!isEqual(items, cachedItems)) {
-      setCachedItems(items)
+    if (!isEqual(items, itemsRef.current)) {
+      itemsRef.current = items
       if (!open) {
         return
       }

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -174,7 +174,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         setFocusedOptionIndex(0)
       }
     }
-  }, [items])
+  }, [items, isOpen, focusedOptionIndex, setIsOpen, setFocusedOptionIndex])
   /* TODO: End of patch */
 
   const renderedChildren = React.useMemo(

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -153,6 +153,13 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     }
   }, [items])
 
+  /*  
+      TODO: Refactor the Context Menu
+      This patch fixes the Autocomplete not showing the items list when input changes
+      See https://contiamo.atlassian.net/browse/UI-130 and https://github.com/contiamo/operational-ui/pull/1229
+      See refactoring rationalisation here: https://www.notion.so/contiamo/b3890a6cab29436188e895bfee4337df?v=95a710c74af6471db0575e217b3bee2b&p=0afec0b5417a4cf5b12959ee817013b2
+      Start of patch
+  */
   const itemsRef = React.useRef<IContextMenuItem<any>[]>([])
   React.useEffect(() => {
     if (!isEqual(items, itemsRef.current)) {
@@ -168,6 +175,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
       }
     }
   }, [items])
+  /* TODO: End of patch */
 
   const renderedChildren = React.useMemo(
     () => (isChildAFunction(children) ? children(isOpen ? isOpen : false) : children),

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import isString from "lodash/isString"
+import isEqual from "lodash/isEqual"
 
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
@@ -131,7 +132,15 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   ...props
 }) => {
   const uniqueId = useUniqueId(id)
-  const { isOpen, setIsOpen, buttonProps, listboxProps, getChildProps, focusedOptionIndex } = useListbox({
+  const {
+    isOpen,
+    setIsOpen,
+    buttonProps,
+    listboxProps,
+    getChildProps,
+    focusedOptionIndex,
+    setFocusedOptionIndex,
+  } = useListbox({
     itemCount: items.length,
     isMultiSelect: keepOpenOnItemClick,
     isDisabled: disabled,
@@ -141,6 +150,22 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   React.useEffect(() => {
     if (!items) {
       throw new Error("No array of items has been provided for the ContextMenu.")
+    }
+  }, [items])
+
+  const [cachedItems, setCachedItems] = React.useState(items)
+  React.useEffect(() => {
+    if (!isEqual(items, cachedItems)) {
+      setCachedItems(items)
+      if (!open) {
+        return
+      }
+      if (setIsOpen && !isOpen) {
+        setIsOpen(true)
+      }
+      if (setFocusedOptionIndex) {
+        setFocusedOptionIndex(0)
+      }
     }
   }, [items])
 

--- a/src/useListbox/index.ts
+++ b/src/useListbox/index.ts
@@ -192,5 +192,6 @@ export const useListbox = ({
       id: `${id}-${childItemIndex}`,
     }),
     focusedOptionIndex: focusedOptionIndex,
+    setFocusedOptionIndex,
   }
 }


### PR DESCRIPTION
# Why WIP
To be tested with both https://contiamo.atlassian.net/browse/DSS-245 and https://contiamo.atlassian.net/browse/DSS-255 for the dynamically, since the list of the Teilmarkt selector, updating dynamically as soon as the selection for Town changes, should not pop-up opened. Potentially, this case could be solved only by exposing the `_setIsOpen` outside the `<ContextMenu>` component, not the only the `useListbox` hook.

# Refactoring CIP:
https://www.notion.so/contiamo/b3890a6cab29436188e895bfee4337df?v=95a710c74af6471db0575e217b3bee2b&p=0afec0b5417a4cf5b12959ee817013b2


# Summary
Fixes the issue, that the ContextMenu of the Autocomplete component does not re-appear after selecting one of the items

Original Repro:
1. Start typing 
1. Get the response and see the context menu list
1. Select an item in the context menu drop-down
1. continue typing in the input
1. observe the issue: the context menu drop-down does not re-appear (until the input is clicked with the mouse)

Fixed behaviour:

![UI-130](https://user-images.githubusercontent.com/639406/64158924-a51b5380-ce39-11e9-8019-b00ccc150cd8.gif)

# Related issue
https://contiamo.atlassian.net/browse/UI-130

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [ ] Things look good on the demo.
- [ ] No regression on ActionMenu
- [ ] No regression on ContextMenu
- [ ] No regression on DropdownButton
- [ ] No regression on Select
- [ ] No regression on TopbarSelect
- [ ] No regression on DataTableSelect
- [x] No regression on Autocomplete


Tester 1

- [ ] Things look good on the demo.
- [ ] No regression on ActionMenu
- [ ] No regression on ContextMenu
- [ ] No regression on DropdownButton
- [ ] No regression on Select
- [ ] No regression on TopbarSelect
- [ ] No regression on DataTableSelect
- [ ] No regression on Autocomplete

