### PR TITLE
**Feature:** Add syntax to support left & right icon in table headers

### DIFF
--- a/src/DataTable/CellContent.tsx
+++ b/src/DataTable/CellContent.tsx
@@ -1,9 +1,7 @@
 import * as React from "react"
 import isString from "lodash/isString"
-import noop from "lodash/noop"
 
-import { CellGrid, CellTruncator, ViewMoreToggle, GhostCell, dataTableActionContainerSize } from "./DataTable.styled"
-import { DotMenuHorizontalIcon } from "../Icon"
+import { CellGrid, CellTruncator, GhostCell, dataTableActionContainerSize } from "./DataTable.styled"
 import useWindowSize from "../useWindowSize"
 import constants from "../utils/constants"
 
@@ -13,9 +11,9 @@ export interface CellContentProps {
   close: () => void
 }
 
-const stringifyIfNeeded = (value: any) => {
+const stringifyBooleanAndNull = (value: any) => {
   // We compare booleans like this and without typeof for perf
-  return value === true || value === false ? String(value) : value
+  return value === true || value === false || value === null ? String(value) : value
 }
 
 const CellContent: React.FC<CellContentProps> = ({ cell, open, close }) => {
@@ -49,21 +47,14 @@ const CellContent: React.FC<CellContentProps> = ({ cell, open, close }) => {
 
   return (
     <CellGrid ref={$cell} canTruncate={isString(cell)}>
-      {isString(cell) ? <CellTruncator>{stringifyIfNeeded(cell)}</CellTruncator> : stringifyIfNeeded(cell)}
-      {isString(cell) && <GhostCell ref={$ghostCell}>{stringifyIfNeeded(cell)}</GhostCell>}
-      {isString(cell) && isTextOverflowing ? (
-        <ViewMoreToggle>
-          <DotMenuHorizontalIcon
-            color="color.text.lighter"
-            size={20}
-            onClick={noop} // for the hover/focus effect
-            onMouseEnter={open(cell)}
-            onMouseLeave={close}
-          />
-        </ViewMoreToggle>
+      {isString(stringifyBooleanAndNull(cell)) && isTextOverflowing ? (
+        <CellTruncator onMouseEnter={open(stringifyBooleanAndNull(cell))} onMouseLeave={close}>
+          {stringifyBooleanAndNull(cell)}
+        </CellTruncator>
       ) : (
-        <div /> // We need an empty element for CSS Grid to place things correctly
+        stringifyBooleanAndNull(cell)
       )}
+      <GhostCell ref={$ghostCell}>{stringifyBooleanAndNull(cell)}</GhostCell>
     </CellGrid>
   )
 }

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -36,7 +36,13 @@ const CustomCell = styled.span`
         actions={[{ label: "Say hi", onClick: () => alert("HIIII") }]}
       />,
     ],
-    [<DataTableHeader title="Foooooooooooooood" actions={[{ label: "Say bye", onClick: () => alert("BYEEE <3") }]} />],
+    [
+      <DataTableHeader
+        title="Foooooooooooooood"
+        icon={{ right: YesIcon }}
+        actions={[{ label: "Say bye", onClick: () => alert("BYEEE <3") }]}
+      />,
+    ],
     ["Loves You"],
   ]}
   rows={[

--- a/src/DataTableHeader/DataTableHeader.styled.ts
+++ b/src/DataTableHeader/DataTableHeader.styled.ts
@@ -5,7 +5,7 @@ export const Container = styled.div<{ hasIcon: boolean }>`
   display: grid;
 
   /**
-   * The columns are: type, name, "see more" icon, and caret for icons
+   * The columns are: type, name, right icon, and caret for icons
    */
   grid-template-columns: ${({ hasIcon }) =>
     hasIcon

--- a/src/DataTableHeader/DataTableHeader.tsx
+++ b/src/DataTableHeader/DataTableHeader.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom"
 import noop from "lodash/noop"
 
 import { ActionsContainer, Container, TitleContainer, GhostTitleContainer } from "./DataTableHeader.styled"
-import { IconComponentType, DotMenuHorizontalIcon, ChevronDownIcon } from "../Icon"
+import { IconComponentType, ChevronDownIcon } from "../Icon"
 import { IContextMenuItem } from "../ContextMenu/ContextMenu.Item"
 import isString from "lodash/isString"
 import { ViewMorePopup } from "../DataTable/DataTable.styled"
@@ -13,11 +13,22 @@ import useWindowSize from "../useWindowSize"
 
 export interface DataTableHeaderProps {
   title: React.ReactNode
-  icon?: IconComponentType
+  icon?:
+    | IconComponentType
+    | {
+        left?: IconComponentType
+        right?: IconComponentType
+      }
   actions?: IContextMenuItem[]
 }
 
-const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon: Icon, actions, title }) => {
+const isIcon = (icon: any): icon is IconComponentType => {
+  return typeof icon === "function"
+}
+
+const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon, actions, title }) => {
+  const LeftIcon = icon && (isIcon(icon) ? icon : icon.left)
+  const RightIcon = icon && !isIcon(icon) && icon.right
   const $title = React.useRef<HTMLDivElement>(null)
   const $ghostTitle = React.useRef<HTMLDivElement>(null)
   const [isTitleOverflowing, setIsTitleOverflowing] = React.useState(false)
@@ -43,23 +54,19 @@ const DataTableHeader: React.FC<DataTableHeaderProps> = ({ icon: Icon, actions, 
 
   return (
     <>
-      <Container hasIcon={Boolean(Icon)}>
-        {Icon && <Icon color="primary" style={{ margin: "auto" /* for centering */ }} size={12} />}
-        <TitleContainer ref={$title}>{title}</TitleContainer>
-        <GhostTitleContainer hasIcon={Boolean(Icon)} ref={$ghostTitle}>
+      <Container hasIcon={Boolean(LeftIcon)}>
+        {LeftIcon && <LeftIcon color="primary" style={{ margin: "auto" /* for centering */ }} size={12} />}
+        {isTitleOverflowing ? (
+          <TitleContainer onMouseEnter={isString(title) ? open(title) : noop} onMouseLeave={close} ref={$title}>
+            {title}
+          </TitleContainer>
+        ) : (
+          <TitleContainer ref={$title}>{title}</TitleContainer>
+        )}
+        <GhostTitleContainer hasIcon={Boolean(LeftIcon)} ref={$ghostTitle}>
           {title}
         </GhostTitleContainer>
-        {isTitleOverflowing ? (
-          <DotMenuHorizontalIcon
-            style={{ margin: "auto" }}
-            onMouseEnter={isString(title) ? open(title) : noop}
-            onMouseLeave={close}
-            color="color.text.lighter"
-            size={20}
-          />
-        ) : (
-          <div /> // Just to fill the grid column with emptiness and use the next one.
-        )}
+        {RightIcon ? <RightIcon color="primary" style={{ margin: "auto" /* for centering */ }} size={12} /> : <div />}
         {actions && (
           <ActionsContainer>
             <ContextMenu items={actions}>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Add `icon: {left: MyIcon, right: MyOtherIcon}` syntax for the `DataTableHeader` to be able to have multiples icons.

This is needed to be able to implement this:

![image](https://user-images.githubusercontent.com/1761469/67761957-9a013000-fa44-11e9-9a4f-04ccbbb9b12f.png)

This feature is totally retro-compatible, so nothing should break 😁 

I also remove the strange behaviour around the truncation, now the hover is on the text itself

![image](https://user-images.githubusercontent.com/1761469/67762051-d3d23680-fa44-11e9-9426-32918ee01528.png)

This feel more natural and let the space for the custom icon.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
- [x] I can have an icon on right
- [x] I can have an icon on left
- [x] I can have two icons!
- [x] The truncate hover is beautiful
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->
