### PR TITLE
**Feature:** Extend Page's title to be a ReactNode

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -14,7 +14,7 @@ export interface BaseProps extends DefaultProps {
   /** Content of the page */
   children?: PageContentProps["children"]
   /** Page title */
-  title?: string
+  title?: React.ReactNode
   /** Page actions, typically `condensed button` component inside a fragment */
   actions?: React.ReactNode
   /** Toggles a top progress bar to indicate loading state */

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -14,6 +14,41 @@ import { Page, Card } from "@operational/components"
 </Page>
 ```
 
+### Dynamic Title
+
+You can have whatever you want in your title:
+
+```jsx
+import * as React from "react"
+import { Page, Card } from "@operational/components"
+;<Page
+  title={
+    <div style={{ display: "flex", alignItems: "center" animation: "evolve 5s infinite", width: "100%", marginBottom: 16, padding: 16, color: "white" }}>
+      I AM CONSTANTLY EVOLVING
+      <img style={{ display: "block", marginLeft: "auto", height: "60px" }} alt="LOL" src="https://media.giphy.com/media/WQxkpI7LTStUExhrR7/giphy.gif" />
+    </div>
+  }
+>
+  <Card>Hello, this is page content</Card>
+  <style>
+    {`@keyframes evolve {
+      0% {
+        background-color: #f00;
+      }
+      33% {
+        background-color: #0f0;
+      }
+      66% {
+        background-color: #00f;
+      }
+      100% {
+        background-color: #f00;
+      }
+    }`}
+  </style>
+</Page>
+```
+
 ### Long Children
 
 Here's a case where children are too long. The card has a _hard_ max-width set to its grid area, and any text children are hyphenated.

--- a/src/Typography/Title/index.tsx
+++ b/src/Typography/Title/index.tsx
@@ -10,6 +10,7 @@ export const Title = styled("h1")<{
   lineHeight: theme.font.lineHeight,
   margin: 0,
   color: theme.color.text[color ? color : "dark"],
+  width: "100%",
 }))
 
 export default Title


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR makes `Page`'s title be a `ReactNode` instead of just a `string` so that we can add anything we want in the title (like a search bar!)

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] No regression on `Page`.

Tester 1

- [ ] Things look good on the demo.
- [ ] No regression on `Page`.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->
