### PR TITLE
**Fix:** Button focus state

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -61,7 +61,7 @@ export const makeColors = (theme: OperationalStyleConstants, color: string) => {
   const textColor =
     textColors[color] || readableTextColor(backgroundColor, [theme.color.text.default, theme.color.white])
 
-  const borderColor = borderColors[color] || (isWhite(backgroundColor) ? theme.color.border.disabled : backgroundColor)
+  const borderColor = borderColors[color] || (isWhite(backgroundColor) ? theme.color.border.default : backgroundColor)
 
   return {
     background: backgroundColor,

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -103,11 +103,13 @@ const BaseButton = styled<"button" | "a">("button")<{
     justifyContent: "center",
     padding: `0 ${condensed ? theme.space.medium : theme.space.element}px`,
     borderRadius: theme.borderRadius,
-    border: `1px solid ${borderColor}`,
+    border: `none`,
+    boxShadow: `0 0 0 1px ${borderColor}`,
     cursor: disabled ? "not-allowed" : "pointer",
     opacity: disabled ? 0.6 : 1.0,
     position: "relative",
     width: fullWidth ? "100%" : "initial",
+    margin: "1px 1px",
     marginRight: theme.space.small,
     // Apply styles with increased specificity to override defaults
     "&, a:link&, a:visited&": {
@@ -118,9 +120,6 @@ const BaseButton = styled<"button" | "a">("button")<{
       ...inputFocus({ theme, isError: color_ === "error" }),
       //Higher zIndex will make right border appear on ButtonGroup Focus.
       zIndex: theme.zIndex.confirm,
-    },
-    ".no-focus &:focus": {
-      boxShadow: "none",
     },
     ...(!disabled
       ? {

--- a/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ButtonGroup Component Should initialize properly 1`] = `
   >
     <button
       aria-label="Hello"
-      class="css-1mr8tso"
+      class="css-qj6ccr"
       role="button"
     >
       Hello

--- a/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Chip Should render 1`] = `
     class="css-p29iif"
   />
   <div
-    class="css-1o7p7q7-chip"
+    class="css-1fq4i0h-chip"
   >
     <div
       aria-label="Hi"

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`DatePicker Component Should render 1`] = `
       </svg>
     </div>
     <input
-      class="css-13yzovf"
+      class="css-17t1nns"
       placeholder="Pick a date"
       readonly=""
       value="2018-01-02 - 2018-01-23"

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -91,7 +91,7 @@ const Field = styled("input")<{
     opacity: disabled ? 0.6 : 1.0,
     border: "none",
     boxShadow: `0 0 0 1px ${isError ? theme.color.error : theme.color.border.default}`,
-    margin: "0 1px", // offset box-shadow like a border
+    margin: "1px 1px", // offset box-shadow like a border
     outline: "none",
     appearance: "none",
     color: preset ? theme.color.text.dark : theme.color.text.default,

--- a/src/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/src/Switch/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Switch Should render 1`] = `
     class="css-p29iif"
   />
   <div
-    class="css-1gcg4hk"
+    class="css-1pu2ql2"
   >
     <div
       class="css-1nz7xkz-switch"

--- a/src/utils/mixins.ts
+++ b/src/utils/mixins.ts
@@ -1,6 +1,6 @@
 import { keyframes } from "@emotion/core"
 
-import { lighten } from "../utils"
+import { lighten, darken } from "../utils"
 import styled from "../utils/styled"
 import { OperationalStyleConstants } from "./constants"
 import memoize from "lodash/memoize"
@@ -30,7 +30,7 @@ export const customScrollbar = memoize(
 
 export const inputFocus = memoize(({ theme, isError }: { theme: OperationalStyleConstants; isError?: boolean }) => ({
   outline: "none",
-  boxShadow: `0 0 0 1px ${isError ? theme.color.error : theme.color.primary}`,
+  boxShadow: `0 0 0 1px ${isError ? darken(theme.color.error, 10) : darken(theme.color.primary, 10)}`,
 }))
 
 export const Label = styled.label<{ fullWidth?: boolean; left?: boolean }>(({ fullWidth, theme, left }) => ({


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

This PR improves the focus state for the Button and improves the way button looks when used in the Form next to the Input component by:
- darkening the focus state, so it is visible even if button has primary colour
- prevents displaying double border when focused
- prevents border being cut off when used in the form
- unifies the border colour of the button with the input

<img width="803" alt="Screenshot 2020-02-13 at 14 24 04" src="https://user-images.githubusercontent.com/639406/74442345-a2556d80-4e71-11ea-8a1b-2aa7b5426c1a.png">


<img width="523" alt="Screenshot 2020-02-13 at 14 23 17" src="https://user-images.githubusercontent.com/639406/74442344-a1bcd700-4e71-11ea-928e-3fe1a541c770.png">


<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
