### PR TITLE
**Fix:** Update truncation behavior

### DIFF
--- a/src/DataTable/CellContent.tsx
+++ b/src/DataTable/CellContent.tsx
@@ -52,11 +52,13 @@ const CellContent: React.FC<CellContentProps> = ({ cell, open, close }) => {
       {isString(cell) ? <CellTruncator>{stringifyIfNeeded(cell)}</CellTruncator> : stringifyIfNeeded(cell)}
       {isString(cell) && <GhostCell ref={$ghostCell}>{stringifyIfNeeded(cell)}</GhostCell>}
       {isString(cell) && isTextOverflowing ? (
-        <ViewMoreToggle onMouseEnter={open(cell)} onMouseLeave={close}>
+        <ViewMoreToggle>
           <DotMenuHorizontalIcon
             color="color.text.lighter"
             size={20}
             onClick={noop} // for the hover/focus effect
+            onMouseEnter={open(cell)}
+            onMouseLeave={close}
           />
         </ViewMoreToggle>
       ) : (

--- a/src/DataTable/CellContent.tsx
+++ b/src/DataTable/CellContent.tsx
@@ -10,6 +10,7 @@ import constants from "../utils/constants"
 export interface CellContentProps {
   cell: React.ReactNode
   open: (content: string) => (e: React.MouseEvent<Element, MouseEvent>) => void
+  close: () => void
 }
 
 const stringifyIfNeeded = (value: any) => {
@@ -17,7 +18,7 @@ const stringifyIfNeeded = (value: any) => {
   return value === true || value === false ? String(value) : value
 }
 
-const CellContent: React.FC<CellContentProps> = ({ cell, open }) => {
+const CellContent: React.FC<CellContentProps> = ({ cell, open, close }) => {
   const $cell = React.useRef<HTMLDivElement>(null)
   const $ghostCell = React.useRef<HTMLDivElement>(null)
   const [isTextOverflowing, setIsTextOverflowing] = React.useState(false)
@@ -51,7 +52,7 @@ const CellContent: React.FC<CellContentProps> = ({ cell, open }) => {
       {isString(cell) ? <CellTruncator>{stringifyIfNeeded(cell)}</CellTruncator> : stringifyIfNeeded(cell)}
       {isString(cell) && <GhostCell ref={$ghostCell}>{stringifyIfNeeded(cell)}</GhostCell>}
       {isString(cell) && isTextOverflowing ? (
-        <ViewMoreToggle onClick={open(cell)}>
+        <ViewMoreToggle onMouseEnter={open(cell)} onMouseLeave={close}>
           <DotMenuHorizontalIcon
             color="color.text.lighter"
             size={20}

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -15,9 +15,6 @@ import {
 } from "./DataTable.styled"
 import { defaultRowHeight, getRowHeight } from "./DataTable.util"
 import useViewMore from "./useViewMore"
-import { CopyIcon } from "../Icon"
-import { Button, OperationalContext } from ".."
-import CopyToClipboard from "react-copy-to-clipboard"
 import CellContent from "./CellContent"
 
 export interface DataTableProps<Columns, Rows> {
@@ -145,19 +142,6 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
     <>
       {viewMorePopup && (
         <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x}>
-          <OperationalContext>
-            {({ pushMessage }) => (
-              <CopyToClipboard
-                text={viewMorePopup.content || ""}
-                onCopy={() => pushMessage({ body: "Copied to clipboard", type: "info" })}
-              >
-                <Button condensed tabIndex={0}>
-                  <CopyIcon size={16} left />
-                  Copy
-                </Button>
-              </CopyToClipboard>
-            )}
-          </OperationalContext>
           {viewMorePopup.content}
         </ViewMorePopup>
       )}

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -61,7 +61,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
   cellWidth = "minmax(200px, 1fr)",
   className,
 }: DataTableProps<Columns, Rows>) {
-  const { open, viewMorePopup } = useViewMore()
+  const { open, close, viewMorePopup } = useViewMore()
   const rowHeight = React.useMemo(() => getRowHeight(initialRowHeight), [initialRowHeight])
 
   const Table = React.useMemo(
@@ -89,7 +89,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
                     key={`op-column-header-cell-${rowIndex}-${cellIndex}`}
                     height={rowHeight}
                   >
-                    <CellContent open={open} cell={cell} />
+                    <CellContent close={close} open={open} cell={cell} />
                   </HeaderCell>
                 ))}
               </HeaderRow>
@@ -123,7 +123,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
                   cell={cellIndex + 1}
                   height={rowHeight}
                 >
-                  <CellContent open={open} cell={cell} />
+                  <CellContent close={close} open={open} cell={cell} />
                 </Cell>
               )
             })}

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -22,7 +22,7 @@ const useViewMore = () => {
   )
 
   const close = () => {
-    closeTimeout = window.setTimeout(() => setViewMorePopup(false), 300)
+    closeTimeoutId = window.setTimeout(() => setViewMorePopup(false), 150)
   }
 
   React.useEffect(

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -39,6 +39,7 @@ const useViewMore = () => {
     viewMorePopup,
     toggle: (content: string) => (viewMorePopup ? setViewMorePopup(false) : openViewMore(content)),
     open: openViewMore,
+    close: () => setViewMorePopup(false),
   }
 }
 

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -7,26 +7,6 @@ import * as React from "react"
 const useViewMore = () => {
   const [viewMorePopup, setViewMorePopup] = React.useState<{ content: string; x: number; y: number } | false>(false)
 
-  React.useEffect(() => {
-    if (!viewMorePopup) {
-      return
-    }
-
-    const close = () => {
-      setViewMorePopup(false)
-    }
-
-    document.addEventListener("click", close)
-    document.addEventListener("contextmenu", close)
-    document.addEventListener("scroll", close)
-
-    return () => {
-      document.removeEventListener("click", close)
-      document.removeEventListener("contextmenu", close)
-      document.removeEventListener("scroll", close)
-    }
-  }, [viewMorePopup])
-
   const openViewMore = React.useCallback(
     (content: string) => (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -35,11 +15,13 @@ const useViewMore = () => {
     [viewMorePopup],
   )
 
+  const close = () => setViewMorePopup(false)
+
   return {
     viewMorePopup,
-    toggle: (content: string) => (viewMorePopup ? setViewMorePopup(false) : openViewMore(content)),
+    toggle: (content: string) => (viewMorePopup ? close() : openViewMore(content)),
     open: openViewMore,
-    close: () => setViewMorePopup(false),
+    close,
   }
 }
 

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -5,17 +5,34 @@ import * as React from "react"
  * triggered by a click event.
  */
 const useViewMore = () => {
+  let closeTimeout = 0
   const [viewMorePopup, setViewMorePopup] = React.useState<{ content: string; x: number; y: number } | false>(false)
 
   const openViewMore = React.useCallback(
     (content: string) => (e: React.MouseEvent) => {
+      window.clearTimeout(closeTimeout)
       e.stopPropagation()
-      setViewMorePopup({ content, x: e.clientX, y: e.clientY })
+      setViewMorePopup({
+        content,
+        x: e.clientX > window.innerWidth / 2 ? e.clientX - 8 : e.clientX + 8,
+        y: e.clientY > window.innerHeight / 2 ? e.clientY - 8 : e.clientY + 8,
+      })
     },
-    [viewMorePopup],
+    [viewMorePopup, closeTimeout],
   )
 
-  const close = () => setViewMorePopup(false)
+  const close = () => {
+    closeTimeout = window.setTimeout(() => setViewMorePopup(false), 300)
+  }
+
+  React.useEffect(
+    () => () => {
+      if (closeTimeout) {
+        window.clearTimeout(closeTimeout)
+      }
+    },
+    [closeTimeout],
+  )
 
   return {
     viewMorePopup,

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -10,7 +10,7 @@ const useViewMore = () => {
 
   const openViewMore = React.useCallback(
     (content: string) => (e: React.MouseEvent) => {
-      window.clearTimeout(closeTimeout)
+      window.clearTimeout(closeTimeoutId)
       e.stopPropagation()
       setViewMorePopup({
         content,
@@ -18,7 +18,7 @@ const useViewMore = () => {
         y: e.clientY > window.innerHeight / 2 ? e.clientY - 8 : e.clientY + 8,
       })
     },
-    [viewMorePopup, closeTimeout],
+    [viewMorePopup, closeTimeoutId],
   )
 
   const close = () => {
@@ -27,11 +27,11 @@ const useViewMore = () => {
 
   React.useEffect(
     () => () => {
-      if (closeTimeout) {
-        window.clearTimeout(closeTimeout)
+      if (closeTimeoutId) {
+        window.clearTimeout(closeTimeoutId)
       }
     },
-    [closeTimeout],
+    [closeTimeoutId],
   )
 
   return {

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -29,6 +29,7 @@ const useViewMore = () => {
 
   const openViewMore = React.useCallback(
     (content: string) => (e: React.MouseEvent) => {
+      e.stopPropagation()
       setViewMorePopup({ content, x: e.clientX, y: e.clientY })
     },
     [viewMorePopup],

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -5,7 +5,7 @@ import * as React from "react"
  * triggered by a click event.
  */
 const useViewMore = () => {
-  let closeTimeout = 0
+  let closeTimeoutId = 0
   const [viewMorePopup, setViewMorePopup] = React.useState<{ content: string; x: number; y: number } | false>(false)
 
   const openViewMore = React.useCallback(

--- a/src/DataTableHeader/DataTableHeader.tsx
+++ b/src/DataTableHeader/DataTableHeader.tsx
@@ -21,7 +21,7 @@ const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon: Icon, actions, 
   const $title = React.useRef<HTMLDivElement>(null)
   const $ghostTitle = React.useRef<HTMLDivElement>(null)
   const [isTitleOverflowing, setIsTitleOverflowing] = React.useState(false)
-  const { open, viewMorePopup } = useViewMore()
+  const { open, close, viewMorePopup } = useViewMore()
   const { width } = useWindowSize()
 
   React.useLayoutEffect(() => {
@@ -52,7 +52,8 @@ const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon: Icon, actions, 
         {isTitleOverflowing ? (
           <DotMenuHorizontalIcon
             style={{ margin: "auto" }}
-            onClick={isString(title) ? open(title) : noop}
+            onMouseEnter={isString(title) ? open(title) : noop}
+            onMouseLeave={close}
             color="color.text.lighter"
             size={20}
           />

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`DatePicker Component Should render 1`] = `
       class="css-1i3ebus"
     >
       <svg
-        class="css-f8oazv"
+        class="css-4lr1pn"
         fill="currentColor"
         height="14"
         size="14"
@@ -42,7 +42,7 @@ exports[`DatePicker Component Should render 1`] = `
           class="css-kaz4mx"
         >
           <svg
-            class="css-eowzpp"
+            class="css-1dywp6p"
             fill="currentColor"
             height="12"
             size="12"
@@ -61,7 +61,7 @@ exports[`DatePicker Component Should render 1`] = `
           class="css-kaz4mx"
         >
           <svg
-            class="css-eowzpp"
+            class="css-1dywp6p"
             fill="currentColor"
             height="12"
             size="12"

--- a/src/Icon/_base.tsx
+++ b/src/Icon/_base.tsx
@@ -41,6 +41,10 @@ export const Svg = styled.svg<IconProps>`
   margin-left: ${({ right, theme }) => (right ? theme.space.small : 0)}px;
   margin-right: ${({ left, theme }) => (left ? theme.space.small : 0)}px;
 
+  > * {
+    pointer-events: none;
+  }
+
   ${({ onClick, theme }) =>
     onClick
       ? `

--- a/src/Internals/Message/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/src/Internals/Message/__tests__/__snapshots__/Message.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Message Component Should render 1`] = `
       class="css-q9kd00"
     >
       <svg
-        class="css-1l34bt5"
+        class="css-1jhocxk"
         fill="currentColor"
         height="18"
         size="18"

--- a/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
+++ b/src/ProgressPanel/__tests__/__snapshots__/ProgressPanel.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ProgressPanel Component Should initialize properly 1`] = `
         class="css-9fq4n"
       >
         <svg
-          class="css-q86bad"
+          class="css-6podpl"
           fill="currentColor"
           height="18"
           size="18"
@@ -38,7 +38,7 @@ exports[`ProgressPanel Component Should initialize properly 1`] = `
         class="css-5ugjy6"
       >
         <svg
-          class="css-q86bad"
+          class="css-6podpl"
           fill="currentColor"
           height="18"
           size="18"
@@ -109,7 +109,7 @@ exports[`ProgressPanel Component Should initialize properly 1`] = `
         class="css-9xk9fc"
       >
         <svg
-          class="css-q86bad"
+          class="css-6podpl"
           fill="currentColor"
           height="18"
           size="18"

--- a/src/SidenavItem/Popout.tsx
+++ b/src/SidenavItem/Popout.tsx
@@ -18,7 +18,6 @@ const Container = styled("div")<{ top: string; left: string; position: string }>
   z-index: ${({ theme }) => theme.zIndex.selectOptions + 1};
   display: flex;
   flex-direction: column;
-  pointer-events: none;
 `
 
 const ScrollTrap = styled("div")`

--- a/src/SidenavItem/Popout.tsx
+++ b/src/SidenavItem/Popout.tsx
@@ -18,6 +18,7 @@ const Container = styled("div")<{ top: string; left: string; position: string }>
   z-index: ${({ theme }) => theme.zIndex.selectOptions + 1};
   display: flex;
   flex-direction: column;
+  pointer-events: none;
 `
 
 const ScrollTrap = styled("div")`

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -6,6 +6,7 @@ import { ChevronRightIcon, ChevronDownIcon, IconComponentType, DotMenuHorizontal
 import Highlighter from "react-highlight-words"
 import constants from "../utils/constants"
 import { ViewMorePopup } from "../DataTable/DataTable.styled"
+import useViewMore from "../DataTable/useViewMore"
 
 interface TreeItemProps {
   level: number
@@ -143,7 +144,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
     [onNodeContextMenu, onNodeClick],
   )
 
-  const [viewMorePopup, setViewMorePopup] = useState<{ x: number; y: number; content: string } | null>(null)
+  const { open, viewMorePopup } = useViewMore()
   const [isTooLong, setIsTooLong] = useState(false)
   const $label = useRef<HTMLDivElement>(null)
 
@@ -199,26 +200,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
           searchWords={searchWords}
         />
       </Label>
-      {isTooLong && (
-        <DotMenuHorizontalIcon
-          size={viewMoreIconSize}
-          left
-          onClick={() => {
-            /** Just the hover style! */
-          }}
-          onMouseEnter={() => {
-            if ($label.current) {
-              const { right, top } = $label.current.getBoundingClientRect()
-              setViewMorePopup({ y: top + viewMoreIconSize, x: right + viewMoreIconSize, content: label })
-            }
-          }}
-          onMouseLeave={() => {
-            if ($label.current) {
-              setViewMorePopup(null)
-            }
-          }}
-        />
-      )}
+      {isTooLong && <DotMenuHorizontalIcon size={viewMoreIconSize} left onClick={open(label)} />}
       <ActionsContainer childrenCount={React.Children.count(actions)}>{actions}</ActionsContainer>
     </Header>
   )

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useRef, useLayoutEffect, useState } from "react"
+import noop from "lodash/noop"
+
 import NameTag from "../NameTag/NameTag"
 import { darken, lighten } from "../utils"
 import styled from "../utils/styled"
@@ -144,7 +146,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
     [onNodeContextMenu, onNodeClick],
   )
 
-  const { open, viewMorePopup } = useViewMore()
+  const { open, close, viewMorePopup } = useViewMore()
   const [isTooLong, setIsTooLong] = useState(false)
   const $label = useRef<HTMLDivElement>(null)
 
@@ -200,7 +202,15 @@ const TreeItem: React.SFC<TreeItemProps> = ({
           searchWords={searchWords}
         />
       </Label>
-      {isTooLong && <DotMenuHorizontalIcon size={viewMoreIconSize} left onClick={open(label)} />}
+      {isTooLong && (
+        <DotMenuHorizontalIcon
+          size={viewMoreIconSize}
+          onClick={noop}
+          left
+          onMouseEnter={open(label)}
+          onMouseLeave={close}
+        />
+      )}
       <ActionsContainer childrenCount={React.Children.count(actions)}>{actions}</ActionsContainer>
     </Header>
   )


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
All truncated popups must display on `hover`.

This PR implements this.

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No new error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
- [ ] Click on `Tree`'s truncated text (4th example from the top) triggers popover
- [ ] Hover on `Tree`'s truncated text (4th example from the top) does not trigger popover
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

