### PR TITLE
**Fix:** Title component width

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -123,6 +123,10 @@ const TabsContainer = styled("div", { shouldForwardProp: prop => prop !== "fill"
   max-width: ${({ theme, fill }) => (fill ? "100%" : `${theme.pageSize.max}px`)};
 `
 
+const PageTitle = styled(Title)`
+  width: 100%;
+`
+
 const Page: React.FC<PageProps> = ({
   actions,
   activeTabName,
@@ -143,7 +147,7 @@ const Page: React.FC<PageProps> = ({
           {title ? (
             <>
               <TitleContainer fill={Boolean(fill)}>
-                <Title>{title}</Title>
+                <PageTitle>{title}</PageTitle>
                 <ActionsContainer>{actions}</ActionsContainer>
               </TitleContainer>
               <TabsContainer fill={Boolean(fill)}>{tabsBar}</TabsContainer>

--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import isString from "lodash/isString"
 
 import Tabs, { Tab } from "../Internals/Tabs"
 import PageArea from "../PageArea/PageArea"
@@ -123,10 +124,6 @@ const TabsContainer = styled("div", { shouldForwardProp: prop => prop !== "fill"
   max-width: ${({ theme, fill }) => (fill ? "100%" : `${theme.pageSize.max}px`)};
 `
 
-const PageTitle = styled(Title)`
-  width: 100%;
-`
-
 const Page: React.FC<PageProps> = ({
   actions,
   activeTabName,
@@ -147,7 +144,7 @@ const Page: React.FC<PageProps> = ({
           {title ? (
             <>
               <TitleContainer fill={Boolean(fill)}>
-                <PageTitle>{title}</PageTitle>
+                {isString(title) ? <Title>{title}</Title> : title}
                 <ActionsContainer>{actions}</ActionsContainer>
               </TitleContainer>
               <TabsContainer fill={Boolean(fill)}>{tabsBar}</TabsContainer>
@@ -165,7 +162,7 @@ const Page: React.FC<PageProps> = ({
     <>
       {title && (
         <TitleContainer fill={Boolean(fill)}>
-          <Title>{title}</Title>
+          {isString(title) ? <Title>{title}</Title> : title}
           <ActionsContainer>{actions}</ActionsContainer>
         </TitleContainer>
       )}

--- a/src/Typography/Title/index.tsx
+++ b/src/Typography/Title/index.tsx
@@ -10,7 +10,6 @@ export const Title = styled("h1")<{
   lineHeight: theme.font.lineHeight,
   margin: 0,
   color: theme.color.text[color ? color : "dark"],
-  width: "100%",
 }))
 
 export default Title


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
#1238 broke `Title`, leading to odd alignment issues. We want `Title` to have a full-width on `Page`, but nowhere else. This PR corrects this regression.

More concretely, we fix this:
![regression](https://user-images.githubusercontent.com/1761469/65598994-051a9b00-df9d-11e9-9747-6d5bc57cb558.png)

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->


# To be tested

Me
- [ ] No new error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
