### PR TITLE
**Fix:** Allow `fill` props on PageWithProps

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -22,13 +22,13 @@ export interface BaseProps extends DefaultProps {
   loading?: boolean
   /** Render a page without padding */
   noPadding?: boolean
+  /** Fill the entire width */
+  fill?: boolean
 }
 
 export interface PropsWithSimplePage extends BaseProps {
   /** Areas template for `PageArea` disposition */
   areas?: "main"
-  /** Fill the entire width */
-  fill?: boolean
   tabs?: never
   activeTabName?: never
   onTabChange?: never
@@ -37,8 +37,6 @@ export interface PropsWithSimplePage extends BaseProps {
 export interface PropsWithComplexPage extends BaseProps {
   /** Areas template for `PageArea` disposition */
   areas: "main side" | "side main"
-  /** Fill the entire width */
-  fill?: boolean
   tabs?: never
   activeTabName?: never
   onTabChange?: never
@@ -62,7 +60,6 @@ export interface PropsWithTabs extends BaseProps {
   onTabChange?: (name: string) => void
   children?: never
   areas?: never
-  fill?: never
 }
 
 export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTabs


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

`fill` was set to `never` on a `Page` with tabs, this is not true and restrict the usage of this component.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
