### PR TITLE
  **Feature:**  CON-1150 Update card columns colours and spacing

### DIFF
--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -55,7 +55,7 @@ const Title = styled.div(({ theme }) => ({
   fontWeight: theme.font.weight.bold,
   color: theme.color.text.default,
   fontSize: theme.font.size.body,
-  borderBottom: `1px solid ${theme.color.separators.light}`,
+  borderBottom: `1px solid ${theme.color.border.lightest}`,
   paddingBottom: theme.space.small,
   marginBottom: theme.space.content,
   display: "flex",

--- a/src/CardColumn/CardColumn.tsx
+++ b/src/CardColumn/CardColumn.tsx
@@ -50,12 +50,12 @@ const Action = styled("div")`
   margin-left: auto;
 `
 
-const Title = styled("div")(({ theme }) => ({
+const Title = styled.div(({ theme }) => ({
   fontFamily: theme.font.family.main,
   fontWeight: theme.font.weight.bold,
-  color: theme.color.text.dark,
+  color: theme.color.text.default,
   fontSize: theme.font.size.body,
-  borderBottom: `1px solid ${theme.color.separators.default}`,
+  borderBottom: `1px solid ${theme.color.separators.light}`,
   paddingBottom: theme.space.small,
   marginBottom: theme.space.content,
   display: "flex",

--- a/src/CardColumns/CardColumns.tsx
+++ b/src/CardColumns/CardColumns.tsx
@@ -11,7 +11,7 @@ export const CardColumns = styled("div")<CardColumnsProps>(({ children, theme, c
   return {
     display: "grid",
     gridTemplateColumns: `repeat(${columns}, 1fr)`,
-    gridGap: theme.space.element,
+    gridGap: theme.space.big,
   }
 })
 


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR updates the spacing and colours for card columns to satisfy the recent updates of the UI requirements:
- Increases the spacing between the cards columns
- makes colour of the card column header lighter
- makes the border under the card column lighter

<img width="860" alt="Screenshot 2020-02-11 at 14 22 58" src="https://user-images.githubusercontent.com/639406/74240325-09401e80-4cda-11ea-80a3-ded4b6653f74.png">


# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
