### PR TITLE
**Feature:** Add support for "active" table rows

### DIFF
--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -38,7 +38,7 @@ import * as React from "react"
 import { Table } from "@operational/components"
 ;<Table
   fixedLayout
-  activeRowIndex={1}
+  activeRowIndices={[1]}
   data={[
     { name: "Max", profession: "Carpenter" },
     { name: "Michael", profession: "Anti-focusring activist" },

--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -2,7 +2,8 @@ Tables simply render a semantic HTML table structure based on raw data.
 
 ### Simple usage
 
-You can render a simple use-case of the table by specifying a list of records and supplying the columns as a list of strings which would serve both as column heading and access keys for fields.
+You can render a simple use-case of the table by specifying a list of records and supplying the columns as a list of
+strings which would serve both as column heading and access keys for fields.
 
 ```jsx
 import * as React from "react"
@@ -15,7 +16,8 @@ import { Table } from "@operational/components"
 
 ### With Fixed Layout
 
-Tables perform better with a forced fixed layout, since the browser doesn't have to recalculate positions depending on the contents of the table. Here's what the same table looks like with a fixed layout.
+Tables perform better with a forced fixed layout, since the browser doesn't have to recalculate positions depending on
+the contents of the table. Here's what the same table looks like with a fixed layout.
 
 ```jsx
 import * as React from "react"
@@ -23,6 +25,26 @@ import { Table } from "@operational/components"
 ;<Table
   fixedLayout
   data={[{ name: "Max", profession: "Carpenter" }, { name: "Moritz", profession: "Baker" }]}
+  columns={["name", "profession"]}
+/>
+```
+
+### With an "active" row
+
+Tables perform better with a forced fixed layout, since the browser doesn't have to recalculate positions depending on
+the contents of the table. Here's what the same table looks like with a fixed layout.
+
+```jsx
+import * as React from "react"
+import { Table } from "@operational/components"
+;<Table
+  fixedLayout
+  activeRowIndex={1}
+  data={[
+    { name: "Max", profession: "Carpenter" },
+    { name: "Michael", profession: "Anti-focusring activist" },
+    { name: "Moritz", profession: "Baker" },
+  ]}
   columns={["name", "profession"]}
 />
 ```
@@ -82,13 +104,16 @@ import { Table } from "@operational/components"
 />
 ```
 
-While this approach is convenient, it is not recommended because it makes it too easy to re-use record keys as table headings, and adds a strong coupling between data and view concerns.
+While this approach is convenient, it is not recommended because it makes it too easy to re-use record keys as table
+headings, and adds a strong coupling between data and view concerns.
 
-We suggest taking the time to think about the best way to describe the data fields and then specifying it explicitly as column headers. The following, slightly more verbose version of the API demonstrates how this can be achieved:
+We suggest taking the time to think about the best way to describe the data fields and then specifying it explicitly as
+column headers. The following, slightly more verbose version of the API demonstrates how this can be achieved:
 
 ### With explicit data formatting
 
-In this case, simple functions taking an individual record as an argument specify how cells should be rendered in a given column:
+In this case, simple functions taking an individual record as an argument specify how cells should be rendered in a
+given column:
 
 ```jsx
 import * as React from "react"
@@ -278,7 +303,9 @@ const data = [
 
 ### With row actions
 
-Row actions are specified as a function of an individual record, returning action items conforming to the [ContextMenu](/#ContextMenu) API. The function in the `rowActions` prop can return either the action items as an array or the `ActionMenu` node itself.
+Row actions are specified as a function of an individual record, returning action items conforming to the
+[ContextMenu](/#ContextMenu) API. The function in the `rowActions` prop can return either the action items as an array
+or the `ActionMenu` node itself.
 
 ```jsx
 import * as React from "react"

--- a/src/Table/README.md
+++ b/src/Table/README.md
@@ -31,8 +31,7 @@ import { Table } from "@operational/components"
 
 ### With an "active" row
 
-Tables perform better with a forced fixed layout, since the browser doesn't have to recalculate positions depending on
-the contents of the table. Here's what the same table looks like with a fixed layout.
+In some cases, you'd like to higlight a certain row in a table. Here's how you can do this.
 
 ```jsx
 import * as React from "react"

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -39,7 +39,7 @@ export interface TableProps<T> extends DefaultProps {
   /** On reorder rows, */
   onReorder?: (result: DropResult, provided: ResponderProvided) => void
   /* The index of an active row */
-  activeRowIndex?: number
+  activeRowIndices?: number[]
 }
 
 export interface Column<T> {
@@ -184,7 +184,7 @@ function Table<T>({
   headless,
   fixedLayout,
   onReorder,
-  activeRowIndex,
+  activeRowIndices,
   ...props
 }: TableProps<T>) {
   const uid = useUniqueId()
@@ -266,8 +266,9 @@ function Table<T>({
                    Because of how border-collapse works, we need a different border color for this TD
                    and the subsequent TD if the current row is "active"
                   */
-                  const shouldTdHaveColoredBorders =
-                    activeRowIndex === dataEntryIndex || activeRowIndex === dataEntryIndex + 1
+                  const shouldTdHaveColoredBorders = activeRowIndices
+                    ? activeRowIndices.includes(dataEntryIndex) || activeRowIndices.includes(dataEntryIndex + 1)
+                    : false
 
                   const rowAction = (() => {
                     if (!rowActions) {
@@ -290,7 +291,7 @@ function Table<T>({
                         <Tr
                           {...provided.draggableProps}
                           {...provided.dragHandleProps}
-                          active={activeRowIndex === dataEntryIndex}
+                          active={activeRowIndices ? activeRowIndices.includes(dataEntryIndex) : false}
                           ref={provided.innerRef}
                           isDragging={Boolean(snapshot.isDragging)}
                           onKeyDown={handleKeyDownOnRow(dataEntry, dataEntryIndex)}

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -65,7 +65,7 @@ const Tr = styled.tr<{ active: boolean; isDragging?: boolean; hover?: boolean; c
     height: 50,
     display: isDragging ? "table" : "table-row",
     tableLayout: "fixed",
-    backgroundColor: active ? lighten(theme.color.primary, 53) : theme.color.white,
+    backgroundColor: active ? lighten(theme.color.primary, 54) : theme.color.white,
     ...(hover
       ? {
           ":hover, :focus": {

--- a/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -14,17 +14,17 @@ exports[`Table Component Should render 1`] = `
       class="css-x4ot8q"
     >
       <tr
-        class="css-1aheh2"
+        class="css-13vzd3l"
       />
     </thead>
     <tbody
       data-react-beautiful-dnd-droppable="0"
     >
       <tr
-        class="css-1aheh2"
+        class="css-13vzd3l"
       >
         <td
-          class="css-zw5kx"
+          class="css-1q4rays"
           colspan="0"
         >
           There are no records available


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR creates the possibility for this type of behavior from `Table`:
![image](https://user-images.githubusercontent.com/9947422/68858902-641ba700-06e6-11ea-9bed-e9f311781735.png)

I added a demo to the README, so it should be visible in the PR preview.


<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
