### PR TITLE
**Feature:** Add x-small size for avatar

### DIFF
--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -72,7 +72,7 @@ const Picture = styled("div")<{
     const backgroundColor = assignedBackgroundColor || fixedBackgroundColor
     const textColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
     const sizeInPixels = size === "medium" ? 48 : size === "small" ? 32 : 12
-    const fontSizeInPixels = size === "medium" ? 13 : size === "small" ? 11 : 8
+    const fontSizeInPixels = size === "medium" ? 13 : size === "small" ? 11 : 7
 
     // Calculate sizes based on the state of the size prop
     const sizes = {
@@ -99,7 +99,7 @@ const Picture = styled("div")<{
       ...sizes,
       ...background,
       marginRight: showName ? theme.space.small : 0, // use for offset the display name
-      border: addBorder ? "2px solid white" : 0,
+      border: addBorder ? (size === "x-small" ? "1px solid white" : "2px solid white") : 0,
     }
   },
 )

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -21,7 +21,7 @@ export interface AvatarProps extends DefaultProps {
   /** Automatically assign a deterministic color. (Invalidates `color` assignment)  */
   assignColor?: boolean
   /** Size of avatars */
-  size?: "small" | "medium"
+  size?: "x-small" | "small" | "medium"
   /** Add a border to the Avatar? */
   addBorder?: boolean
   children?: React.ReactNode
@@ -71,8 +71,8 @@ const Picture = styled("div")<{
       : null
     const backgroundColor = assignedBackgroundColor || fixedBackgroundColor
     const textColor = readableTextColor(backgroundColor, [theme.color.text.default, "white"])
-    const sizeInPixels = size === "medium" ? 48 : 32
-    const fontSizeInPixels = size === "medium" ? 13 : 11
+    const sizeInPixels = size === "medium" ? 48 : size === "small" ? 32 : 12
+    const fontSizeInPixels = size === "medium" ? 13 : size === "small" ? 11 : 8
 
     // Calculate sizes based on the state of the size prop
     const sizes = {

--- a/src/Avatar/README.md
+++ b/src/Avatar/README.md
@@ -10,6 +10,18 @@ import { Avatar } from "@operational/components"
 </>
 ```
 
+### Simple avatar with name (different sizes)
+
+```jsx
+import * as React from "react"
+import { Avatar } from "@operational/components"
+;<>
+  <Avatar showName size="medium" name="Franklin Green" />
+  <Avatar showName size="small" name="Tejas Kumar" />
+  <Avatar showName size="x-small" name="Fabien Bernard" />
+</>
+```
+
 ### Show full name next to the avatar circle
 
 ```jsx

--- a/src/AvatarGroup/AvatarGroup.tsx
+++ b/src/AvatarGroup/AvatarGroup.tsx
@@ -19,7 +19,7 @@ export interface AvatarGroupProps extends DefaultProps {
   /** More button handler */
   onMoreClick?: () => void
   /** Size of avatars */
-  size?: "small" | "medium"
+  size?: "x-small" | "small" | "medium"
 }
 
 const MAX_MORE = 10
@@ -29,9 +29,9 @@ const Container = styled("div")({
   marginLeft: 12,
 })
 
-const AvatarContainer = styled.div`
+const AvatarContainer = styled.div<{ size: AvatarGroupProps["size"] }>`
   position: relative;
-  margin-left: -12px;
+  margin-left: ${({ size }) => (size === "x-small" ? -4 : -12)}px;
 
   [data-avatar] {
     display: none;
@@ -52,7 +52,7 @@ const AvatarGroup: React.SFC<AvatarGroupProps> = ({ avatars, size, onMoreClick, 
   return (
     <Container {...props}>
       {displayAvatars.map((avatar, i) => (
-        <AvatarContainer key={i}>
+        <AvatarContainer key={i} size={size}>
           <Tooltip data-avatar position="top">
             {avatar.name}
           </Tooltip>
@@ -60,7 +60,7 @@ const AvatarGroup: React.SFC<AvatarGroupProps> = ({ avatars, size, onMoreClick, 
         </AvatarContainer>
       ))}
       {moreAvatars && (
-        <AvatarContainer key="more">
+        <AvatarContainer key="more" size={size}>
           <Tooltip data-avatar position="top">
             {moreAvatars.map((avatar, i) => (
               <React.Fragment key={i}>

--- a/src/AvatarGroup/README.md
+++ b/src/AvatarGroup/README.md
@@ -27,6 +27,33 @@ const avatars = [
 </>
 ```
 
+### Different sizes
+
+```jsx
+import * as React from "react"
+import { AvatarGroup } from "@operational/components"
+const avatars = [
+  {
+    name: "Peter Pan",
+    photo: "https://www.robots-and-dragons.de/sites/default/files/field/image/preview/disney-peter_pan.jpg",
+  },
+  { name: "Wendy Darling" },
+  { name: "John Darling" },
+  { name: "Micheal Darling" },
+  { name: "George Darling" },
+  { name: "Tiger Lily" },
+  { name: "Tinker Bell" },
+  { name: "The Crocodile" },
+  { name: "Captain Hook" },
+  { name: "Mr. Smee" },
+]
+;<>
+  <AvatarGroup avatars={avatars} size="x-small" />
+  <AvatarGroup avatars={avatars} size="small" />
+  <AvatarGroup avatars={avatars} size="medium" />
+</>
+```
+
 ### Provide a custom onMoreClick action
 
 ```jsx


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

We need a new "x-small" size for avatars

![image](https://user-images.githubusercontent.com/1761469/73924872-68aec080-48cd-11ea-950d-bbf98620e9a7.png)

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Avatars look good in every sizes
- [x] AvatarGroup look good in every sizes
