### PR TITLE
  **Fix:** Fix hanging popups

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -59,6 +59,11 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
   className,
 }: DataTableProps<Columns, Rows>) {
   const { open, close, viewMorePopup } = useViewMore()
+  React.useEffect(() => {
+    const onScroll = () => close()
+    window.addEventListener("scroll", onScroll)
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [close])
   const rowHeight = React.useMemo(() => getRowHeight(initialRowHeight), [initialRowHeight])
 
   const Table = React.useMemo(
@@ -141,7 +146,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
   return (
     <>
       {viewMorePopup && (
-        <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x}>
+        <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x} onMouseLeave={close}>
           {viewMorePopup.content}
         </ViewMorePopup>
       )}

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -5,28 +5,27 @@ import * as React from "react"
  * triggered by a click event.
  */
 const useViewMore = () => {
-  const [closeTimeoutId, setCloseTimeoutId] = React.useState<number>()
+  const closeTimeoutIdRef = React.useRef<number>()
   const [viewMorePopup, setViewMorePopup] = React.useState<{ content: string; x: number; y: number } | false>(false)
 
   const close = React.useCallback(() => {
     if (viewMorePopup) {
-      setCloseTimeoutId(window.setTimeout(() => setViewMorePopup(false), 150))
+      closeTimeoutIdRef.current = window.setTimeout(() => setViewMorePopup(false), 150)
     }
   }, [viewMorePopup])
-  React.useEffect(() => () => window.clearTimeout(closeTimeoutId), [closeTimeoutId])
+  React.useEffect(() => () => window.clearTimeout(closeTimeoutIdRef.current), [])
 
   const open = React.useCallback(
     (content: string) => (e: React.MouseEvent) => {
       e.stopPropagation()
-      window.clearTimeout(closeTimeoutId)
-      setCloseTimeoutId(undefined)
+      window.clearTimeout(closeTimeoutIdRef.current)
       setViewMorePopup({
         content,
         x: e.clientX > window.innerWidth / 2 ? e.clientX - 8 : e.clientX + 8,
         y: e.clientY > window.innerHeight / 2 ? e.clientY - 8 : e.clientY + 8,
       })
     },
-    [closeTimeoutId],
+    [],
   )
 
   const toggle = React.useCallback((content: string) => (viewMorePopup ? close() : open(content)), [viewMorePopup])

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -5,39 +5,36 @@ import * as React from "react"
  * triggered by a click event.
  */
 const useViewMore = () => {
-  let closeTimeoutId = 0
+  const [closeTimeoutId, setCloseTimeoutId] = React.useState<number>()
   const [viewMorePopup, setViewMorePopup] = React.useState<{ content: string; x: number; y: number } | false>(false)
 
-  const openViewMore = React.useCallback(
+  const close = React.useCallback(() => {
+    if (viewMorePopup) {
+      setCloseTimeoutId(window.setTimeout(() => setViewMorePopup(false), 150))
+    }
+  }, [viewMorePopup])
+  React.useEffect(() => () => window.clearTimeout(closeTimeoutId), [closeTimeoutId])
+
+  const open = React.useCallback(
     (content: string) => (e: React.MouseEvent) => {
-      window.clearTimeout(closeTimeoutId)
       e.stopPropagation()
+      window.clearTimeout(closeTimeoutId)
+      setCloseTimeoutId(undefined)
       setViewMorePopup({
         content,
         x: e.clientX > window.innerWidth / 2 ? e.clientX - 8 : e.clientX + 8,
         y: e.clientY > window.innerHeight / 2 ? e.clientY - 8 : e.clientY + 8,
       })
     },
-    [viewMorePopup, closeTimeoutId],
-  )
-
-  const close = () => {
-    closeTimeoutId = window.setTimeout(() => setViewMorePopup(false), 150)
-  }
-
-  React.useEffect(
-    () => () => {
-      if (closeTimeoutId) {
-        window.clearTimeout(closeTimeoutId)
-      }
-    },
     [closeTimeoutId],
   )
 
+  const toggle = React.useCallback((content: string) => (viewMorePopup ? close() : open(content)), [viewMorePopup])
+
   return {
     viewMorePopup,
-    toggle: (content: string) => (viewMorePopup ? close() : openViewMore(content)),
-    open: openViewMore,
+    toggle,
+    open,
     close,
   }
 }

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -165,7 +165,10 @@ const TreeItem: React.SFC<TreeItemProps> = ({
     // to the parent and using `children[0]`
     if ($label.current && $label.current.children[0]) {
       const { height } = $label.current.children[0].getBoundingClientRect()
-      setIsTooLong(height > 16)
+      const tooLong = height > 16
+      setIsTooLong(tooLong)
+      // hide popup if we hide DotMenuHorizontalIcon
+      if (!tooLong) close()
     }
   })
 

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -170,7 +170,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       // hide popup if we hide DotMenuHorizontalIcon
       if (!tooLong) close()
     }
-  })
+  }, [close])
 
   return (
     <Header


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

`DotMenuHorizontalIcon` shows up and hide based on `useLayoutEffect`, so it can be there even if it is not needed

<img width="216" alt="Screenshot 2019-12-11 at 11 32 24" src="https://user-images.githubusercontent.com/179534/70613996-f93c8d80-1c09-11ea-8933-373f6292b140.png">

when you hover it, it will show popup, but the same time `useLayoutEffect` kicks in and `DotMenuHorizontalIcon` disappears, so there is no more dom element to handle `onMouseLeave={close}` and popups left hanging there forever. 

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
