### PR TITLE
CON-1281 better primary color

### DIFF
--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import styled from "../utils/styled"
 import { SearchIcon, CaretDownIcon, CaretUpIcon, EnterIcon, NoIcon } from "../Icon"
-import { lighten } from "../utils"
+import { setAlpha } from "../utils"
 import useHotkey from "../useHotkey"
 import Chip from "../Chip/Chip"
 
@@ -244,7 +244,7 @@ const CategoryDropdown = styled.div<{ highlighted?: boolean; isCondensed?: boole
 
   :hover {
     background-color: ${({ theme, highlighted }) =>
-      highlighted ? theme.color.background.grey : lighten(theme.color.primary, 54)};
+      highlighted ? theme.color.background.grey : setAlpha(0.05)(theme.color.primary)};
     color: ${({ theme, highlighted }) => (highlighted ? theme.color.basic : theme.color.primary)};
   }
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -14,7 +14,7 @@ import Small from "../Typography/Small"
 import styled from "../utils/styled"
 import { IconComponentType, ChevronDownIcon, ChevronUpDownIcon, ChevronUpIcon } from "../Icon"
 import { useUniqueId } from "../useUniqueId"
-import { lighten } from "../utils"
+import { setAlpha } from "../utils"
 
 export interface TableProps<T> extends DefaultProps {
   data: T[]
@@ -83,21 +83,21 @@ const Tr = styled.tr<{
   height: condensed ? 36 : 50,
   display: isDragging ? "table" : "table-row",
   tableLayout: "fixed",
-  backgroundColor: active ? lighten(theme.color.primary, 54) : theme.color.white,
+  backgroundColor: active ? setAlpha(0.05)(theme.color.primary) : theme.color.white,
   ...(draggable || clickable
     ? {
         ":hover": {
-          backgroundColor: active ? lighten(theme.color.primary, 52) : lighten(theme.color.primary, 54),
+          backgroundColor: active ? setAlpha(0.07)(theme.color.primary) : setAlpha(0.05)(theme.color.primary),
           cursor: clickable ? "pointer" : draggable ? "move" : "default",
         },
       }
     : {}),
   ":focus": {
     outline: "none",
-    backgroundColor: lighten(theme.color.primary, 52),
+    backgroundColor: setAlpha(0.05)(theme.color.primary),
   },
   ".no-focus &:focus": {
-    backgroundColor: active ? lighten(theme.color.primary, 54) : theme.color.white,
+    backgroundColor: active ? setAlpha(0.05)(theme.color.primary) : theme.color.white,
   },
 }))
 

--- a/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -14,14 +14,14 @@ exports[`Table Component Should render 1`] = `
       class="css-x4ot8q"
     >
       <tr
-        class="css-tty73l"
+        class="css-132zagp"
       />
     </thead>
     <tbody
       data-react-beautiful-dnd-droppable="0"
     >
       <tr
-        class="css-tty73l"
+        class="css-132zagp"
       >
         <td
           class="css-9u4d0l"


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
This PR switches to use alpha variation of the primary color instead of lightened one, as lightened one may look bad on custom primary color variations
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
https://contiamo.atlassian.net/browse/CON-1281
<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1
- [ ] Search inout looks good
- [ ] Table looks good 
- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
