### PR TITLE
Move TopBar icons to the left.

### DIFF
--- a/src/TopbarButton/TopbarButton.tsx
+++ b/src/TopbarButton/TopbarButton.tsx
@@ -56,8 +56,8 @@ const TopbarButtonContainer = styled.button<{ disabled?: boolean; flavor: Topbar
 
 const TopbarButton: React.SFC<TopbarButtonProps> = ({ children, icon: Icon, onClick, flavor, ...props }) => (
   <TopbarButtonContainer {...props} flavor={flavor} onClick={props.disabled ? undefined : onClick}>
-    {children}
     {Icon && <Icon left size={12} />}
+    {children}
   </TopbarButtonContainer>
 )
 

--- a/src/TopbarButton/TopbarButton.tsx
+++ b/src/TopbarButton/TopbarButton.tsx
@@ -57,7 +57,7 @@ const TopbarButtonContainer = styled.button<{ disabled?: boolean; flavor: Topbar
 const TopbarButton: React.SFC<TopbarButtonProps> = ({ children, icon: Icon, onClick, flavor, ...props }) => (
   <TopbarButtonContainer {...props} flavor={flavor} onClick={props.disabled ? undefined : onClick}>
     {children}
-    {Icon && <Icon right size={12} />}
+    {Icon && <Icon left size={12} />}
   </TopbarButtonContainer>
 )
 


### PR DESCRIPTION
Move TopBar icons to the left.

<img width="525" alt="Screen Shot 2019-10-18 at 18 37 06" src="https://user-images.githubusercontent.com/489843/67112301-29058100-f1d7-11e9-9bdc-6546820f6217.png">

https://ux.stackexchange.com/questions/56023/when-a-button-contains-text-and-an-icon-which-should-come-first

Before:
<img width="134" alt="Screen Shot 2019-10-18 at 18 50 03" src="https://user-images.githubusercontent.com/489843/67112717-25262e80-f1d8-11e9-8eeb-9426ce903a6b.png">


After:
<img width="147" alt="Screen Shot 2019-10-18 at 18 49 55" src="https://user-images.githubusercontent.com/489843/67112728-28b9b580-f1d8-11e9-95a0-ea0e7c391cf9.png">
