### PR TITLE
**Fix**: Fallback on the first tab if not exists

### DIFF
--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -190,6 +190,10 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
     [activeTab, onTabClick],
   )
 
+  if (tabsWithId.length === 0 || tabs.length === 0) {
+    return null
+  }
+
   // Work around: wrap return in fragment- to prevent type error and not having to change childrens return type
   // https://github.com/Microsoft/TypeScript/issues/21699
   return (

--- a/src/Internals/Tabs.tsx
+++ b/src/Internals/Tabs.tsx
@@ -212,8 +212,8 @@ const Tabs = ({ onTabChange, tabs, activeTabName, children }: Props) => {
               ))}
           </TabsBar>
         ),
-        activeTabId: tabsWithId[activeTab].id,
-        activeChildren: tabs[activeTab].children,
+        activeTabId: (tabsWithId[activeTab] || tabsWithId[0]).id,
+        activeChildren: (tabs[activeTab] || tabs[0]).children,
       })}
     </>
   )


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

On advanced usecase, when the number of tabs change dynamically, the active tab can be undefined and crash the application.

This little fix make sure to fallback correctly.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
