### PR TITLE
**Fix:** bug when tooltips get stuck on scroll

### DIFF
--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -2,7 +2,7 @@ import styled from "../utils/styled"
 import { DataTableProps } from "./DataTable"
 import { getHeaderRowHeight } from "./DataTable.util"
 
-export const Container = styled.div<{ width: string }>`
+export const Container = styled("div", { shouldForwardProp: prop => prop !== "width" })<{ width: string }>`
   width: ${({ width }) => width};
   overflow: visible;
 `

--- a/src/DataTable/DataTable.styled.ts
+++ b/src/DataTable/DataTable.styled.ts
@@ -2,12 +2,12 @@ import styled from "../utils/styled"
 import { DataTableProps } from "./DataTable"
 import { getHeaderRowHeight } from "./DataTable.util"
 
-export const Container = styled("div", { shouldForwardProp: prop => prop !== "width" })<{ width: string }>`
+export const Container = styled.div<{ width: string }>`
   width: ${({ width }) => width};
   overflow: visible;
 `
 
-export const HeadersContainer = styled("div")<{
+export const HeadersContainer = styled.div<{
   numColumns: number
   numHeaders: number
   columnWidth: string
@@ -18,7 +18,7 @@ export const HeadersContainer = styled("div")<{
   grid-template-rows: repeat(${({ numHeaders, rowHeight }) => `${numHeaders}, ${getHeaderRowHeight(rowHeight)}px`});
 `
 
-export const Row = styled("div")<{ numCells: number; cellWidth: string }>`
+export const Row = styled.div<{ numCells: number; cellWidth: string }>`
   display: grid;
   grid-template-columns: repeat(${({ numCells, cellWidth }) => `${numCells}, ${cellWidth}`});
 `

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -52,6 +52,11 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
 }: DataTableProps<Columns, Rows>) {
   const { open, close, viewMorePopup } = useViewMore()
   const rowHeight = React.useMemo(() => getRowHeight(initialRowHeight), [initialRowHeight])
+  React.useEffect(() => {
+    const onScroll = () => close(true)
+    window.addEventListener("scroll", onScroll)
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [close])
 
   const Table = React.useMemo(
     () =>

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -9,6 +9,8 @@ import { defaultRowHeight, getRowHeight, findScrollableAncestor } from "./DataTa
 import useViewMore from "./useViewMore"
 import CellContent from "./CellContent"
 
+const fixedSizeListClass = "operational-ui__DataTable--virtual-scroller"
+
 export interface DataTableProps<Columns, Rows> {
   /* The columns of our table. They are an array of header layers. */
   columns: Columns
@@ -56,7 +58,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
     if (ref.current) {
       const scrollableAncestor = findScrollableAncestor(
         // we can't get this element other way, because of react-window
-        ref.current.getElementsByClassName("operational-ui__DataTable--virtual-scroller")[0],
+        ref.current.getElementsByClassName(fixedSizeListClass)[0],
       )
       scrollableAncestor.addEventListener("scroll", close)
       return () => scrollableAncestor.removeEventListener("scroll", close)
@@ -156,7 +158,7 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
           width={width}
           innerElementType={Table}
           /** can't use data-cy or any other prop because of react-window */
-          className="operational-ui__DataTable--virtual-scroller"
+          className={fixedSizeListClass}
           style={{ willChange: undefined }}
         >
           {VirtualRow}

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -54,13 +54,12 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
   const { open, close, viewMorePopup } = useViewMore()
   React.useEffect(() => {
     if (ref.current) {
-      const onScroll = () => close()
       const scrollableAncestor = findScrollableAncestor(
         // we can't get this element other way, because of react-window
         ref.current.getElementsByClassName("operational-ui__DataTable--virtual-scroller")[0],
       )
-      scrollableAncestor.addEventListener("scroll", onScroll)
-      return () => scrollableAncestor.removeEventListener("scroll", onScroll)
+      scrollableAncestor.addEventListener("scroll", close)
+      return () => scrollableAncestor.removeEventListener("scroll", close)
     }
   }, [close, ref])
   const rowHeight = React.useMemo(() => getRowHeight(initialRowHeight), [initialRowHeight])

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -51,12 +51,12 @@ export function DataTable<Columns extends any[][], Rows extends any[][]>({
   className,
 }: DataTableProps<Columns, Rows>) {
   const { open, close, viewMorePopup } = useViewMore()
-  const rowHeight = React.useMemo(() => getRowHeight(initialRowHeight), [initialRowHeight])
   React.useEffect(() => {
     const onScroll = () => close(true)
     window.addEventListener("scroll", onScroll)
     return () => window.removeEventListener("scroll", onScroll)
   }, [close])
+  const rowHeight = React.useMemo(() => getRowHeight(initialRowHeight), [initialRowHeight])
 
   const Table = React.useMemo(
     () =>

--- a/src/DataTable/DataTable.util.ts
+++ b/src/DataTable/DataTable.util.ts
@@ -15,3 +15,30 @@ export const getRowHeight = (initialRowHeight: DataTableProps<any, any>["rowHeig
       return initialRowHeight || defaultRowHeight
   }
 }
+
+const canScroll = (overflow: string) => overflow === "auto" || overflow === "scroll"
+
+// inspired by https://github.com/civiccc/react-waypoint/blob/6004756ad6b6699f358fc6008e29e242b2777379/src/waypoint.jsx#L134
+export const findScrollableAncestor = (node: Element) => {
+  while (node.parentNode) {
+    if (node === document.body) {
+      // We've reached all the way to the root node.
+      return window
+    }
+
+    const style = window.getComputedStyle(node)
+    const overflowX = style.getPropertyValue("overflow-x")
+    const overflowY = style.getPropertyValue("overflow-y")
+    const overflow = style.getPropertyValue("overflow")
+
+    if (canScroll(overflowX) || canScroll(overflowY) || canScroll(overflow)) {
+      return node
+    }
+
+    node = node.parentNode as Element
+  }
+
+  // A scrollable ancestor element was not found, which means that we need to
+  // do stuff on window.
+  return window
+}

--- a/src/DataTable/DataTable.util.ts
+++ b/src/DataTable/DataTable.util.ts
@@ -15,30 +15,3 @@ export const getRowHeight = (initialRowHeight: DataTableProps<any, any>["rowHeig
       return initialRowHeight || defaultRowHeight
   }
 }
-
-const canScroll = (overflow: string) => overflow === "auto" || overflow === "scroll"
-
-// inspired by https://github.com/civiccc/react-waypoint/blob/6004756ad6b6699f358fc6008e29e242b2777379/src/waypoint.jsx#L134
-export const findScrollableAncestor = (node: Element) => {
-  while (node.parentNode) {
-    if (node === document.body) {
-      // We've reached all the way to the root node.
-      return window
-    }
-
-    const style = window.getComputedStyle(node)
-    const overflowX = style.getPropertyValue("overflow-x")
-    const overflowY = style.getPropertyValue("overflow-y")
-    const overflow = style.getPropertyValue("overflow")
-
-    if (canScroll(overflowX) || canScroll(overflowY) || canScroll(overflow)) {
-      return node
-    }
-
-    node = node.parentNode as Element
-  }
-
-  // A scrollable ancestor element was not found, which means that we need to
-  // do stuff on window.
-  return window
-}

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -10,9 +10,14 @@ const useViewMore = () => {
     false,
   )
 
-  const close = React.useCallback(() => {
+  const close = React.useCallback((immediately?: any) => {
     window.clearTimeout(closeTimeoutIdRef.current)
-    closeTimeoutIdRef.current = window.setTimeout(() => setViewMorePopup(false), 150)
+    if (immediately === true) {
+      closeTimeoutIdRef.current = undefined
+      setViewMorePopup(false)
+    } else {
+      closeTimeoutIdRef.current = window.setTimeout(() => setViewMorePopup(false), 150)
+    }
   }, [])
   React.useEffect(() => () => window.clearTimeout(closeTimeoutIdRef.current), [])
 

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -10,7 +10,7 @@ const useViewMore = () => {
     false,
   )
 
-  const close = React.useCallback((immediately?: any) => {
+  const close = React.useCallback((immediately?: true | React.MouseEvent) => {
     window.clearTimeout(closeTimeoutIdRef.current)
     if (immediately === true) {
       closeTimeoutIdRef.current = undefined

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -11,31 +11,28 @@ const useViewMore = () => {
   )
 
   const close = React.useCallback(() => {
-    if (viewMorePopup) {
-      closeTimeoutIdRef.current = window.setTimeout(() => setViewMorePopup(false), 150)
-    }
-  }, [viewMorePopup])
+    window.clearTimeout(closeTimeoutIdRef.current)
+    closeTimeoutIdRef.current = window.setTimeout(() => setViewMorePopup(false), 150)
+  }, [])
   React.useEffect(() => () => window.clearTimeout(closeTimeoutIdRef.current), [])
 
   const open = React.useCallback(
     (content: React.ReactNode) => (e: React.MouseEvent) => {
       e.stopPropagation()
       window.clearTimeout(closeTimeoutIdRef.current)
-      setViewMorePopup(
-        viewMorePopup
-          ? {
-              ...viewMorePopup,
-              // Update content, but not position to prevent "sliding" of popup
-              content,
-            }
+      closeTimeoutIdRef.current = undefined
+      const { clientX, clientY } = e
+      setViewMorePopup(current =>
+        current && current.content === content
+          ? current
           : {
               content,
-              x: e.clientX > window.innerWidth / 2 ? e.clientX - 8 : e.clientX + 8,
-              y: e.clientY > window.innerHeight / 2 ? e.clientY - 8 : e.clientY + 8,
+              x: clientX > window.innerWidth / 2 ? clientX - 8 : clientX + 8,
+              y: clientY > window.innerHeight / 2 ? clientY - 8 : clientY + 8,
             },
       )
     },
-    [viewMorePopup],
+    [],
   )
 
   const toggle = React.useCallback((content: React.ReactNode) => (viewMorePopup ? close() : open(content)), [

--- a/src/DataTable/useViewMore.ts
+++ b/src/DataTable/useViewMore.ts
@@ -13,7 +13,6 @@ const useViewMore = () => {
   const close = React.useCallback((immediately?: true | React.MouseEvent) => {
     window.clearTimeout(closeTimeoutIdRef.current)
     if (immediately === true) {
-      closeTimeoutIdRef.current = undefined
       setViewMorePopup(false)
     } else {
       closeTimeoutIdRef.current = window.setTimeout(() => setViewMorePopup(false), 150)
@@ -25,7 +24,6 @@ const useViewMore = () => {
     (content: React.ReactNode) => (e: React.MouseEvent) => {
       e.stopPropagation()
       window.clearTimeout(closeTimeoutIdRef.current)
-      closeTimeoutIdRef.current = undefined
       const { clientX, clientY } = e
       setViewMorePopup(current =>
         current && current.content === content


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

The problem was due to dependencies in open/close functions so they got called way to much times.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Resize window to make table horizontally scrollable, check that tooltip disappears on all scroll directions

Tester 2

- [ ] Resize window to make table horizontally scrollable, check that tooltip disappears on all scroll directions