### PR TITLE
**Fix:** Make Page title height dynamic

### DIFF
--- a/src/Page/Page.tsx
+++ b/src/Page/Page.tsx
@@ -9,7 +9,6 @@ import Progress from "../Progress/Progress"
 import { DefaultProps } from "../types"
 import { Title } from "../Typography/Title"
 import styled from "../utils/styled"
-import { OperationalStyleConstants } from "../utils/constants"
 
 export interface BaseProps extends DefaultProps {
   /** Content of the page */
@@ -64,22 +63,13 @@ export interface PropsWithTabs extends BaseProps {
 
 export type PageProps = PropsWithSimplePage | PropsWithComplexPage | PropsWithTabs
 
-const computeRowHeights = (theme: OperationalStyleConstants, hasTitle: boolean, hasTabs: boolean) => {
-  const titleHeightString = hasTitle ? `${theme.titleHeight}px ` : ""
-  const tabsHeightString = hasTabs ? `${theme.tabsBarHeight}px ` : ""
-  const titleHeightWithRowGap = hasTitle ? theme.titleHeight + theme.space.element : 0
-  const tabsHeightWithRowGap = hasTabs ? theme.tabsBarHeight + theme.space.element : 0
-  const viewContainerHeightString = `calc(100% - ${titleHeightWithRowGap + tabsHeightWithRowGap}px)`
-  return `${titleHeightString}${tabsHeightString}${viewContainerHeightString}`
-}
-
 const Container = styled("div")<{ hasTitle: boolean; hasTabs: boolean }>(({ theme, hasTitle, hasTabs }) => ({
   position: "relative",
   height: "100%",
   display: "grid",
   gridRowGap: theme.space.element,
   backgroundColor: theme.color.white,
-  gridTemplateRows: computeRowHeights(theme, hasTitle, hasTabs),
+  gridTemplateRows: `${hasTitle ? `min-content ` : ""}${hasTabs ? `${theme.tabsBarHeight}px ` : ""}auto`,
   padding: "50px 35px 35px",
   overflow: "auto",
 }))
@@ -88,7 +78,6 @@ const TitleContainer = styled("div", { shouldForwardProp: prop => prop !== "fill
   ({ theme, fill }) => ({
     display: "flex",
     alignItems: "center",
-    height: theme.titleHeight,
     fontWeight: theme.font.weight.medium,
     minWidth: theme.pageSize.min,
     maxWidth: fill ? "100%" : `${theme.pageSize.max}px`,

--- a/src/Page/README.md
+++ b/src/Page/README.md
@@ -23,7 +23,7 @@ import * as React from "react"
 import { Page, Card } from "@operational/components"
 ;<Page
   title={
-    <div style={{ display: "flex", alignItems: "center" animation: "evolve 5s infinite", width: "100%", marginBottom: 16, padding: 16, color: "white" }}>
+    <div style={{ display: "flex", alignItems: "center" animation: "evolve 5s infinite", width: "100%", padding: 16, color: "white" }}>
       I AM CONSTANTLY EVOLVING
       <img style={{ display: "block", marginLeft: "auto", height: "60px" }} alt="LOL" src="https://media.giphy.com/media/WQxkpI7LTStUExhrR7/giphy.gif" />
     </div>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR adjusts the height of the dynamic `title` of Page and more closely follows our design guidelines, space-wise.

Here's an overview of the problem this PR fixes:
![image](https://user-images.githubusercontent.com/9947422/67777486-181fff80-fa62-11e9-81d5-c64cf7327246.png)

On the left (this PR) screen, we see that `title` can expand to any height it needs to: for example if we decide to add a description under the title like on GitHub repos. Currently, the title is fixed to `50px`. This PR removes that restriction.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->


# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
