### PR TITLE
[WiP] **Feature:** use context

### DIFF
--- a/src/Internals/Confirm.tsx
+++ b/src/Internals/Confirm.tsx
@@ -1,161 +1,19 @@
 import * as React from "react"
-import Button, { ButtonProps } from "../Button/Button"
-import styled from "../utils/styled"
-import ControlledModal from "./ControlledModal"
-
-export interface ConfirmBodyProps<T> {
-  setConfirmState: (state?: Partial<T>) => void
-  confirmState: T
-}
-
-export interface ConfirmOptions<T> {
-  title: React.ReactNode
-  body: React.ReactNode | React.ComponentType<ConfirmBodyProps<T>>
-  fullSize?: boolean
-  cancelButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>) | null
-  actionButton?: React.ReactElement<ButtonProps> | ((confirmState: T) => React.ReactElement<ButtonProps>) | null
-  onConfirm?: (confirmState: T) => void
-  onCancel?: (confirmState: T) => void
-  state?: T
-  /**
-   * Prevent closing the modal on overlay click if it's specify to `false`
-   *
-   * @default true
-   */
-  closeOnOverlayClick?: boolean
-}
-
-export interface State<T> {
-  options: Partial<ConfirmOptions<T>>
-}
+import { useConfirm, ConfirmOptions } from "../useConfirm"
 
 export interface Props {
-  children: (confirm: <T, P = ConfirmOptions<T>>(options: P) => void) => React.ReactNode
+  children: (confirm: <T>(confirmOptions: ConfirmOptions<T>) => void) => React.ReactNode
 }
 
-const actionsBarSize = 36
-
-function isBodyAFunction<T>(
-  component: ConfirmOptions<T>["body"],
-): component is React.ComponentType<ConfirmBodyProps<T>> {
-  return typeof component === "function"
-}
-
-export const Actions = styled("div")`
-  margin-top: ${({ theme }) => theme.space.element}px;
-  align-self: flex-start;
-  height: ${actionsBarSize}px;
-  display: flex;
-  flex-direction: row-reverse;
-`
-
-export const ControlledModalContent = styled("div")<{ fullSize: boolean }>(({ fullSize, theme }) => ({
-  label: "ControlledModalContent",
-
-  // Invert control of spacing from Card to Modal
-  marginTop: theme.space.element * -1,
-  marginLeft: theme.space.element * -1,
-  marginRight: theme.space.element * -1,
-  padding: theme.space.element,
-
-  ...(fullSize
-    ? {
-        height: `calc(100% - ${actionsBarSize}px)`,
-        overflowY: "auto",
-      }
-    : {}),
-}))
-
-export class Confirm<T> extends React.Component<Props, Readonly<State<T>>> {
-  public readonly state: State<T> = {
-    options: {},
-  }
-
-  private openConfirm = (options: Partial<ConfirmOptions<T>>) => {
-    this.setState({ options })
-  }
-
-  private closeConfirm = () => {
-    this.setState({ options: {} })
-  }
-
-  private onCancelClick = () => {
-    const { onCancel, state } = this.state.options
-
-    if (onCancel) {
-      onCancel(state as T)
-    }
-
-    this.closeConfirm()
-  }
-
-  private onActionClick = () => {
-    const { onConfirm, state } = this.state.options
-
-    if (onConfirm) {
-      onConfirm(state as T)
-    }
-
-    this.closeConfirm()
-  }
-
-  private setConfirmState: ConfirmBodyProps<T>["setConfirmState"] = state => {
-    this.setState(prevState => ({
-      options: {
-        ...prevState.options,
-        // No spreading here due to https://github.com/Microsoft/TypeScript/issues/10727
-        state: Object.assign({}, prevState.options.state, state),
-      },
-    }))
-  }
-
-  public render() {
-    const { actionButton, fullSize, title, cancelButton, state, body: Body, closeOnOverlayClick } = this.state.options
-    const isOpen = Boolean(Body)
-
-    return (
-      <>
-        {this.props.children(this.openConfirm)}
-        {isOpen && (
-          <ControlledModal
-            type="confirm"
-            fullSize={fullSize}
-            title={title}
-            onClose={this.closeConfirm}
-            closeOnOverlayClick={closeOnOverlayClick}
-          >
-            <ControlledModalContent fullSize={Boolean(fullSize)}>
-              {isBodyAFunction(Body) && state ? (
-                <Body setConfirmState={this.setConfirmState} confirmState={state} />
-              ) : (
-                Body
-              )}
-            </ControlledModalContent>
-            <Actions data-cy="confirm__actions">
-              {cancelButton !== null &&
-                React.cloneElement(
-                  typeof cancelButton === "function"
-                    ? cancelButton(state as T)
-                    : cancelButton || <Button>Cancel</Button>,
-                  {
-                    onClick: this.onCancelClick,
-                  },
-                )}
-              {actionButton !== null &&
-                React.cloneElement(
-                  typeof actionButton === "function"
-                    ? actionButton(state as T)
-                    : actionButton || <Button color="success">Confirm</Button>,
-                  {
-                    onClick: this.onActionClick,
-                  },
-                )}
-            </Actions>
-          </ControlledModal>
-        )}
-      </>
-    )
-  }
+// Can we delete this?
+export const Confirm: React.FC<Props> = ({ children }) => {
+  const [open, Placeholder] = useConfirm()
+  return (
+    <>
+      {children(open as <T>(confirmOptions: ConfirmOptions<T>) => void)}
+      <Placeholder />
+    </>
+  )
 }
 
 export default Confirm

--- a/src/Internals/Modal.tsx
+++ b/src/Internals/Modal.tsx
@@ -13,7 +13,7 @@ export interface Props {
   children: (modal: (options: ModalOptions) => void) => React.ReactNode
 }
 
-export const Modal = ({ children }: Props) => {
+export const useModal = () => {
   const [options, setOptions] = useState<State>({})
 
   const openModal = useCallback((newOptions: ModalOptions) => {
@@ -24,14 +24,26 @@ export const Modal = ({ children }: Props) => {
     setOptions({})
   }, [])
 
-  return (
-    <>
-      {children(openModal)}
-      {Boolean(options.body) && (
+  const Placeholder: React.FC<{}> = useCallback(
+    () =>
+      Boolean(options.body) ? (
         <ControlledModal fullSize={options.fullSize} title={options.title} onClose={closeModal}>
           {typeof options.body === "function" ? options.body(closeModal) : options.body}
         </ControlledModal>
-      )}
+      ) : null,
+    [],
+  )
+
+  return [openModal, Placeholder] as const
+}
+
+// Can we delete this?
+export const Modal = ({ children }: Props) => {
+  const [open, Placeholder] = useModal()
+  return (
+    <>
+      {children(open)}
+      {<Placeholder />}
     </>
   )
 }

--- a/src/PageContent/PageContentContext.tsx
+++ b/src/PageContent/PageContentContext.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import { ModalOptions } from "../Internals/Modal"
+import { ConfirmOptions } from "../useConfirm"
+
+export interface ModalConfirmContext {
+  modal: (modalOptions: ModalOptions) => void
+  confirm: <T>(confirmOptions: ConfirmOptions<T>) => void
+}
+
+/**
+ * Defining a default context value here, used below when instantiating
+ * the context consumer and provider below in order for context to be
+ * correctly detected throughout the application.
+ */
+const defaultContext: ModalConfirmContext = {
+  confirm: () => {
+    throw new Error("You can use this function inside PageContent")
+  },
+  modal: () => {
+    throw new Error("You can use this function inside PageContent")
+  },
+}
+
+const ctx = React.createContext(defaultContext)
+
+export const { Consumer: PageContentContext, Provider: PageContentProvider } = ctx
+
+export const usePageContentContextContext = () => React.useContext(ctx)

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,8 @@ export { default as OperationalUI, OperationalUIProps } from "./OperationalUI/Op
 export { default as Page, PageProps } from "./Page/Page"
 export { default as PageArea, PageAreaProps } from "./PageArea/PageArea"
 export { default as PageAreas, PageAreasProps } from "./PageAreas/PageAreas"
-export { default as PageContent, PageContentProps, ModalConfirmContext } from "./PageContent/PageContent"
+export { default as PageContent, PageContentProps } from "./PageContent/PageContent"
+export { ModalConfirmContext } from "./PageContent/PageContentContext"
 export { default as Paginator, PaginatorProps } from "./Paginator/Paginator"
 export { default as Progress, ProgressProps, FixedProgress } from "./Progress/Progress"
 export { default as ProgressPanel, ProgressPanelProps } from "./ProgressPanel/ProgressPanel"
@@ -94,7 +95,7 @@ export { default as Title } from "./Typography/Title"
 export { default as Small } from "./Typography/Small"
 
 // Internals components
-export { Actions, ControlledModalContent, ConfirmBodyProps, ConfirmOptions } from "./Internals/Confirm"
+export { ConfirmBodyProps, ConfirmOptions } from "./useConfirm"
 export { default as ControlledModal } from "./Internals/ControlledModal"
 export { Tab } from "./Internals/Tabs"
 

--- a/src/useConfirm/index.tsx
+++ b/src/useConfirm/index.tsx
@@ -1,0 +1,147 @@
+import * as React from "react"
+import Button, { ButtonProps } from "../Button/Button"
+import styled from "../utils/styled"
+import ControlledModal from "../Internals/ControlledModal"
+
+export interface ConfirmBodyProps<T> {
+  setConfirmState: (state?: Partial<T>) => void
+  confirmState: T
+}
+
+export interface ConfirmOptions<T> {
+  title: React.ReactNode
+  body: React.ReactNode | React.ComponentType<ConfirmBodyProps<T>>
+  fullSize?: boolean
+  cancelButton?: React.ReactElement<ButtonProps> | ((confirmState?: T) => React.ReactElement<ButtonProps>) | null
+  actionButton?: React.ReactElement<ButtonProps> | ((confirmState?: T) => React.ReactElement<ButtonProps>) | null
+  onConfirm?: (confirmState?: T) => void
+  onCancel?: (confirmState?: T) => void
+  state?: T
+  /**
+   * Prevent closing the modal on overlay click if it's specify to `false`
+   *
+   * @default true
+   */
+  closeOnOverlayClick?: boolean
+}
+
+const actionsBarSize = 36
+
+function isBodyAFunction<T>(
+  component: ConfirmOptions<T>["body"],
+): component is React.ComponentType<ConfirmBodyProps<T>> {
+  return typeof component === "function"
+}
+
+export const Actions = styled.div`
+  margin-top: ${({ theme }) => theme.space.element}px;
+  align-self: flex-start;
+  height: ${actionsBarSize}px;
+  display: flex;
+  flex-direction: row-reverse;
+`
+
+export const ControlledModalContent = styled.div<{ fullSize: boolean }>(({ fullSize, theme }) => ({
+  label: "ControlledModalContent",
+
+  // Invert control of spacing from Card to Modal
+  marginTop: theme.space.element * -1,
+  marginLeft: theme.space.element * -1,
+  marginRight: theme.space.element * -1,
+  padding: theme.space.element,
+
+  ...(fullSize
+    ? {
+        height: `calc(100% - ${actionsBarSize}px)`,
+        overflowY: "auto",
+      }
+    : {}),
+}))
+
+export const useConfirm = <T, P = ConfirmOptions<T>>() => {
+  const [options, setOptions] = React.useState<Partial<ConfirmOptions<T>>>({})
+
+  const openConfirm = React.useCallback(
+    (options: P) => {
+      setOptions(options)
+    },
+    [setOptions],
+  )
+
+  const closeConfirm = React.useCallback(() => {
+    setOptions({})
+  }, [setOptions])
+
+  const onCancelClick = React.useCallback(() => {
+    const { onCancel, state } = options
+
+    if (onCancel) {
+      onCancel(state)
+    }
+
+    closeConfirm()
+  }, [options, closeConfirm])
+
+  const onActionClick = React.useCallback(() => {
+    const { onConfirm, state } = options
+
+    if (onConfirm) {
+      onConfirm(state)
+    }
+
+    closeConfirm()
+  }, [options, closeConfirm])
+
+  const setConfirmState: ConfirmBodyProps<T>["setConfirmState"] = React.useCallback(
+    state => {
+      setOptions(prevOptions => ({
+        ...prevOptions,
+        state: { ...prevOptions.state, ...state } as T,
+      }))
+    },
+    [setOptions],
+  )
+
+  const Placeholder: React.FC<{}> = React.useCallback(() => {
+    const { actionButton, fullSize, title, cancelButton, state, body: Body, closeOnOverlayClick } = options
+    const isOpen = Boolean(Body)
+
+    return (
+      <>
+        {isOpen && (
+          <ControlledModal
+            type="confirm"
+            fullSize={fullSize}
+            title={title}
+            onClose={closeConfirm}
+            closeOnOverlayClick={closeOnOverlayClick}
+          >
+            <ControlledModalContent fullSize={Boolean(fullSize)}>
+              {isBodyAFunction(Body) && state ? <Body setConfirmState={setConfirmState} confirmState={state} /> : Body}
+            </ControlledModalContent>
+            <Actions data-cy="confirm__actions">
+              {cancelButton !== null &&
+                React.cloneElement(
+                  typeof cancelButton === "function" ? cancelButton(state) : cancelButton || <Button>Cancel</Button>,
+                  {
+                    onClick: onCancelClick,
+                  },
+                )}
+              {actionButton !== null &&
+                React.cloneElement(
+                  typeof actionButton === "function"
+                    ? actionButton(state)
+                    : actionButton || <Button color="success">Confirm</Button>,
+                  {
+                    onClick: onActionClick,
+                  },
+                )}
+            </Actions>
+          </ControlledModal>
+        )}
+      </>
+    )
+  }, [options, closeConfirm, onCancelClick, onActionClick, setConfirmState])
+
+  return [openConfirm, Placeholder] as const
+}

--- a/src/utils/isChildFunction.ts
+++ b/src/utils/isChildFunction.ts
@@ -1,4 +1,5 @@
-import { PageContentProps, ModalConfirmContext } from "../PageContent/PageContent"
+import { PageContentProps } from "../PageContent/PageContent"
+import { ModalConfirmContext } from "../PageContent/PageContentContext"
 
 export const isChildFunction = (
   children: PageContentProps["children"],


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Just idea how to liberate confirm API from page component.

**Broken for this case**:

<img width="1149" alt="Screenshot 2020-02-25 at 15 17 21" src="https://user-images.githubusercontent.com/179534/75255298-fbae8c80-57e1-11ea-9e59-4aa1e59012b2.png">

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
