### PR TITLE
PLAT-874 Add copy option on hover for DataTable

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -15,7 +15,9 @@ import {
   ViewMoreToggle,
 } from "./DataTable.styled"
 import { defaultRowHeight, getRowHeight } from "./DataTable.util"
-import { ChevronDownIcon } from "../Icon"
+import { ChevronDownIcon, CopyIcon } from "../Icon"
+import { Button, OperationalContext } from ".."
+import CopyToClipboard from "react-copy-to-clipboard"
 
 export interface DataTableProps<Columns, Rows> {
   /* The columns of our table. They are an array of header layers. */
@@ -182,6 +184,19 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
     <>
       {viewMorePopup && (
         <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x}>
+          <OperationalContext>
+            {({ pushMessage }) => (
+              <CopyToClipboard
+                text={viewMorePopup.content || ""}
+                onCopy={() => pushMessage({ body: "Copied to clipboard", type: "info" })}
+              >
+                <Button condensed tabIndex={0}>
+                  <CopyIcon size={16} left />
+                  Copy
+                </Button>
+              </CopyToClipboard>
+            )}
+          </OperationalContext>
           {viewMorePopup.content}
         </ViewMorePopup>
       )}


### PR DESCRIPTION
# Summary
Adds **Copy** control to the DataTable cell to simplify copying the content of the pop-up

<img width="628" alt="Screenshot 2019-09-06 at 16 46 30" src="https://user-images.githubusercontent.com/639406/64437090-e6279800-d0c5-11e9-8dd1-42708f6cb05e.png">

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
