### PR TITLE
**Feature:** Allow advanced use-case on Table

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -356,7 +356,7 @@ function Table<T>({
                                 key={columnIndex}
                                 {...(column.tdProps ? column.tdProps(dataEntry, dataEntryIndex) : {})}
                               >
-                                {column.cell(dataEntry, dataEntryIndex)}
+                                {cell}
                               </Td>
                             )
                           })}

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -47,6 +47,7 @@ export interface TableProps<T> extends DefaultProps {
 export interface Column<T> {
   heading: React.ReactNode
   cell: (dataEntry: T, index: number) => React.ReactNode
+  tdProps?: (dataEntry: T, index: number) => React.TdHTMLAttributes<HTMLTableDataCellElement>
   sortOrder?: "asc" | "desc"
   onSortClick?: (order: "asc" | "desc") => void
   width?: number
@@ -299,6 +300,9 @@ function Table<T>({
                       return null
                     }
                     const dataEntryRowActions = rowActions(dataEntry)
+                    if (dataEntryRowActions === false) {
+                      return null
+                    }
                     return (
                       <Actions coloredBorders={shouldTdHaveColoredBorders}>
                         {Array.isArray(dataEntryRowActions) ? (
@@ -340,11 +344,22 @@ function Table<T>({
                               {React.createElement(icon!(dataEntry), { color: iconColor && iconColor(dataEntry) })}
                             </CellIcon>
                           )}
-                          {standardizedColumns.map((column, columnIndex) => (
-                            <Td coloredBorders={shouldTdHaveColoredBorders} cellWidth={column.width} key={columnIndex}>
-                              {column.cell(dataEntry, dataEntryIndex)}
-                            </Td>
-                          ))}
+                          {standardizedColumns.map((column, columnIndex) => {
+                            const cell = column.cell(dataEntry, dataEntryIndex)
+
+                            if (cell === false) return
+
+                            return (
+                              <Td
+                                coloredBorders={shouldTdHaveColoredBorders}
+                                cellWidth={column.width}
+                                key={columnIndex}
+                                {...(column.tdProps ? column.tdProps(dataEntry, dataEntryIndex) : {})}
+                              >
+                                {column.cell(dataEntry, dataEntryIndex)}
+                              </Td>
+                            )
+                          })}
                           {rowAction}
                           {onRowClick && rowActionName && (
                             <Actions coloredBorders={shouldTdHaveColoredBorders}>


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

We have this use-case in our product:

![image](https://user-images.githubusercontent.com/1761469/72734158-7bb95500-3b99-11ea-828b-e81775bcd8fe.png)


To do this, we need a way to tweak a bit the table data element (to pass `backgroundColor` and `colSpan`. The idea of this PR is to permit a bit more control to support non-standard use-cases. If our non-standard use cases become standard, we will extend the API later 😉

We can also send an explicit `false` to skip a `td` (needed for the `colSpan` use-case)

Note: Since it's not really standard, I would prefer to not expose this to the official doc.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
