### PR TITLE
**Feature:** add onMouseEnter, onMouseLeave prop to Tree

### DIFF
--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -7,8 +7,8 @@ type Props = TreeProps["trees"][-1] & {
   searchWords?: string[]
   level: number
   hasIconOffset: boolean
-  tooltip?: React.ReactNode
-  onTooltip?: (e: React.MouseEvent<HTMLDivElement> | undefined) => void
+  onMouseEnter?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void
 }
 
 const Container = styled.div<{ hasChildren: boolean; disabled: boolean }>`
@@ -36,8 +36,8 @@ const ChildTree: React.SFC<Props> = ({
   level,
   actions,
   hasIconOffset,
-  tooltip,
-  onTooltip,
+  onMouseEnter,
+  onMouseLeave,
   ...props
 }) => {
   const [isOpen, setIsOpen] = React.useState(Boolean(initiallyOpen))
@@ -89,8 +89,8 @@ const ChildTree: React.SFC<Props> = ({
         actions={actions}
         cursor={cursor}
         hasIconOffset={hasIconOffset && !hasChildren}
-        tooltip={tooltip}
-        onTooltip={onTooltip}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
       />
       {hasChildren && isOpen && (
         <Tree

--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -8,6 +8,7 @@ type Props = TreeProps["trees"][-1] & {
   level: number
   hasIconOffset: boolean
   tooltip?: React.ReactNode
+  onTooltip?: (e: React.MouseEvent<HTMLDivElement> | undefined) => void
 }
 
 const Container = styled.div<{ hasChildren: boolean; disabled: boolean }>`
@@ -36,6 +37,7 @@ const ChildTree: React.SFC<Props> = ({
   actions,
   hasIconOffset,
   tooltip,
+  onTooltip,
   ...props
 }) => {
   const [isOpen, setIsOpen] = React.useState(Boolean(initiallyOpen))
@@ -88,6 +90,7 @@ const ChildTree: React.SFC<Props> = ({
         cursor={cursor}
         hasIconOffset={hasIconOffset && !hasChildren}
         tooltip={tooltip}
+        onTooltip={onTooltip}
       />
       {hasChildren && isOpen && (
         <Tree

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -28,13 +28,6 @@ const Wrapper = styled.div`
       {
         label: "ERP",
         tag: "OR",
-        tooltip: (
-          <>
-            Hello this is tooltip!
-            <br />
-            <b>Bold text</b>
-          </>
-        ),
         childNodes: [
           {
             label: "Region",

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -176,7 +176,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
     if (onTooltip) {
       onTooltip(undefined)
     }
-  }, [tooltip, open])
+  }, [onTooltip])
 
   return (
     <Header

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -25,6 +25,7 @@ interface TreeItemProps {
   cursor?: string
   onNodeClick?: (e: React.MouseEvent<HTMLDivElement>) => void
   onNodeContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onTooltip?: (e: React.MouseEvent<HTMLDivElement> | undefined) => void
   actions?: React.ReactNode
   hasIconOffset?: boolean
   tooltip?: React.ReactNode
@@ -129,6 +130,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
   hasIconOffset,
   searchWords = defaultSearch,
   tooltip,
+  onTooltip,
 }) => {
   const handleKeyDown = useCallback(
     e => {
@@ -157,7 +159,24 @@ const TreeItem: React.SFC<TreeItemProps> = ({
   )
 
   const { open, close, viewMorePopup } = useViewMore()
-  const onMouseEnter = useCallback(e => (tooltip ? open(tooltip)(e) : undefined), [tooltip, open])
+  const onMouseEnter = useCallback(
+    e => {
+      if (tooltip) {
+        open(tooltip)(e)
+      }
+      if (onTooltip) {
+        onTooltip(e)
+      }
+    },
+    [tooltip, open, onTooltip],
+  )
+
+  const onMouseLeave = useCallback(() => {
+    close()
+    if (onTooltip) {
+      onTooltip(undefined)
+    }
+  }, [tooltip, open])
 
   return (
     <Header
@@ -170,7 +189,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       cursor={cursor}
       tabIndex={0} // TODO: tabIndex -1 for disabled items
       onMouseEnter={onMouseEnter}
-      onMouseLeave={close}
+      onMouseLeave={onMouseLeave}
     >
       {viewMorePopup && (
         <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x} padding={0} onClick={preventBubbling}>

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -6,10 +6,6 @@ import styled from "../utils/styled"
 import { ChevronRightIcon, ChevronDownIcon, IconComponentType } from "../Icon"
 import Highlighter from "react-highlight-words"
 import constants from "../utils/constants"
-import { ViewMorePopup } from "../Internals/ViewMorePopup"
-import useViewMore from "../DataTable/useViewMore"
-
-const preventBubbling = (e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()
 
 interface TreeItemProps {
   level: number
@@ -25,10 +21,10 @@ interface TreeItemProps {
   cursor?: string
   onNodeClick?: (e: React.MouseEvent<HTMLDivElement>) => void
   onNodeContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void
-  onTooltip?: (e: React.MouseEvent<HTMLDivElement> | undefined) => void
+  onMouseEnter?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void
   actions?: React.ReactNode
   hasIconOffset?: boolean
-  tooltip?: React.ReactNode
 }
 
 const Header = styled.div<{
@@ -129,8 +125,8 @@ const TreeItem: React.SFC<TreeItemProps> = ({
   actions,
   hasIconOffset,
   searchWords = defaultSearch,
-  tooltip,
-  onTooltip,
+  onMouseEnter,
+  onMouseLeave,
 }) => {
   const handleKeyDown = useCallback(
     e => {
@@ -158,26 +154,6 @@ const TreeItem: React.SFC<TreeItemProps> = ({
     [onNodeContextMenu, onNodeClick],
   )
 
-  const { open, close, viewMorePopup } = useViewMore()
-  const onMouseEnter = useCallback(
-    e => {
-      if (tooltip) {
-        open(tooltip)(e)
-      }
-      if (onTooltip) {
-        onTooltip(e)
-      }
-    },
-    [tooltip, open, onTooltip],
-  )
-
-  const onMouseLeave = useCallback(() => {
-    close()
-    if (onTooltip) {
-      onTooltip(undefined)
-    }
-  }, [onTooltip])
-
   return (
     <Header
       level={level}
@@ -191,11 +167,6 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      {viewMorePopup && (
-        <ViewMorePopup top={viewMorePopup.y} left={viewMorePopup.x} padding={0} onClick={preventBubbling}>
-          {viewMorePopup.content}
-        </ViewMorePopup>
-      )}
       {hasChildren &&
         React.createElement(isOpen ? ChevronDownIcon : ChevronRightIcon, {
           size: 11,


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

add onMouseEnter, onMouseLeave prop to tree, so we can show fixed position tooltip for the tree.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
