### PR TITLE
**Breaking:** Update DataTable truncation

### DIFF
--- a/src/ActionMenu/ActionMenu.tsx
+++ b/src/ActionMenu/ActionMenu.tsx
@@ -93,7 +93,7 @@ const Container = styled.div<{ isOpen: boolean }>(({ theme, isOpen }) => ({
 }))
 
 const ActionMenu: React.SFC<ActionMenuProps> = ({ items, ...props }) => (
-  <StyledContextMenu align="right" {...props} items={items} condensed>
+  <StyledContextMenu anchored align="right" {...props} items={items} condensed>
     {isOpen => {
       const iconColor = isOpen ? "primary" : "color.text.lighter"
 

--- a/src/Autocomplete/README.md
+++ b/src/Autocomplete/README.md
@@ -74,7 +74,7 @@ In some cases, we'd want our `Autocomplete`s to hold on to the value selected, a
 
 ```jsx
 import * as React from "react"
-import { Autocomplete } from "@operational/components"
+import { Autocomplete, AddIcon } from "@operational/components"
 
 const MyOtherComponent = () => {
   const [text, setText] = React.useState("")
@@ -122,7 +122,7 @@ const MyOtherComponent = () => {
         fullWidth
         value={text}
         loading={loading}
-        resultIcon="Add"
+        resultIcon={AddIcon}
         results={data}
         noResultsMessage="No result Found"
         placeholder="Search for Pokémon..."

--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -1,0 +1,80 @@
+import * as React from "react"
+import { createPortal } from "react-dom"
+
+import styled from "../utils/styled"
+import { ContextMenuProps } from "./ContextMenu"
+import useSticky from "../useSticky/useSticky"
+
+export interface ContextMenuPopoutProps {
+  embedChildrenInMenu?: ContextMenuProps["embedChildrenInMenu"]
+  numRows: number
+  align: ContextMenuProps["align"]
+  condensed: ContextMenuProps["condensed"]
+  rowHeight: number
+  container?: React.RefObject<HTMLDivElement>
+  children?: React.ReactNode
+}
+
+interface PositionProps {
+  left: string
+  top: string
+  position: string
+  width?: string
+}
+
+const Container = styled.div<ContextMenuPopoutProps & PositionProps>`
+  position: ${({ position }) => position};
+  top: ${({ top }) => top};
+  left: ${({ left }) => left};
+  max-height: 50vh;
+  overflow: auto;
+  box-shadow: ${({ theme }) => theme.shadows.contextMenu};
+  min-width: fit-content;
+  width: ${({ width }) => width};
+  max-width: 90vw;
+  min-height: ${({ rowHeight }) => rowHeight}px;
+  display: grid;
+  grid-template-rows: repeat(${({ numRows }) => numRows}, max-content);
+  background-color: ${({ theme }) => theme.color.white};
+  padding: ${({ theme }) => theme.space.small}px 0;
+  z-index: ${({ theme }) => theme.zIndex.selectOptions + 2};
+`
+
+const ContextMenuPopout = React.forwardRef(
+  (
+    { align, children, condensed, container, embedChildrenInMenu, numRows, rowHeight }: ContextMenuPopoutProps,
+    forwardRef: React.Ref<HTMLDivElement>,
+  ) => {
+    const fallbackRef = React.useRef<HTMLDivElement | null>(null)
+    const ref = forwardRef || fallbackRef
+
+    const { left, position, top, width } = useSticky(ref, {
+      position: "absolute",
+      left: align === "left" ? "0" : "auto",
+      top: embedChildrenInMenu ? "0" : "100%",
+      width: "100%",
+      alignment: "flex-start",
+    })
+
+    const areWeFixedYet = position === "fixed"
+    const popOut = (
+      <Container
+        align={align}
+        condensed={condensed}
+        numRows={numRows}
+        rowHeight={rowHeight}
+        left={left}
+        width={width}
+        top={top}
+        position={position}
+        ref={ref}
+      >
+        {children}
+      </Container>
+    )
+
+    return areWeFixedYet && container && container.current ? createPortal(popOut, container.current) : popOut
+  },
+)
+
+export default ContextMenuPopout

--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -12,6 +12,7 @@ export interface ContextMenuPopoutProps {
   align: ContextMenuProps["align"]
   condensed: ContextMenuProps["condensed"]
   rowHeight: number
+  anchored: boolean
   container?: React.RefObject<HTMLDivElement>
   children?: React.ReactNode
 }
@@ -38,22 +39,25 @@ const Container = styled.div<ContextMenuPopoutProps & PositionProps>`
   grid-template-rows: repeat(${({ numRows }) => numRows}, max-content);
   background-color: ${({ theme }) => theme.color.white};
   padding: ${({ theme }) => theme.space.small}px 0;
-  z-index: ${({ theme }) => theme.zIndex.selectOptions + 2};
+
+  ${({ theme, anchored }) => (anchored ? "" : `z-index: ${theme.zIndex.selectOptions + 2};`)}
 `
 
 const ContextMenuPopout = React.forwardRef<HTMLDivElement, ContextMenuPopoutProps>(
-  ({ align, children, condensed, container, embedChildrenInMenu, numRows, rowHeight }, forwardRef) => {
+  ({ align, children, condensed, container, embedChildrenInMenu, numRows, rowHeight, anchored }, forwardRef) => {
     const $fallback = React.useRef<HTMLDivElement | null>(null)
     const $el = isRefRefObject(forwardRef) ? forwardRef : $fallback
 
+    const initialValue = {
+      position: "absolute",
+      left: align === "left" ? "0" : "auto",
+      top: embedChildrenInMenu ? "0" : "100%",
+      width: "100%",
+    } as const
+
     const { left, position, top, width } = useSticky({
       $el: $el,
-      initialValue: {
-        position: "absolute",
-        left: align === "left" ? "0" : "auto",
-        top: embedChildrenInMenu ? "0" : "100%",
-        width: "100%",
-      },
+      initialValue,
     })
 
     const areWeFixedYet = position === "fixed"
@@ -64,17 +68,21 @@ const ContextMenuPopout = React.forwardRef<HTMLDivElement, ContextMenuPopoutProp
         condensed={condensed}
         numRows={numRows}
         rowHeight={rowHeight}
-        left={left}
-        width={width}
-        top={top}
-        position={position}
+        anchored={anchored}
+        left={anchored ? initialValue.left : left}
+        width={anchored ? initialValue.width : width}
+        top={anchored ? initialValue.top : top}
+        position={anchored ? initialValue.position : position}
         ref={$el}
+        role="listbox"
       >
         {children}
       </Container>
     )
 
-    return areWeFixedYet && container && container.current ? createPortal(popOut, container.current) : popOut
+    return !anchored && areWeFixedYet && container && container.current
+      ? createPortal(popOut, container.current)
+      : popOut
   },
 )
 

--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -48,12 +48,16 @@ const ContextMenuPopout = React.forwardRef(
     const fallbackRef = React.useRef<HTMLDivElement | null>(null)
     const ref = forwardRef || fallbackRef
 
-    const { left, position, top, width } = useSticky(ref, {
-      position: "absolute",
-      left: align === "left" ? "0" : "auto",
-      top: embedChildrenInMenu ? "0" : "100%",
-      width: "100%",
-      alignment: "flex-start",
+    const { left, position, top, width } = useSticky({
+      inputRef: ref,
+      options: { shouldAvoidToggler: true },
+      initialValue: {
+        position: "absolute",
+        left: align === "left" ? "0" : "auto",
+        top: embedChildrenInMenu ? "0" : "100%",
+        width: "100%",
+        alignment: "flex-start",
+      },
     })
 
     const areWeFixedYet = position === "fixed"

--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom"
 import styled from "../utils/styled"
 import { ContextMenuProps } from "./ContextMenu"
 import useSticky from "../useSticky/useSticky"
+import { isRefRefObject } from "../utils/isRefRefObject"
 
 export interface ContextMenuPopoutProps {
   embedChildrenInMenu?: ContextMenuProps["embedChildrenInMenu"]
@@ -40,13 +41,10 @@ const Container = styled.div<ContextMenuPopoutProps & PositionProps>`
   z-index: ${({ theme }) => theme.zIndex.selectOptions + 2};
 `
 
-const ContextMenuPopout = React.forwardRef(
-  (
-    { align, children, condensed, container, embedChildrenInMenu, numRows, rowHeight }: ContextMenuPopoutProps,
-    forwardRef: React.Ref<HTMLDivElement>,
-  ) => {
+const ContextMenuPopout = React.forwardRef<HTMLDivElement, ContextMenuPopoutProps>(
+  ({ align, children, condensed, container, embedChildrenInMenu, numRows, rowHeight }, forwardRef) => {
     const $fallback = React.useRef<HTMLDivElement | null>(null)
-    const $el = forwardRef || $fallback
+    const $el = isRefRefObject(forwardRef) ? forwardRef : $fallback
 
     const { left, position, top, width } = useSticky({
       $el: $el,

--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -50,17 +50,16 @@ const ContextMenuPopout = React.forwardRef(
 
     const { left, position, top, width } = useSticky({
       inputRef: ref,
-      options: { shouldAvoidToggler: true },
       initialValue: {
         position: "absolute",
         left: align === "left" ? "0" : "auto",
         top: embedChildrenInMenu ? "0" : "100%",
         width: "100%",
-        alignment: "flex-start",
       },
     })
 
     const areWeFixedYet = position === "fixed"
+
     const popOut = (
       <Container
         align={align}

--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -45,11 +45,11 @@ const ContextMenuPopout = React.forwardRef(
     { align, children, condensed, container, embedChildrenInMenu, numRows, rowHeight }: ContextMenuPopoutProps,
     forwardRef: React.Ref<HTMLDivElement>,
   ) => {
-    const fallbackRef = React.useRef<HTMLDivElement | null>(null)
-    const ref = forwardRef || fallbackRef
+    const $fallback = React.useRef<HTMLDivElement | null>(null)
+    const $el = forwardRef || $fallback
 
     const { left, position, top, width } = useSticky({
-      inputRef: ref,
+      $el: $el,
       initialValue: {
         position: "absolute",
         left: align === "left" ? "0" : "auto",
@@ -70,7 +70,7 @@ const ContextMenuPopout = React.forwardRef(
         width={width}
         top={top}
         position={position}
-        ref={ref}
+        ref={$el}
       >
         {children}
       </Container>

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -41,6 +41,8 @@ export interface ContextMenuProps extends DefaultProps {
   embedChildrenInMenu?: boolean
   /** Where do we start focus from? */
   initialFocusedItemIndex?: number
+  /** Is this ContextMenu anchored to an element? */
+  anchored?: boolean
 }
 
 export interface State {
@@ -108,6 +110,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   disabled,
   width,
   open,
+  anchored,
   ...props
 }) => {
   const $invisibleOverlay = React.useRef<HTMLDivElement | null>(null)
@@ -159,22 +162,22 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     }
   }, [currentItem, onClick])
 
+  const overlay = (
+    <InvisibleOverlay
+      ref={$invisibleOverlay}
+      onClick={e => {
+        e.stopPropagation()
+        setIsOpen && setIsOpen(false)
+        if (onOutsideClick) {
+          onOutsideClick()
+        }
+      }}
+    />
+  )
+
   return (
     <>
-      {isOpen &&
-        createPortal(
-          <InvisibleOverlay
-            ref={$invisibleOverlay}
-            onClick={e => {
-              e.stopPropagation()
-              setIsOpen && setIsOpen(false)
-              if (onOutsideClick) {
-                onOutsideClick()
-              }
-            }}
-          />,
-          document.body,
-        )}
+      {isOpen && (anchored ? overlay : createPortal(overlay, document.body))}
       <Container
         {...props}
         isOpen={isOpen || false}
@@ -211,6 +214,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
             embedChildrenInMenu={embedChildrenInMenu}
             container={$invisibleOverlay}
             rowHeight={rowHeight}
+            anchored={Boolean(anchored)}
           >
             {embedChildrenInMenu && renderedChildren}
             {items.map((item, index: number) => (

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -120,18 +120,14 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   })
 
   React.useEffect(() => {
-    const hideOnScroll = () => setIsOpen && setIsOpen(false)
-
-    if (isOpen) {
+    if (isOpen && setIsOpen) {
+      const hideOnScroll = () => setIsOpen(false)
       document.addEventListener("scroll", hideOnScroll)
-    } else {
-      document.removeEventListener("scroll", hideOnScroll)
+      return () => {
+        document.removeEventListener("scroll", hideOnScroll)
+      }
     }
-
-    return () => {
-      document.removeEventListener("scroll", hideOnScroll)
-    }
-  }, [isOpen])
+  }, [isOpen, setIsOpen])
 
   React.useEffect(() => {
     if (!items) {

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -207,6 +207,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         {isOpen && (
           <ContextMenuPopout
             {...listboxProps}
+            key={`ContextMenuPopout-${uniqueId}-${items.length}-items`}
             ref={containerRef}
             condensed={Boolean(condensed)}
             numRows={items.length}

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -185,7 +185,7 @@ const Wrapper = () => {
       <Code>
           {`Rect: ${JSON.stringify(rect, null, 2)}`}
       </Code>
-      <ContextMenu open containerRef={menuRef} items={menuItems} onClick={() => alert("clicked")}>
+      <ContextMenu open containerRef={$menu} items={menuItems} onClick={() => alert("clicked")}>
         <Button>Click here</Button>
       </ContextMenu>
     </>

--- a/src/ContextMenu/README.md
+++ b/src/ContextMenu/README.md
@@ -169,14 +169,14 @@ import * as React from "react"
 import { Button, ContextMenu, ContextMenuProps, Code } from "@operational/components"
 
 const menuItems = ["Menu 1", "Menu 2", "Menu 3"]
-const menuRef = React.createRef<HTMLDivElement>();
+const $menu = React.createRef<HTMLDivElement>();
 
 const Wrapper = () => {
   const [rect, setRect] = React.useState<DOMRect>();
 
   React.useEffect(() => {
-    if (menuRef.current) {
-      setRect(menuRef.current.getBoundingClientRect());
+    if ($menu.current) {
+      setRect($menu.current.getBoundingClientRect());
     }
   }, []);
 

--- a/src/DataTable/CellContent.tsx
+++ b/src/DataTable/CellContent.tsx
@@ -59,7 +59,7 @@ const CellContent: React.FC<CellContentProps> = ({ cell, open }) => {
           />
         </ViewMoreToggle>
       ) : (
-        <div />
+        <div /> // We need an empty element for CSS Grid to place things correctly
       )}
     </CellGrid>
   )

--- a/src/DataTable/CellContent.tsx
+++ b/src/DataTable/CellContent.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import isString from "lodash/isString"
+import noop from "lodash/noop"
+
+import { CellGrid, CellTruncator, ViewMoreToggle } from "./DataTable.styled"
+import { DotMenuHorizontalIcon } from "../Icon"
+
+export interface CellContentProps {
+  cell: React.ReactNode
+  open: (content: string) => (e: React.MouseEvent<Element, MouseEvent>) => void
+}
+
+const stringifyIfNeeded = (value: any) => {
+  // We compare booleans like this and without typeof for perf
+  return value === true || value === false ? String(value) : value
+}
+
+const CellContent: React.FC<CellContentProps> = ({ cell, open }: any) => {
+  const glyphSize = 8 // it's an opinionated UI library don't @ me
+  const $cell = React.useRef<HTMLDivElement | null>(null)
+  const [isTextProbablyOverflowing, setIsTextProbablyOverflowing] = React.useState(false)
+
+  React.useLayoutEffect(() => {
+    const currentCell = $cell.current
+    if (currentCell) {
+      if (cell.length * glyphSize > currentCell.getBoundingClientRect().width) {
+        setIsTextProbablyOverflowing(true)
+      } else {
+        setIsTextProbablyOverflowing(false)
+      }
+    }
+  }, [])
+
+  return (
+    <CellGrid ref={$cell} canTruncate={isString(cell)}>
+      {isString(cell) ? <CellTruncator>{stringifyIfNeeded(cell)}</CellTruncator> : stringifyIfNeeded(cell)}
+      {isString(cell) && isTextProbablyOverflowing ? (
+        <ViewMoreToggle onClick={open(cell)}>
+          <DotMenuHorizontalIcon
+            color="color.text.lighter"
+            size={20}
+            onClick={noop} // for the hover/focus effect
+          />
+        </ViewMoreToggle>
+      ) : (
+        <div />
+      )}
+    </CellGrid>
+  )
+}
+
+export default CellContent

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -151,8 +151,9 @@ export const GhostCell = styled.div`
   position: absolute;
   top: 0;
   left: ${({ theme }) => theme.space.content}px;
-  overflow: visible;
+  overflow: hidden;
   visibility: hidden;
   white-space: pre;
   pointer-events: none;
+  max-width: 100%;
 `

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -83,11 +83,11 @@ export const HeaderCell = styled(Cell)<{
   rowIndex: number
 }>`
   position: relative;
-  background-color: ${({ theme }) => theme.color.background.grey};
+  background-color: ${({ theme }) => theme.color.background.almostWhite};
   color: ${({ theme }) => theme.color.text.dark};
   font-weight: ${({ theme }) => theme.font.weight.bold};
   border-top: ${({ rowIndex }) => (rowIndex === 0 ? "1px solid" : 0)};
-  border-color: ${({ theme }) => theme.color.border.default};
+  border-color: ${({ theme }) => theme.color.border.medium};
 `
 
 export const DataWrapper = styled("div")<{ numHeaders: number; rowHeight: DataTableProps<any, any>["rowHeight"] }>`

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -137,3 +137,22 @@ export const ViewMorePopup = styled.div<{ top: number; left: number }>`
   ${({ top }) =>
     window.innerHeight - top > 0.5 * window.innerHeight ? `top: ${top}` : `bottom: ${window.innerHeight - top}`}px;
 `
+
+/**
+ * We need to render a "ghost cell" in the table
+ * in order to understand if a cell's content is
+ * overflowing its container and then show a
+ * "see more" icon.
+ *
+ * This is that ghost cell.
+ */
+
+export const GhostCell = styled.div`
+  position: absolute;
+  top: 0;
+  left: ${({ theme }) => theme.space.content}px;
+  overflow: visible;
+  visibility: hidden;
+  white-space: pre;
+  pointer-events: none;
+`

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -43,10 +43,24 @@ export const Cell = styled.div<{
   font-family: ${({ theme }) => theme.font.family.code};
   font-size: ${({ theme }) => theme.font.size.fineprint}px;
   font-weight: ${({ theme }) => theme.font.weight.regular};
-  padding: 0 ${({ theme }) => theme.space.content}px;
   color: ${({ theme }) => theme.color.text.default};
   grid-column: ${({ cell }) => cell};
   background-color: ${({ theme }) => theme.color.white};
+`
+
+export const CellGrid = styled.div<{ canTruncate: boolean }>`
+  display: ${({ canTruncate }) => (canTruncate ? "grid" : "flex")};
+  align-items: center;
+  width: 100%;
+  ${({ canTruncate }) => (canTruncate ? "grid-template-columns: calc(100% - 36px) 36px" : "")};
+  padding: 0 ${({ theme }) => theme.space.content}px;
+`
+
+export const CellTruncator = styled.div`
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
 `
 
 export const HeaderRow = styled.div<{
@@ -77,23 +91,12 @@ export const DataWrapper = styled("div")<{ numHeaders: number; rowHeight: DataTa
   top: ${({ numHeaders, rowHeight }) => numHeaders * getHeaderRowHeight(rowHeight)}px;
 `
 
-export const ViewMoreToggle = styled("div", { shouldForwardProp: prop => prop !== "height" })<{ height: number }>`
-  position: absolute;
-  right: 0;
-  top: 0;
-  height: ${({ height }) => height}px;
-  width: 40px;
+export const ViewMoreToggle = styled("div")`
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   cursor: pointer;
-  padding-right: ${({ theme }) => theme.space.small}px;
-  background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(255, 255, 255, 1) 46%);
-  border-radius: ${({ theme }) => theme.borderRadius}px;
-
-  > * {
-    pointer-events: none;
-  }
 `
 
 const animateIn = keyframes`

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -48,11 +48,16 @@ export const Cell = styled.div<{
   background-color: ${({ theme }) => theme.color.white};
 `
 
+export const dataTableActionContainerSize = 36
+
 export const CellGrid = styled.div<{ canTruncate: boolean }>`
   display: ${({ canTruncate }) => (canTruncate ? "grid" : "flex")};
   align-items: center;
   width: 100%;
-  ${({ canTruncate }) => (canTruncate ? "grid-template-columns: calc(100% - 36px) 36px" : "")};
+  ${({ canTruncate }) =>
+    canTruncate
+      ? `grid-template-columns: calc(100% - ${dataTableActionContainerSize}px) ${dataTableActionContainerSize}px`
+      : ""};
   padding: 0 ${({ theme }) => theme.space.content}px;
 `
 
@@ -91,7 +96,7 @@ export const DataWrapper = styled("div")<{ numHeaders: number; rowHeight: DataTa
   top: ${({ numHeaders, rowHeight }) => numHeaders * getHeaderRowHeight(rowHeight)}px;
 `
 
-export const ViewMoreToggle = styled("div")`
+export const ViewMoreToggle = styled.div`
   width: 100%;
   display: flex;
   align-items: center;

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -31,16 +31,16 @@ const CustomCell = styled.span`
     ],
     [
       <DataTableHeader
-        title="Jithin Bas Choondapurrakkal and Nagarajan Ganapathysubramanian are really long Indian names"
+        title="Jithin Bas Choondapurrakkal"
         icon={YesIcon}
         actions={[{ label: "Say hi", onClick: () => alert("HIIII") }]}
       />,
     ],
-    [<DataTableHeader title="Foooood" actions={[{ label: "Say bye", onClick: () => alert("BYEEE <3") }]} />],
+    [<DataTableHeader title="Foooooooooooooood" actions={[{ label: "Say bye", onClick: () => alert("BYEEE <3") }]} />],
     ["Loves You"],
   ]}
   rows={[
-    [String(Math.random()).repeat(1000), "Imogen Mason", "Good Stuff", true],
+    [String(Math.random()) + " whats up", "Imogen Mason", "Good Stuff", true],
     [String(Math.random()).repeat(1000), "Fabien Bernard", "🥖🥐🧀🍷", false],
     [String(Math.random()).repeat(1000), "STEREO BOOSTER", "☕️", true],
     [String(Math.random()).repeat(1000), <CustomCell>Mischa Potomin</CustomCell>, "null", false],

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -11,7 +11,15 @@ Additionally, you can supply a component as a cell to customize the styling and 
 
 ```jsx
 import * as React from "react"
-import { DataTable, DataTableSelect, DataTableInput, Checkbox, styled } from "@operational/components"
+import {
+  DataTable,
+  DataTableHeader,
+  DataTableSelect,
+  YesIcon,
+  DataTableInput,
+  Checkbox,
+  styled,
+} from "@operational/components"
 
 const CustomCell = styled.span`
   color: red;
@@ -19,10 +27,16 @@ const CustomCell = styled.span`
 ;<DataTable
   columns={[
     [
-      "I am so long I am the longest the longest of the long LOL look how long I am my mom said I would never be long but I really am the longest KOBE BRYANT AINT GOT NOTHING ON ME HOMIE",
+      "I am so long I am the longest the longest of the long LOL look how long I am my mom said I would never be long but I really am the longest SHAQ AINT GOT NOTHING ON ME HOMIE",
     ],
-    ["Name"],
-    ["Diet"],
+    [
+      <DataTableHeader
+        title="Jithin Bas Choondapurrakkal and Nagarajan Ganapathysubramanian are really long Indian names"
+        icon={YesIcon}
+        actions={[{ label: "Say hi", onClick: () => alert("HIIII") }]}
+      />,
+    ],
+    [<DataTableHeader title="Foooood" actions={[{ label: "Say bye", onClick: () => alert("BYEEE <3") }]} />],
     ["Loves You"],
   ]}
   rows={[

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -1,0 +1,42 @@
+import * as React from "react"
+
+/**
+ * Handles logic to display a popup at mouse cursor position,
+ * triggered by a click event.
+ */
+const useViewMore = () => {
+  const [viewMorePopup, setViewMorePopup] = React.useState<{ content: string; x: number; y: number } | false>(false)
+
+  React.useEffect(() => {
+    if (!viewMorePopup) {
+      return
+    }
+
+    const handleClickOutside = () => {
+      setViewMorePopup(false)
+    }
+
+    document.addEventListener("click", handleClickOutside)
+    document.addEventListener("contextmenu", handleClickOutside)
+
+    return () => {
+      document.removeEventListener("click", handleClickOutside)
+      document.removeEventListener("contextmenu", handleClickOutside)
+    }
+  }, [viewMorePopup])
+
+  const openViewMore = React.useCallback(
+    (content: string) => (e: React.MouseEvent) => {
+      setViewMorePopup({ content, x: e.clientX, y: e.clientY })
+    },
+    [viewMorePopup],
+  )
+
+  return {
+    viewMorePopup,
+    toggle: (content: string) => (viewMorePopup ? setViewMorePopup(false) : openViewMore(content)),
+    open: openViewMore,
+  }
+}
+
+export default useViewMore

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -12,16 +12,18 @@ const useViewMore = () => {
       return
     }
 
-    const handleClickOutside = () => {
+    const close = () => {
       setViewMorePopup(false)
     }
 
-    document.addEventListener("click", handleClickOutside)
-    document.addEventListener("contextmenu", handleClickOutside)
+    document.addEventListener("click", close)
+    document.addEventListener("contextmenu", close)
+    document.addEventListener("scroll", close)
 
     return () => {
-      document.removeEventListener("click", handleClickOutside)
-      document.removeEventListener("contextmenu", handleClickOutside)
+      document.removeEventListener("click", close)
+      document.removeEventListener("contextmenu", close)
+      document.removeEventListener("scroll", close)
     }
   }, [viewMorePopup])
 

--- a/src/DataTableFooter/DataTableFooter.tsx
+++ b/src/DataTableFooter/DataTableFooter.tsx
@@ -11,6 +11,6 @@ const Container = styled("div")<{ onClick?: (e: React.MouseEvent) => void }>`
   border: 1px solid ${({ theme }) => theme.color.border.disabled};
 `
 
-export const DataTableFooter: React.FC = props => <Container {...props} />
+export const DataTableFooter: React.FC<{ onClick?: (e: React.MouseEvent) => void }> = props => <Container {...props} />
 
 export default DataTableFooter

--- a/src/DataTableHeader/DataTableHeader.styled.ts
+++ b/src/DataTableHeader/DataTableHeader.styled.ts
@@ -24,6 +24,14 @@ export const TitleContainer = styled.div`
   overflow: hidden;
   white-space: pre;
 `
+export const GhostTitleContainer = styled.div<{ hasIcon: boolean }>`
+  position: absolute;
+  top: 0;
+  left: ${({ theme, hasIcon }) => (hasIcon ? dataTableActionContainerSize : theme.space.content)}px;
+  visibility: hidden;
+  pointer-events: none;
+  white-space: pre;
+`
 
 export const ActionsContainer = styled.div`
   display: flex;

--- a/src/DataTableHeader/DataTableHeader.styled.ts
+++ b/src/DataTableHeader/DataTableHeader.styled.ts
@@ -1,4 +1,5 @@
 import styled from "../utils/styled"
+import { dataTableActionContainerSize } from "../DataTable/DataTable.styled"
 
 export const Container = styled.div<{ hasIcon: boolean }>`
   display: grid;
@@ -6,7 +7,10 @@ export const Container = styled.div<{ hasIcon: boolean }>`
   /**
    * The columns are: type, name, "see more" icon, and caret for icons
    */
-  grid-template-columns: ${({ hasIcon }) => (hasIcon ? `36px auto 36px 36px` : `auto 36px 36px`)};
+  grid-template-columns: ${({ hasIcon }) =>
+    hasIcon
+      ? `${dataTableActionContainerSize}px auto ${dataTableActionContainerSize}px ${dataTableActionContainerSize}px`
+      : `auto ${dataTableActionContainerSize}px ${dataTableActionContainerSize}px`};
   width: calc(100% + ${({ theme }) => theme.space.content * 2}px);
   height: 100%;
   margin: 0 -${({ theme }) => theme.space.content}px;

--- a/src/DataTableHeader/DataTableHeader.styled.ts
+++ b/src/DataTableHeader/DataTableHeader.styled.ts
@@ -31,6 +31,7 @@ export const GhostTitleContainer = styled.div<{ hasIcon: boolean }>`
   visibility: hidden;
   pointer-events: none;
   white-space: pre;
+  max-width: 100%;
 `
 
 export const ActionsContainer = styled.div`

--- a/src/DataTableHeader/DataTableHeader.styled.ts
+++ b/src/DataTableHeader/DataTableHeader.styled.ts
@@ -1,0 +1,39 @@
+import styled from "../utils/styled"
+
+export const Container = styled.div<{ hasIcon: boolean }>`
+  display: grid;
+
+  /**
+   * The columns are: type, name, "see more" icon, and caret for icons
+   */
+  grid-template-columns: ${({ hasIcon }) => (hasIcon ? `36px auto 36px 36px` : `auto 36px 36px`)};
+  width: calc(100% + ${({ theme }) => theme.space.content * 2}px);
+  height: 100%;
+  margin: 0 -${({ theme }) => theme.space.content}px;
+  align-items: center;
+  padding-left: ${({ hasIcon, theme }) => (hasIcon ? 0 : theme.space.content)}px;
+  grid-column: 1 / span 2;
+`
+
+export const TitleContainer = styled.div`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: pre;
+`
+
+export const ActionsContainer = styled.div`
+  display: flex;
+  align-items: stretch;
+  margin: auto;
+  width: 100%;
+  height: 100%;
+
+  /* The ContextMenu */
+  div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+`

--- a/src/DataTableHeader/DataTableHeader.tsx
+++ b/src/DataTableHeader/DataTableHeader.tsx
@@ -11,22 +11,11 @@ import useViewMore from "../DataTable/useViewMore"
 import ContextMenu from "../ContextMenu/ContextMenu"
 import useWindowSize from "../useWindowSize"
 
-export interface BaseDataTableHeaderProps {
+export interface DataTableHeaderProps {
   title: React.ReactNode
   icon?: IconComponentType
+  actions?: IContextMenuItem[]
 }
-
-export interface DataTableHeaderPropsWithoutActions extends BaseDataTableHeaderProps {
-  actions?: never
-  onPerformAction?: never
-}
-
-export interface DataTableHeaderPropsWithActions extends BaseDataTableHeaderProps {
-  actions: IContextMenuItem[]
-  onPerformAction: (action: IContextMenuItem) => void
-}
-
-type DataTableHeaderProps = DataTableHeaderPropsWithoutActions | DataTableHeaderPropsWithActions
 
 const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon: Icon, actions, title }) => {
   const $title = React.useRef<HTMLDivElement>(null)

--- a/src/DataTableHeader/DataTableHeader.tsx
+++ b/src/DataTableHeader/DataTableHeader.tsx
@@ -2,13 +2,14 @@ import * as React from "react"
 import { createPortal } from "react-dom"
 import noop from "lodash/noop"
 
-import { ActionsContainer, Container, TitleContainer } from "./DataTableHeader.styled"
+import { ActionsContainer, Container, TitleContainer, GhostTitleContainer } from "./DataTableHeader.styled"
 import { IconComponentType, DotMenuHorizontalIcon, ChevronDownIcon } from "../Icon"
 import { IContextMenuItem } from "../ContextMenu/ContextMenu.Item"
 import isString = require("lodash/isString")
 import { ViewMorePopup } from "../DataTable/DataTable.styled"
 import useViewMore from "../DataTable/useViewMore"
 import ContextMenu from "../ContextMenu/ContextMenu"
+import useWindowSize from "../useWindowSize"
 
 export interface BaseDataTableHeaderProps {
   title: React.ReactNode
@@ -28,26 +29,38 @@ export interface DataTableHeaderPropsWithActions extends BaseDataTableHeaderProp
 type DataTableHeaderProps = DataTableHeaderPropsWithoutActions | DataTableHeaderPropsWithActions
 
 const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon: Icon, actions, title }) => {
-  const titleGlyphSize = 8
   const $title = React.useRef<HTMLDivElement>(null)
-  const [isTitleProbablyOverflowing, setIsTitleProbablyOverflowing] = React.useState(false)
+  const $ghostTitle = React.useRef<HTMLDivElement>(null)
+  const [isTitleOverflowing, setIsTitleOverflowing] = React.useState(false)
   const { open, viewMorePopup } = useViewMore()
+  const { width } = useWindowSize()
 
   React.useLayoutEffect(() => {
     const currentTitle = $title.current
+    const ghostTitle = $ghostTitle.current
 
-    if (currentTitle) {
-      const rect = currentTitle.getBoundingClientRect()
-      setIsTitleProbablyOverflowing(isString(title) && rect.width < title.length * titleGlyphSize)
+    if (!currentTitle) {
+      return
     }
-  }, [])
+
+    if (!ghostTitle) {
+      return
+    }
+
+    setIsTitleOverflowing(
+      isString(title) && currentTitle.getBoundingClientRect().width < ghostTitle.getBoundingClientRect().width,
+    )
+  }, [width])
 
   return (
     <>
       <Container hasIcon={Boolean(Icon)}>
         {Icon && <Icon color="primary" style={{ margin: "auto" /* for centering */ }} size={12} />}
         <TitleContainer ref={$title}>{title}</TitleContainer>
-        {isTitleProbablyOverflowing ? (
+        <GhostTitleContainer hasIcon={Boolean(Icon)} ref={$ghostTitle}>
+          {title}
+        </GhostTitleContainer>
+        {isTitleOverflowing ? (
           <DotMenuHorizontalIcon
             style={{ margin: "auto" }}
             onClick={isString(title) ? open(title) : noop}

--- a/src/DataTableHeader/DataTableHeader.tsx
+++ b/src/DataTableHeader/DataTableHeader.tsx
@@ -5,7 +5,7 @@ import noop from "lodash/noop"
 import { ActionsContainer, Container, TitleContainer, GhostTitleContainer } from "./DataTableHeader.styled"
 import { IconComponentType, DotMenuHorizontalIcon, ChevronDownIcon } from "../Icon"
 import { IContextMenuItem } from "../ContextMenu/ContextMenu.Item"
-import isString = require("lodash/isString")
+import isString from "lodash/isString"
 import { ViewMorePopup } from "../DataTable/DataTable.styled"
 import useViewMore from "../DataTable/useViewMore"
 import ContextMenu from "../ContextMenu/ContextMenu"

--- a/src/DataTableHeader/DataTableHeader.tsx
+++ b/src/DataTableHeader/DataTableHeader.tsx
@@ -1,0 +1,84 @@
+import * as React from "react"
+import { createPortal } from "react-dom"
+import noop from "lodash/noop"
+
+import { ActionsContainer, Container, TitleContainer } from "./DataTableHeader.styled"
+import { IconComponentType, DotMenuHorizontalIcon, ChevronDownIcon } from "../Icon"
+import { IContextMenuItem } from "../ContextMenu/ContextMenu.Item"
+import isString = require("lodash/isString")
+import { ViewMorePopup } from "../DataTable/DataTable.styled"
+import useViewMore from "../DataTable/useViewMore"
+import ContextMenu from "../ContextMenu/ContextMenu"
+
+export interface BaseDataTableHeaderProps {
+  title: React.ReactNode
+  icon?: IconComponentType
+}
+
+export interface DataTableHeaderPropsWithoutActions extends BaseDataTableHeaderProps {
+  actions?: never
+  onPerformAction?: never
+}
+
+export interface DataTableHeaderPropsWithActions extends BaseDataTableHeaderProps {
+  actions: IContextMenuItem[]
+  onPerformAction: (action: IContextMenuItem) => void
+}
+
+type DataTableHeaderProps = DataTableHeaderPropsWithoutActions | DataTableHeaderPropsWithActions
+
+const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon: Icon, actions, title }) => {
+  const titleGlyphSize = 8
+  const $title = React.useRef<HTMLDivElement>(null)
+  const [isTitleProbablyOverflowing, setIsTitleProbablyOverflowing] = React.useState(false)
+  const { open, viewMorePopup } = useViewMore()
+
+  React.useLayoutEffect(() => {
+    const currentTitle = $title.current
+
+    if (currentTitle) {
+      const rect = currentTitle.getBoundingClientRect()
+      setIsTitleProbablyOverflowing(isString(title) && rect.width < title.length * titleGlyphSize)
+    }
+  }, [])
+
+  return (
+    <>
+      <Container hasIcon={Boolean(Icon)}>
+        {Icon && <Icon color="primary" style={{ margin: "auto" /* for centering */ }} size={12} />}
+        <TitleContainer ref={$title}>{title}</TitleContainer>
+        {isTitleProbablyOverflowing ? (
+          <DotMenuHorizontalIcon
+            style={{ margin: "auto" }}
+            onClick={isString(title) ? open(title) : noop}
+            color="color.text.lighter"
+            size={20}
+          />
+        ) : (
+          <div /> // Just to fill the grid column with emptiness and use the next one.
+        )}
+        {actions && (
+          <ActionsContainer>
+            <ContextMenu items={actions}>
+              <ChevronDownIcon color="color.text.lighter" size={20} onClick={noop} />
+            </ContextMenu>
+          </ActionsContainer>
+        )}
+      </Container>
+
+      {/**
+       * Portals because position: sticky; support is sketchy.
+       * We render the popup _just_ before </body>.
+       */}
+      {viewMorePopup &&
+        createPortal(
+          <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x}>
+            {viewMorePopup.content}
+          </ViewMorePopup>,
+          document.body,
+        )}
+    </>
+  )
+}
+
+export default DataTableHeader

--- a/src/DataTableHeader/README.md
+++ b/src/DataTableHeader/README.md
@@ -1,0 +1,1 @@
+This component can be used as a more sophisticated header for [`DataTable`](/#/Components/DataTable). Please see the first example of [`DataTable`](/#/Components/DataTable) for usage.

--- a/src/DataTableSelect/DataTableSelect.tsx
+++ b/src/DataTableSelect/DataTableSelect.tsx
@@ -12,7 +12,7 @@ const StyledSelect = styled(Select)`
   width: calc(100% + ${({ theme }) => theme.space.content * 2}px); /* 2 for left _and_ right. */
   border-radius: 0;
 
-  [role="listbox"] > div:nth-child(2) {
+  [role="listbox"] > div:nth-of-type(2) {
     box-shadow: 0 4px 9px 2px rgba(0, 0, 0, 0.3);
   }
 

--- a/src/DropdownButton/DropdownButton.tsx
+++ b/src/DropdownButton/DropdownButton.tsx
@@ -83,7 +83,14 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
   })
 
   return (
-    <ContextMenuWithBorder {...props} onClick={onItemClick} iconLocation="right" items={itemsWithCarets} align={align}>
+    <ContextMenuWithBorder
+      {...props}
+      anchored
+      onClick={onItemClick}
+      iconLocation="right"
+      items={itemsWithCarets}
+      align={align}
+    >
       {isOpen => {
         return (
           <BaseDropdownButton

--- a/src/Foldable/Foldable.tsx
+++ b/src/Foldable/Foldable.tsx
@@ -14,16 +14,16 @@ export interface FoldableProps {
 }
 
 const Foldable = ({ initialState = "open", children }: FoldableProps) => {
-  const togglerRef = React.useRef<HTMLDivElement>(null)
+  const $toggler = React.useRef<HTMLDivElement>(null)
   const [isParentFolded, setIsFolded] = React.useState(initialState === "closed")
   const [isTogglerHovered, setIsTogglerHovered] = React.useState(false)
 
   React.useEffect(() => {
     const handleMouseMove = (e: any) => {
-      if (togglerRef.current === null) {
+      if ($toggler.current === null) {
         return
       }
-      if (isTogglerHovered && !e.path.map((el: HTMLElement) => el.className).includes(togglerRef.current.className)) {
+      if (isTogglerHovered && !e.path.map((el: HTMLElement) => el.className).includes($toggler.current.className)) {
         setIsTogglerHovered(false)
       }
     }

--- a/src/HeaderMenu/HeaderMenu.tsx
+++ b/src/HeaderMenu/HeaderMenu.tsx
@@ -91,7 +91,7 @@ class HeaderMenu extends React.PureComponent<HeaderMenuProps, Readonly<HeaderMen
     withCaret: false,
   }
 
-  private menuRef = React.createRef<HTMLDivElement>()
+  private $menu = React.createRef<HTMLDivElement>()
 
   public componentDidMount() {
     this.updateRenderedWidth()
@@ -116,10 +116,10 @@ class HeaderMenu extends React.PureComponent<HeaderMenuProps, Readonly<HeaderMen
   }, 200)
 
   private updateRenderedWidth() {
-    if (!this.menuRef || this.menuRef.current === null) {
+    if (!this.$menu || this.$menu.current === null) {
       return
     }
-    const node = this.menuRef.current
+    const node = this.$menu.current
     const renderedMenuWidth = node.clientWidth
     if (renderedMenuWidth !== this.state.renderedMenuWidth) {
       this.setState(() => ({
@@ -133,7 +133,7 @@ class HeaderMenu extends React.PureComponent<HeaderMenuProps, Readonly<HeaderMen
     return (
       <HeaderContextMenu width={this.state.renderedMenuWidth} {...props}>
         {isOpen => (
-          <Container ref={this.menuRef} isOpen={isOpen} align={props.align} withCaret={Boolean(props.withCaret)}>
+          <Container ref={this.$menu} isOpen={isOpen} align={props.align} withCaret={Boolean(props.withCaret)}>
             {props.children}
           </Container>
         )}

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -107,16 +107,16 @@ const getTabIndexByName = (tabs: Tab[], tabName?: string): number => {
 }
 
 const SingleTab = ({ id, index, isActive, onTabClick, tab, isKeyboardActive }: SingleTabProps) => {
-  const ref = React.useRef<HTMLDivElement>(null)
+  const $container = React.useRef<HTMLDivElement>(null)
   useEffect(() => {
-    if (isActive && isKeyboardActive && ref.current) {
-      ref.current.focus()
+    if (isActive && isKeyboardActive && $container.current) {
+      $container.current.focus()
     }
   }, [isKeyboardActive, isActive])
 
   return (
     <TabContainer
-      ref={ref}
+      ref={$container}
       role="tab"
       active={isActive}
       aria-selected={isActive}

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -37,12 +37,12 @@ export const Select: React.FC<SelectProps> = ({
 }) => {
   const uniqueId = useUniqueId(id)
   const [filter, setFilter] = React.useState("")
-  const containerRef = React.useRef<HTMLDivElement>(null)
-  const inputRef = React.useMemo(() => React.createRef<HTMLInputElement>(), [])
+  const $container = React.useRef<HTMLDivElement>(null)
+  const $input = React.useMemo(() => React.createRef<HTMLInputElement>(), [])
 
   React.useEffect(() => {
-    if (customOption && value === customOption.value && inputRef.current) {
-      inputRef.current.focus()
+    if (customOption && value === customOption.value && $input.current) {
+      $input.current.focus()
     }
   }, [value, customOption])
 
@@ -114,11 +114,11 @@ export const Select: React.FC<SelectProps> = ({
         if (onChange) {
           onChange(getNewValue(value)(item.value), getOptionFromItem(items)(item))
         }
-        if (containerRef.current) {
-          containerRef.current.focus()
+        if ($container.current) {
+          $container.current.focus()
         }
-        if (inputRef.current) {
-          inputRef.current.focus()
+        if ($input.current) {
+          $input.current.focus()
         }
       }}
       disabled={disabled}
@@ -131,7 +131,7 @@ export const Select: React.FC<SelectProps> = ({
       {isOpen => (
         <Listbox
           fullWidth={Boolean(fullWidth)}
-          ref={containerRef}
+          ref={$container}
           aria-labelledby={`operational-ui__Select-Label-${uniqueId}`}
           aria-disabled={Boolean(disabled)}
           disabled={Boolean(disabled)}
@@ -146,7 +146,7 @@ export const Select: React.FC<SelectProps> = ({
             naked={Boolean(naked)}
           >
             <SelectInput
-              inputRef={inputRef}
+              inputRef={$input}
               fullWidth={fullWidth}
               tabIndex={customOption && customOption.value === value ? 0 : -1}
               disabled={disabled}

--- a/src/SidenavItem/Popout.tsx
+++ b/src/SidenavItem/Popout.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
+
 import styled from "../utils/styled"
+import useSticky from "../useSticky/useSticky"
 
 export interface SidenavPopoutProps {
   ref?: React.RefObject<HTMLDivElement>
@@ -25,29 +27,7 @@ const ScrollTrap = styled("div")`
 
 export const SidenavPopout: React.FC<SidenavPopoutProps> = ({ children, ...props }) => {
   const containerNode = React.useRef<HTMLDivElement>(null)
-  const [top, setTop] = React.useState("0")
-  const [alignment, setAlignment] = React.useState("flex-start")
-  const [left, setLeft] = React.useState("100%")
-  const [position, setPosition] = React.useState("absolute")
-
-  React.useLayoutEffect(() => {
-    const node = containerNode.current
-    if (node) {
-      const rect = node.getBoundingClientRect()
-      setLeft(`${rect.left}px`)
-
-      // If we're in the lower half of the screen
-      if (rect.top > window.innerHeight / 2) {
-        // open towards the top
-        setTop(`${rect.top - (rect.height - (node.parentElement ? node.parentElement.clientHeight : 0))}px`)
-        setAlignment("flex-end")
-      } else {
-        setTop(`${rect.top}px`)
-        setAlignment("flex-start")
-      }
-      setPosition("fixed")
-    }
-  }, [])
+  const { alignment, left, position, top } = useSticky(containerNode)
 
   return (
     <Container {...props} position={position} top={top} alignment={alignment} left={left} ref={containerNode}>

--- a/src/SidenavItem/Popout.tsx
+++ b/src/SidenavItem/Popout.tsx
@@ -34,7 +34,6 @@ export const SidenavPopout: React.FC<SidenavPopoutProps> = ({ children, ...props
     const node = $container.current
     if (node) {
       const rect = node.getBoundingClientRect()
-      console.log(node, rect.top, height)
       // If we're in the lower half of the screen
       if (rect.top > height / 2) {
         // open towards the top

--- a/src/SidenavItem/Popout.tsx
+++ b/src/SidenavItem/Popout.tsx
@@ -2,12 +2,13 @@ import * as React from "react"
 
 import styled from "../utils/styled"
 import useSticky from "../useSticky/useSticky"
+import useWindowSize from "../useWindowSize"
 
 export interface SidenavPopoutProps {
   ref?: React.RefObject<HTMLDivElement>
 }
 
-const Container = styled("div")<{ top: string; alignment: string; left: string; position: string }>`
+const Container = styled("div")<{ top: string; left: string; position: string }>`
   position: ${({ position }) => position};
   top: ${({ top }) => top};
   left: ${({ left }) => left};
@@ -17,7 +18,6 @@ const Container = styled("div")<{ top: string; alignment: string; left: string; 
   z-index: ${({ theme }) => theme.zIndex.selectOptions + 1};
   display: flex;
   flex-direction: column;
-  justify-content: ${({ alignment }) => alignment};
 `
 
 const ScrollTrap = styled("div")`
@@ -27,10 +27,28 @@ const ScrollTrap = styled("div")`
 
 export const SidenavPopout: React.FC<SidenavPopoutProps> = ({ children, ...props }) => {
   const containerNode = React.useRef<HTMLDivElement>(null)
-  const { alignment, left, position, top } = useSticky({ inputRef: containerNode })
+  const [initialTop, setInitialTop] = React.useState("0")
+  const { height } = useWindowSize()
+
+  React.useLayoutEffect(() => {
+    const node = containerNode.current
+    if (node) {
+      const rect = node.getBoundingClientRect()
+      console.log(node, rect.top, height)
+      // If we're in the lower half of the screen
+      if (rect.top > height / 2) {
+        // open towards the top
+        setInitialTop(`${rect.top - (rect.height - (node.parentElement ? node.parentElement.clientHeight : 0))}px`)
+      } else {
+        setInitialTop(`${rect.top}px`)
+      }
+    }
+  }, [height])
+
+  const { left, position } = useSticky({ inputRef: containerNode })
 
   return (
-    <Container {...props} position={position} top={top} alignment={alignment} left={left} ref={containerNode}>
+    <Container {...props} position={position} top={initialTop} left={left} ref={containerNode}>
       <ScrollTrap>{children}</ScrollTrap>
     </Container>
   )

--- a/src/SidenavItem/Popout.tsx
+++ b/src/SidenavItem/Popout.tsx
@@ -12,7 +12,7 @@ const Container = styled("div")<{ top: string; alignment: string; left: string; 
   top: ${({ top }) => top};
   left: ${({ left }) => left};
   width: 256px;
-  height: 100vh;
+  max-height: 90vh;
   overflow: hidden;
   z-index: ${({ theme }) => theme.zIndex.selectOptions + 1};
   display: flex;
@@ -27,7 +27,7 @@ const ScrollTrap = styled("div")`
 
 export const SidenavPopout: React.FC<SidenavPopoutProps> = ({ children, ...props }) => {
   const containerNode = React.useRef<HTMLDivElement>(null)
-  const { alignment, left, position, top } = useSticky(containerNode)
+  const { alignment, left, position, top } = useSticky({ inputRef: containerNode })
 
   return (
     <Container {...props} position={position} top={top} alignment={alignment} left={left} ref={containerNode}>

--- a/src/SidenavItem/Popout.tsx
+++ b/src/SidenavItem/Popout.tsx
@@ -26,12 +26,12 @@ const ScrollTrap = styled("div")`
 `
 
 export const SidenavPopout: React.FC<SidenavPopoutProps> = ({ children, ...props }) => {
-  const containerNode = React.useRef<HTMLDivElement>(null)
+  const $container = React.useRef<HTMLDivElement>(null)
   const [initialTop, setInitialTop] = React.useState("0")
   const { height } = useWindowSize()
 
   React.useLayoutEffect(() => {
-    const node = containerNode.current
+    const node = $container.current
     if (node) {
       const rect = node.getBoundingClientRect()
       console.log(node, rect.top, height)
@@ -45,10 +45,10 @@ export const SidenavPopout: React.FC<SidenavPopoutProps> = ({ children, ...props
     }
   }, [height])
 
-  const { left, position } = useSticky({ inputRef: containerNode })
+  const { left, position } = useSticky({ $el: $container })
 
   return (
-    <Container {...props} position={position} top={initialTop} left={left} ref={containerNode}>
+    <Container {...props} position={position} top={initialTop} left={left} ref={$container}>
       <ScrollTrap>{children}</ScrollTrap>
     </Container>
   )

--- a/src/Stepper/Stepper.tsx
+++ b/src/Stepper/Stepper.tsx
@@ -160,10 +160,10 @@ const Stepper: React.FC<StepperProps> = props => {
   })
 
   // Set actual focus on each render
-  const focusedTabRef = React.useRef<HTMLLIElement>(null)
+  const $focusedTab = React.useRef<HTMLLIElement>(null)
   React.useEffect(() => {
-    if (focusedTabRef.current && focusedTab.shouldFocus) {
-      focusedTabRef.current.focus()
+    if ($focusedTab.current && focusedTab.shouldFocus) {
+      $focusedTab.current.focus()
       setFocusedTab({ ...focusedTab, shouldFocus: false })
     }
   }, [focusedTab])
@@ -190,7 +190,7 @@ const Stepper: React.FC<StepperProps> = props => {
           return (
             <Step
               data-cy={`operational-ui__Stepper__step-${index}`}
-              ref={index === focusedTab.index ? focusedTabRef : undefined}
+              ref={index === focusedTab.index ? $focusedTab : undefined}
               tabIndex={index === focusedTab.index ? 0 : -1}
               key={index}
               stepState={stepState}

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -58,10 +58,10 @@ const Tabs: React.FC<TabsProps> = ({
   // track if action was triggered by user or not
   // we need this to activate focus in case action was triggered by user, but not if it was re-render
   const userAction = React.useRef(false)
-  const activeTab = React.useRef<HTMLDivElement>(null)
+  const $activeTab = React.useRef<HTMLDivElement>(null)
   React.useEffect(() => {
-    if (activeTab.current && userAction.current) {
-      activeTab.current.focus()
+    if ($activeTab.current && userAction.current) {
+      $activeTab.current.focus()
       userAction.current = false
     }
   }, [active, tabs])
@@ -121,28 +121,28 @@ const Tabs: React.FC<TabsProps> = ({
     [active, onActivate, onInsert],
   )
 
-  const tabListRef = React.useRef<HTMLDivElement>(null)
-  const tabScrollRef = React.useRef<HTMLDivElement>(null)
+  const $tabList = React.useRef<HTMLDivElement>(null)
+  const $tabScroll = React.useRef<HTMLDivElement>(null)
   const [leftDisabled, setLeftDisabled] = React.useState(true)
   const [rightDisabled, setRightDisabled] = React.useState(true)
 
   const scrollLeft = React.useCallback(event => {
     event && event.preventDefault() // so the button won't get focus when clicked
-    if (tabListRef.current) {
-      tabListRef.current.scrollLeft = tabListRef.current.scrollLeft - 100
+    if ($tabList.current) {
+      $tabList.current.scrollLeft = $tabList.current.scrollLeft - 100
     }
   }, [])
 
   const scrollRight = React.useCallback(event => {
     event && event.preventDefault() // so the button won't get focus when clicked
-    if (tabListRef.current) {
-      tabListRef.current.scrollLeft = tabListRef.current.scrollLeft + 100
+    if ($tabList.current) {
+      $tabList.current.scrollLeft = $tabList.current.scrollLeft + 100
     }
   }, [])
 
   const onScroll = React.useCallback(() => {
-    if (tabListRef.current) {
-      const tabListElement = tabListRef.current
+    if ($tabList.current) {
+      const tabListElement = $tabList.current
       const scrollLeft = tabListElement.scrollLeft
       setLeftDisabled(scrollLeft === 0)
       setRightDisabled(scrollLeft === tabListElement.scrollWidth - tabListElement.offsetWidth)
@@ -159,8 +159,8 @@ const Tabs: React.FC<TabsProps> = ({
   return (
     <Container data-cy="operational-ui__Tabs" style={style}>
       <PlusWrapper>
-        <TabList scroll={Boolean(scroll)} aria-label={label} onKeyDown={onKeyDown} ref={tabListRef} onScroll={onScroll}>
-          <TabScroll ref={tabScrollRef}>
+        <TabList scroll={Boolean(scroll)} aria-label={label} onKeyDown={onKeyDown} ref={$tabList} onScroll={onScroll}>
+          <TabScroll ref={$tabScroll}>
             {tabs.map(({ title, icon, color }, i) => {
               const onClick = () => {
                 onActivate(i)
@@ -180,7 +180,7 @@ const Tabs: React.FC<TabsProps> = ({
                       onClose(i)
                     }
                   }}
-                  ref={i === active ? activeTab : undefined}
+                  ref={i === active ? $activeTab : undefined}
                   color={color}
                   last={i === tabs.length - 1}
                 >

--- a/src/TopbarSelect/TopbarSelect.tsx
+++ b/src/TopbarSelect/TopbarSelect.tsx
@@ -72,6 +72,7 @@ const TopbarSelect = ({ label, selected, items, onChange, ...props }: TopbarSele
 
   return (
     <ContextMenu
+      anchored
       condensed
       items={items}
       width={containerWidth}

--- a/src/TopbarSelect/TopbarSelect.tsx
+++ b/src/TopbarSelect/TopbarSelect.tsx
@@ -62,11 +62,11 @@ const TopbarSelect = ({ label, selected, items, onChange, ...props }: TopbarSele
     const item = items.find(item => (typeof item === "string" ? false : item.label === selected))
     return typeof item === "object" && item.icon
   }, [items, selected])
-  const containerRef = useRef<HTMLDivElement>(null)
+  const $container = useRef<HTMLDivElement>(null)
 
   useLayoutEffect(() => {
-    if (containerRef.current) {
-      setContainerWidth(containerRef.current.clientWidth)
+    if ($container.current) {
+      setContainerWidth($container.current.clientWidth)
     }
   })
 
@@ -82,7 +82,7 @@ const TopbarSelect = ({ label, selected, items, onChange, ...props }: TopbarSele
       }}
     >
       {isActive => (
-        <TopbarSelectContainer {...props} isActive={isActive} ref={containerRef}>
+        <TopbarSelectContainer {...props} isActive={isActive} ref={$container}>
           <TopbarSelectLabel>{label}</TopbarSelectLabel>
           <TopbarSelectValue>
             {Icon && <Icon left />}

--- a/src/TourModal/TourModal.tsx
+++ b/src/TourModal/TourModal.tsx
@@ -94,8 +94,8 @@ const TourModal: React.FC<TourModalProps> = ({
   isLast,
   messages = { quit: "Quit the Tour", finish: "Finish", continue: "Continue" },
 }) => {
-  const body = React.useRef(document.body)
-  useHotkey(body, { key: "Escape" }, () => {
+  const $body = React.useRef(document.body)
+  useHotkey($body, { key: "Escape" }, () => {
     if (onQuit && !isLast) {
       onQuit()
     }

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -145,15 +145,15 @@ const TreeItem: React.SFC<TreeItemProps> = ({
 
   const [viewMorePopup, setViewMorePopup] = useState<{ x: number; y: number; content: string } | null>(null)
   const [isTooLong, setIsTooLong] = useState(false)
-  const labelRef = useRef<HTMLDivElement>(null)
+  const $label = useRef<HTMLDivElement>(null)
 
   // We compute this on every re-render to handle the resize
   // (resize event is only supported by chrome for now)
   useLayoutEffect(() => {
     // We can't attach the ref to `Highlighter`, this is why we attached the ref
     // to the parent and using `children[0]`
-    if (labelRef.current && labelRef.current.children[0]) {
-      const { height } = labelRef.current.children[0].getBoundingClientRect()
+    if ($label.current && $label.current.children[0]) {
+      const { height } = $label.current.children[0].getBoundingClientRect()
       setIsTooLong(height > 16)
     }
   })
@@ -192,7 +192,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
           color: iconColor || "color.text.lighter",
           style: { marginLeft: 0, marginRight: 4, flex: "0 0 15px" },
         })}
-      <Label hasChildren={hasChildren} ref={labelRef}>
+      <Label hasChildren={hasChildren} ref={$label}>
         <Highlighter
           textToHighlight={label}
           highlightStyle={{ color: constants.color.text.action, backgroundColor: "transparent", fontWeight: "bold" }}
@@ -207,13 +207,13 @@ const TreeItem: React.SFC<TreeItemProps> = ({
             /** Just the hover style! */
           }}
           onMouseEnter={() => {
-            if (labelRef.current) {
-              const { right, top } = labelRef.current.getBoundingClientRect()
+            if ($label.current) {
+              const { right, top } = $label.current.getBoundingClientRect()
               setViewMorePopup({ y: top + viewMoreIconSize, x: right + viewMoreIconSize, content: label })
             }
           }}
           onMouseLeave={() => {
-            if (labelRef.current) {
+            if ($label.current) {
               setViewMorePopup(null)
             }
           }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export { default as DropdownButton, DropdownButtonProps } from "./DropdownButton
 export { default as Contact, ContactProps } from "./Contact/Contact"
 export { default as ContextMenu, ContextMenuProps } from "./ContextMenu/ContextMenu"
 export { default as DataTable, DataTableProps } from "./DataTable/DataTable"
+export { default as DataTableHeader } from "./DataTableHeader/DataTableHeader"
 export { default as DataTableFooter } from "./DataTableFooter/DataTableFooter"
 export { default as DataTableInput } from "./DataTableInput/DataTableInput"
 export { default as DataTableSelect } from "./DataTableSelect/DataTableSelect"

--- a/src/useListbox/index.ts
+++ b/src/useListbox/index.ts
@@ -20,14 +20,14 @@ export const useListbox = ({
   isDisabled = false,
   initiallyOpen = false,
 }: UseListboxOptions) => {
-  const buttonRef = useRef<HTMLDivElement>(null)
-  const listboxRef = useRef<HTMLDivElement>(null)
+  const $button = useRef<HTMLDivElement>(null)
+  const $listbox = useRef<HTMLDivElement>(null)
   const [isOpen, _setIsOpen] = useState(initiallyOpen)
   const [focusedOptionIndex, setFocusedOptionIndex] = useState<number | null | undefined>()
   const id = useUniqueId()
 
   useEffect(() => {
-    const node = buttonRef.current
+    const node = $button.current
     if (node) {
       if (focusedOptionIndex === null) {
         node.focus()
@@ -139,7 +139,7 @@ export const useListbox = ({
 
   const handleButtonClick = useCallback(
     e => {
-      const node = buttonRef.current
+      const node = $button.current
       if (e.target === node) {
         _setIsOpen(!isOpen)
       }
@@ -148,7 +148,7 @@ export const useListbox = ({
   )
 
   useEffect(() => {
-    const node = buttonRef.current
+    const node = $button.current
 
     if (node) {
       node.addEventListener("keydown", handleKeyDown)
@@ -170,7 +170,7 @@ export const useListbox = ({
     isOpen: isOpen,
     setIsOpen: setIsOpen,
     buttonProps: {
-      ref: buttonRef,
+      ref: $button,
       tabIndex: isDisabled ? -1 : 0,
       role: "button",
       "aria-expanded": isOpen,
@@ -178,7 +178,7 @@ export const useListbox = ({
       "aria-disabled": Boolean(isDisabled),
     },
     listboxProps: {
-      ref: listboxRef,
+      ref: $listbox,
       role: "listbox",
       // tabIndex: -1,
       ...(focusedOptionIndex !== null && {

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -20,7 +20,7 @@ const useSticky = ({
   options,
   initialValue,
 }: {
-  inputRef: React.Ref<HTMLDivElement>
+  inputRef: React.Ref<HTMLElement>
   options?: {
     shouldAvoidToggler: boolean
   }

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -1,4 +1,5 @@
 import * as React from "react"
+import get from "lodash/get"
 
 /**
  *
@@ -14,16 +15,23 @@ import * as React from "react"
  * @param inputRef - a ref to the component we would like to stick
  * @param initialValue - initial positioning CSS values
  */
-const useSticky = (
-  inputRef: React.Ref<HTMLDivElement>,
+const useSticky = ({
+  inputRef,
+  options,
+  initialValue,
+}: {
+  inputRef: React.Ref<HTMLDivElement>
+  options?: {
+    shouldAvoidToggler: boolean
+  }
   initialValue?: {
     top: string
     left: string
     width?: string
     position: "fixed" | "absolute" | "sticky" | "relative" | "static" | "initial"
     alignment: "flex-start" | "flex-end"
-  },
-) => {
+  }
+}) => {
   const defaultDisplaySettings = {
     top: initialValue ? initialValue.top : "0",
     left: initialValue ? initialValue.left : "100%",
@@ -47,9 +55,12 @@ const useSticky = (
 
       if (!hasEnoughRoomUnderContainer) {
         // open towards the top
-        ;(draftSettings.top = `${rect.top -
-          (rect.height + (node.parentElement ? node.parentElement.getBoundingClientRect().height : 0))}px`),
-          (draftSettings.alignment = "flex-end")
+        draftSettings.top = get(options, "shouldAvoidToggler", false)
+          ? `${rect.top -
+              (rect.height + (node.parentElement ? node.parentElement.getBoundingClientRect().height : 0))}px`
+          : `${rect.top - (rect.height - (node.parentElement ? node.parentElement.clientHeight : 0))}px`
+
+        draftSettings.alignment = "flex-end"
       } else {
         draftSettings.top = `${rect.top}px`
         draftSettings.alignment = "flex-start"

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -76,7 +76,7 @@ const useSticky = ({
       draftSettings.position = "fixed"
       setDisplaySettings({ ...displaySettings, ...draftSettings })
     }
-  }, [inputRef])
+  }, [inputRef, options])
 
   return displaySettings
 }

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { isRefRefObject } from "../utils/isRefRefObject"
 
 /**
  *
@@ -19,7 +18,7 @@ const useSticky = ({
   $el,
   initialValue,
 }: {
-  $el: React.Ref<HTMLElement>
+  $el: React.RefObject<HTMLElement>
   initialValue?: {
     top?: string
     left?: string
@@ -37,7 +36,7 @@ const useSticky = ({
   const [displaySettings, setDisplaySettings] = React.useState(defaultDisplaySettings)
 
   React.useLayoutEffect(() => {
-    const node = isRefRefObject($el) && $el.current
+    const node = $el.current
 
     if (node) {
       const rect = node.getBoundingClientRect()

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -1,0 +1,66 @@
+import * as React from "react"
+
+/**
+ *
+ * Hook to take a component from an initial position
+ * and FIX/stick it to the screen. Typically used for
+ * nailing down positions of elements and then placing
+ * them above other elements in the viewport.
+ *
+ * Used in:
+ * - SidenavItem/Popout
+ * - ContextMenu
+ *
+ * @param inputRef - a ref to the component we would like to stick
+ * @param initialValue - initial positioning CSS values
+ */
+const useSticky = (
+  inputRef: React.Ref<HTMLDivElement>,
+  initialValue?: {
+    top: string
+    left: string
+    width?: string
+    position: "fixed" | "absolute" | "sticky" | "relative" | "static" | "initial"
+    alignment: "flex-start" | "flex-end"
+  },
+) => {
+  const defaultDisplaySettings = {
+    top: initialValue ? initialValue.top : "0",
+    left: initialValue ? initialValue.left : "100%",
+    width: initialValue ? initialValue.width : "100%",
+    position: initialValue ? initialValue.position : "absolute",
+    alignment: initialValue ? initialValue.alignment : "flex-start",
+  }
+
+  const [displaySettings, setDisplaySettings] = React.useState(defaultDisplaySettings)
+
+  React.useLayoutEffect(() => {
+    const node = inputRef && (inputRef as React.RefObject<HTMLDivElement>).current // ts can't figure out it's a refObject and thinks it's a function ref.
+
+    if (node) {
+      const draftSettings: Partial<typeof defaultDisplaySettings> = {}
+      const rect = node.getBoundingClientRect()
+      const hasEnoughRoomUnderContainer = rect.top + rect.height + window.scrollY < window.scrollY + window.innerHeight
+
+      draftSettings.left = `${rect.left}px`
+      draftSettings.width = `${rect.width}px`
+
+      if (!hasEnoughRoomUnderContainer) {
+        // open towards the top
+        ;(draftSettings.top = `${rect.top -
+          (rect.height + (node.parentElement ? node.parentElement.getBoundingClientRect().height : 0))}px`),
+          (draftSettings.alignment = "flex-end")
+      } else {
+        draftSettings.top = `${rect.top}px`
+        draftSettings.alignment = "flex-start"
+      }
+
+      draftSettings.position = "fixed"
+      setDisplaySettings({ ...displaySettings, ...draftSettings })
+    }
+  }, [inputRef])
+
+  return displaySettings
+}
+
+export default useSticky

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -1,5 +1,5 @@
 import * as React from "react"
-import get from "lodash/get"
+import { isRefRefObject } from "../utils/isRefRefObject"
 
 /**
  *
@@ -17,67 +17,33 @@ import get from "lodash/get"
  */
 const useSticky = ({
   inputRef,
-  options,
   initialValue,
 }: {
   inputRef: React.Ref<HTMLElement>
-  options?: {
-    shouldAvoidToggler: boolean
-  }
   initialValue?: {
-    top: string
-    left: string
+    top?: string
+    left?: string
     width?: string
-    position: "fixed" | "absolute" | "sticky" | "relative" | "static" | "initial"
-    alignment: "flex-start" | "flex-end"
+    position?: "fixed" | "absolute" | "sticky" | "relative" | "static" | "initial"
   }
 }) => {
   const defaultDisplaySettings = {
-    top: initialValue ? initialValue.top : "0",
-    left: initialValue ? initialValue.left : "100%",
-    width: initialValue ? initialValue.width : "100%",
-    position: initialValue ? initialValue.position : "absolute",
-    alignment: initialValue ? initialValue.alignment : "flex-start",
+    top: (initialValue && initialValue.top) || "0",
+    left: (initialValue && initialValue.left) || "100%",
+    width: (initialValue && initialValue.width) || "100%",
+    position: (initialValue && initialValue.position) || "absolute",
   }
 
   const [displaySettings, setDisplaySettings] = React.useState(defaultDisplaySettings)
-  const shouldAvoidToggler = get(options, "shouldAvoidToggler", false)
 
   React.useLayoutEffect(() => {
-    /**
-     * inputRef is of type React.Ref
-     * React.Ref = ((instance: HTMLElement | null) => void) | React.RefObject<HTMLElement> | undefined
-     *
-     * We check for emptiness first with &&, but then we still need the `as` assertion because
-     * ts can't figure out that React.Ref in this case is a React.RefObject and NOT a function-style ref.
-     */
-    const node = inputRef && (inputRef as React.RefObject<HTMLDivElement>).current
+    const node = isRefRefObject(inputRef) && inputRef.current
 
     if (node) {
-      const draftSettings: Partial<typeof defaultDisplaySettings> = {}
       const rect = node.getBoundingClientRect()
-      const hasEnoughRoomUnderContainer = rect.top + rect.height + window.scrollY < window.scrollY + window.innerHeight
-
-      draftSettings.left = `${rect.left}px`
-      draftSettings.width = `${rect.width}px`
-
-      if (!hasEnoughRoomUnderContainer) {
-        // open towards the top
-        draftSettings.top = shouldAvoidToggler
-          ? `${rect.top -
-              (rect.height + (node.parentElement ? node.parentElement.getBoundingClientRect().height : 0))}px`
-          : `${rect.top - (rect.height - (node.parentElement ? node.parentElement.clientHeight : 0))}px`
-
-        draftSettings.alignment = "flex-end"
-      } else {
-        draftSettings.top = `${rect.top}px`
-        draftSettings.alignment = "flex-start"
-      }
-
-      draftSettings.position = "fixed"
-      setDisplaySettings({ ...displaySettings, ...draftSettings })
+      setDisplaySettings({ position: "fixed", left: `${rect.left}px`, width: `${rect.width}px`, top: `${rect.top}px` })
     }
-  }, [inputRef, shouldAvoidToggler])
+  }, [inputRef])
 
   return displaySettings
 }

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -41,6 +41,7 @@ const useSticky = ({
   }
 
   const [displaySettings, setDisplaySettings] = React.useState(defaultDisplaySettings)
+  const shouldAvoidToggler = get(options, "shouldAvoidToggler", false)
 
   React.useLayoutEffect(() => {
     /**
@@ -62,7 +63,7 @@ const useSticky = ({
 
       if (!hasEnoughRoomUnderContainer) {
         // open towards the top
-        draftSettings.top = get(options, "shouldAvoidToggler", false)
+        draftSettings.top = shouldAvoidToggler
           ? `${rect.top -
               (rect.height + (node.parentElement ? node.parentElement.getBoundingClientRect().height : 0))}px`
           : `${rect.top - (rect.height - (node.parentElement ? node.parentElement.clientHeight : 0))}px`
@@ -76,7 +77,7 @@ const useSticky = ({
       draftSettings.position = "fixed"
       setDisplaySettings({ ...displaySettings, ...draftSettings })
     }
-  }, [inputRef, options])
+  }, [inputRef, shouldAvoidToggler])
 
   return displaySettings
 }

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -12,14 +12,14 @@ import { isRefRefObject } from "../utils/isRefRefObject"
  * - SidenavItem/Popout
  * - ContextMenu
  *
- * @param inputRef - a ref to the component we would like to stick
+ * @param $input - a ref to the component we would like to stick
  * @param initialValue - initial positioning CSS values
  */
 const useSticky = ({
-  inputRef,
+  $el,
   initialValue,
 }: {
-  inputRef: React.Ref<HTMLElement>
+  $el: React.Ref<HTMLElement>
   initialValue?: {
     top?: string
     left?: string
@@ -37,13 +37,13 @@ const useSticky = ({
   const [displaySettings, setDisplaySettings] = React.useState(defaultDisplaySettings)
 
   React.useLayoutEffect(() => {
-    const node = isRefRefObject(inputRef) && inputRef.current
+    const node = isRefRefObject($el) && $el.current
 
     if (node) {
       const rect = node.getBoundingClientRect()
       setDisplaySettings({ position: "fixed", left: `${rect.left}px`, width: `${rect.width}px`, top: `${rect.top}px` })
     }
-  }, [inputRef])
+  }, [$el])
 
   return displaySettings
 }

--- a/src/useSticky/useSticky.ts
+++ b/src/useSticky/useSticky.ts
@@ -43,7 +43,14 @@ const useSticky = ({
   const [displaySettings, setDisplaySettings] = React.useState(defaultDisplaySettings)
 
   React.useLayoutEffect(() => {
-    const node = inputRef && (inputRef as React.RefObject<HTMLDivElement>).current // ts can't figure out it's a refObject and thinks it's a function ref.
+    /**
+     * inputRef is of type React.Ref
+     * React.Ref = ((instance: HTMLElement | null) => void) | React.RefObject<HTMLElement> | undefined
+     *
+     * We check for emptiness first with &&, but then we still need the `as` assertion because
+     * ts can't figure out that React.Ref in this case is a React.RefObject and NOT a function-style ref.
+     */
+    const node = inputRef && (inputRef as React.RefObject<HTMLDivElement>).current
 
     if (node) {
       const draftSettings: Partial<typeof defaultDisplaySettings> = {}

--- a/src/utils/isRefRefObject.ts
+++ b/src/utils/isRefRefObject.ts
@@ -1,3 +1,4 @@
+// React.Ref !== React.RefObject
 export function isRefRefObject<T>(ref: React.Ref<T>): ref is React.RefObject<T> {
   return ref !== null && "current" in ref
 }

--- a/src/utils/isRefRefObject.ts
+++ b/src/utils/isRefRefObject.ts
@@ -1,0 +1,3 @@
+export function isRefRefObject<T>(ref: React.Ref<T>): ref is React.RefObject<T> {
+  return ref !== null && "current" in ref
+}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR implements this spec for `DataTable`:
![image](https://user-images.githubusercontent.com/9947422/65167708-5aa5f380-da43-11e9-9bbd-fcafdaca965b.png)

Of course, implementing the spec was not as straightforward as it seemed. 🤦‍♂ It required a lot more rewiring and updating of related components in the following ways:

## `DataTableHeader`

`DataTable`'s column headers were always `ReactNode`s – meaning they could be `string`s, or other React components. For this reason, we create a new `DataTableHeader` that can go into a column header that supports:

- icons
- text with truncation
- "view more" functionality
- a context menu with actions

## `useSticky`

There has been a recurring need in the product for **true absolute positioning** since Operational UI began: we used to have tooltips that get cut off by a sidenav overflow, various modal issues, and most recently, _super weird behavior_ with `position: sticky;` on the `DataTable` headers. For this reason, I introduced a `useSticky` hook. The behavior was already implemented in [SidenavItem/Popout.tsx](https://github.com/contiamo/operational-ui/blob/a5ddf74251c90be4427c48e9177c16da5d991f55/src/SidenavItem/Popout.tsx#L27-L50) and I started writing the same code before I decided to turn it into a hook.

This hook takes any component. Its order of execution is the following:
- component mounts with initial position (`absolute`, `relative`, whatever)
- get the rect of this component
- set its position to `fixed` and update all coordinates (`top`, `left`, etc.)
- use a [portal](https://reactjs.org/docs/portals.html) and render it outside of our current DOM tree, just above `</body>`

The above flow ensures that `position: fixed` elements are **always on top of things and in the right place**. This was painful to get right, but I think from this point, positioning things will become a whole lot easier.

## `useViewMore`
We have "view more" functionality in two places: 
- `DataTable` cells
- `DataTableHeader`

We grouped the following behavior into a hook for reuse:
- get mouse coordinates
- display popup at coordinates
- display on a side with enough space always
- click outside to close
- do not be longer than the screen
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Breaking Changes
Since the truncation of strings is now dynamic (related to the width of the cell) instead of static (via a magic number), [the `maxCharactersInCell` prop](https://github.com/contiamo/operational-ui/blob/a5ddf74251c90be4427c48e9177c16da5d991f55/src/DataTable/DataTable.tsx#L50) is removed.

# Known issues
The "down arrow" icon is not 100% according to the spec. @nathanedavis1 will provide the right SVG soon and we can solve this in another PR.


# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] No regression on `DataTable`
- [x] No regression on `ContextMenu`
- [x] No regression on `Autocomplete`
- [x] No regression on `Select`
- [x] No regression on `DropdownButton`
- [x] No regression on `TopbarSelect`
- [x] No regression on `SidenavItem`

Tester 1

- [x] Things look good on the demo.
- [x] No regression on `DataTable`
- [x] No regression on `ContextMenu`
- [x] No regression on `Autocomplete`
- [x] No regression on `Select`
- [x] No regression on `DropdownButton`
- [x] No regression on `TopbarSelect`
- [x] No regression on `SidenavItem`
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
- [ ] No regression on `DataTable`
- [ ] No regression on `ContextMenu`
- [ ] No regression on `Autocomplete`
- [ ] No regression on `Select`
- [ ] No regression on `DropdownButton`
- [ ] No regression on `TopbarSelect`
- [ ] No regression on `SidenavItem`
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
