### PR TITLE
**Fix:** Fix line height for Table

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -192,7 +192,7 @@ const ActionLabel = styled(Small)`
 const EmptyView = styled(Td)<{ condensed?: boolean }>`
   color: ${({ theme }) => theme.color.text.default};
   height: ${({ condensed }) => (condensed ? 36 : 50)}px;
-  height: ${({ condensed }) => (condensed ? 36 : 50)}px;
+  line-height: ${({ condensed }) => (condensed ? 36 : 50)}px;
   text-align: center;
 `
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -189,12 +189,12 @@ const ActionLabel = styled(Small)`
   display: block;
 `
 
-const EmptyView = styled(Td)<{ condensed?: boolean }>(({ theme, condensed }) => ({
-  color: theme.color.text.default,
-  height: condensed ? 36 : 50,
-  lineHeight: condensed ? 36 : 50,
-  textAlign: "center",
-}))
+const EmptyView = styled(Td)<{ condensed?: boolean }>`
+  color: ${({ theme }) => theme.color.text.default};
+  height: ${({ condensed }) => (condensed ? 36 : 50)}px;
+  height: ${({ condensed }) => (condensed ? 36 : 50)}px;
+  text-align: center;
+`
 
 function Table<T>({
   data = [],

--- a/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Table Component Should render 1`] = `
         class="css-tty73l"
       >
         <td
-          class="css-fboe66"
+          class="css-89nfwf"
           colspan="0"
         >
           There are no records available


### PR DESCRIPTION

# Summary
This PR fixes the line height of the empty table, which was broken by 
https://github.com/contiamo/operational-ui/pull/1270
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

Broken:
<img width="1547" alt="Screenshot 2019-12-18 at 12 25 56" src="https://user-images.githubusercontent.com/639406/71082573-a1fe6600-2191-11ea-8f57-aaa82b904148.png">

Fixed:
<img width="2201" alt="Screenshot 2019-12-18 at 12 26 20" src="https://user-images.githubusercontent.com/639406/71082592-a9257400-2191-11ea-80e0-74654e35dae5.png">


# Related issue


# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
