### PR TITLE
**Feature:** Improve Tree's item highlight state

### DIFF
--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -539,6 +539,7 @@ const MyComponent = () => {
               {
                 label: "db_01",
                 strong: true,
+                highlight: true,
                 icon: VirtualIcon,
                 initiallyOpen: true,
                 childNodes: [

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -210,7 +210,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
         React.createElement(isOpen ? ChevronDownIcon : ChevronRightIcon, {
           size: 12,
           left: true,
-          color: "color.text.lighter",
+          color: isOpen ? "color.text.lighter" : "primary",
           style: { marginRight: 8 },
         })}
       {tag && (

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react"
 import NameTag from "../NameTag/NameTag"
-import { darken, lighten } from "../utils"
+import { lighten } from "../utils"
 import styled from "../utils/styled"
 import { ChevronRightIcon, ChevronDownIcon, IconComponentType } from "../Icon"
 import Highlighter from "react-highlight-words"
@@ -60,8 +60,7 @@ const Header = styled.div<{
 
   :hover,
   .no-focus &:hover:focus {
-    background: ${({ theme, highlight }) =>
-      highlight ? darken(theme.color.highlight, 20) : theme.color.background.lighter};
+    background: ${({ theme, highlight }) => (highlight ? theme.color.highlight : theme.color.background.lighter)};
 
     /* Show ActionsContainer on hover */
     div:last-of-type {

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react"
 import NameTag from "../NameTag/NameTag"
-import { setAlpha } from "../utils"
+import { setAlpha } from "../utils/color"
 import styled from "../utils/styled"
 import { ChevronRightIcon, ChevronDownIcon, IconComponentType } from "../Icon"
 import Highlighter from "react-highlight-words"

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react"
 import NameTag from "../NameTag/NameTag"
-import { lighten } from "../utils"
+import { setAlpha } from "../utils"
 import styled from "../utils/styled"
 import { ChevronRightIcon, ChevronDownIcon, IconComponentType } from "../Icon"
 import Highlighter from "react-highlight-words"
@@ -71,7 +71,7 @@ const Header = styled.div<{
   :focus {
     outline: none;
     color: ${({ theme }) => theme.color.primary};
-    background: ${({ theme }) => lighten(theme.color.primary, 50)};
+    background: ${({ theme }) => setAlpha(0.05)(theme.color.primary)};
 
     /* Show ActionsContainer on hover */
     div:last-of-type {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import get from "lodash/get"
+import { lighten } from "."
 
 /**
  * # Operational UI's styling constants.
@@ -120,9 +121,7 @@ const color = {
   basic: "#636363",
   ghost: "hsla(0, 0%, 100%, 0.33)",
   white: whiteColor,
-  /** `#fff26666` */
-  highlight: "#fff26666",
-  /** `#000` */
+  highlight: lighten(primaryColor, 50),
   black: "#000",
   background: backgroundColors,
   separators: separatorColors,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import get from "lodash/get"
-import { lighten } from "."
+import { setAlpha } from "./color"
 
 /**
  * # Operational UI's styling constants.
@@ -121,7 +121,8 @@ const color = {
   basic: "#636363",
   ghost: "hsla(0, 0%, 100%, 0.33)",
   white: whiteColor,
-  highlight: lighten(primaryColor, 50),
+  highlight: setAlpha(0.05)(primaryColor),
+  /** `#000` */
   black: "#000",
   background: backgroundColors,
   separators: separatorColors,


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR:
1. Update the tree item highlight state to be a variation of the primary theme colour
1. Updates the colouring of the chevron of the closed tree item with children to have primary colour

<img width="865" alt="Screenshot 2020-03-09 at 13 10 18" src="https://user-images.githubusercontent.com/639406/76212105-061c4d80-6208-11ea-9e46-bc4225ee0ed9.png">


# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
