### PR TITLE
**Fix:** Select component border

### DIFF
--- a/src/Select/Select.styled.ts
+++ b/src/Select/Select.styled.ts
@@ -23,7 +23,8 @@ export const Combobox = styled("div")<{ naked: boolean; isOpen: boolean; hasCust
   align-items: stretch;
   box-shadow: 0 0 0 1px
     ${({ theme, isOpen, hasCustomOption }) =>
-      !hasCustomOption && isOpen ? theme.color.primary : theme.color.border.select};
+      !hasCustomOption && isOpen ? theme.color.primary : theme.color.border.select}
+    inset;
   border-width: ${({ naked }) => (naked ? 0 : 1)}px;
   border-radius: ${({ theme }) => theme.borderRadius}px;
   background-color: ${({ naked }) => (naked ? "transparent" : "white")};


### PR DESCRIPTION
Hello,

This small fix attempts to address a visual issue with the select component appearing to have a missing border on one side.

The `box-shadow` property being used to style the borders doesn't count as part of the element dimensions. Consequently, depending on what the select component is used inside, different sides of the border can be clipped.

The fix is simply to use an `inset` based `box-shadow`.

This should also resolve a one pixel offset issue with the select component when used in conjunction with other elements. This is a zoomed in example to illustrate:

![image](https://user-images.githubusercontent.com/43751307/68071004-88a38500-fdb0-11e9-8b20-6bce412c3434.png)

Closes #1249