### PR TITLE
**Fix:** Remove all focus rings if mouse is being used

### DIFF
--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -60,6 +60,10 @@ const baseStylesheet = (theme: OperationalStyleConstants) => `
   font-smoothing: antialiased;
 }
 
+*:focus:not(:focus-visible) {
+  outline: none;
+}
+
 html,
 body {
   margin: 0;


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR uses CSS' `:focus-visible` selector to hide/show focus styles based on input modality ([further reading](https://twitter.com/TejasKumar_/status/1186326187364229120)).

**Left half:** this PR
**Right half:** `master`

![wow](https://user-images.githubusercontent.com/9947422/68857208-9e834500-06e2-11ea-8737-1b47b13909cc.gif)

If we're using a mouse, we'll never see a focus ring on anything.
If we're tabbing around with a keyboard, we will.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
