### PR TITLE
**Fix:** Toggle tree only when clicking on the arrow

### DIFF
--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -64,14 +64,16 @@ const ChildTree: React.SFC<Props> = ({
   )
 
   const onNodeClick =
-    !disabled && onClick
+    !disabled && (onClick || onNodeContextMenu)
       ? (e: React.MouseEvent<HTMLDivElement>) => {
           e.stopPropagation()
           if (e.altKey && onNodeContextMenu) {
             onNodeContextMenu(e)
             return
           }
-          onClick(e)
+          if (onClick) {
+            onClick(e)
+          }
         }
       : undefined
 

--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -64,7 +64,7 @@ const ChildTree: React.SFC<Props> = ({
   )
 
   const onNodeClick =
-    !disabled && (onClick || onNodeContextMenu)
+    !disabled && (onClick || onNodeContextMenu || hasChildren)
       ? (e: React.MouseEvent<HTMLDivElement>) => {
           e.stopPropagation()
           if (e.altKey && onNodeContextMenu) {
@@ -73,6 +73,8 @@ const ChildTree: React.SFC<Props> = ({
           }
           if (onClick) {
             onClick(e)
+          } else if (hasChildren) {
+            setIsOpen(!isOpen)
           }
         }
       : undefined

--- a/src/Tree/ChildTree.tsx
+++ b/src/Tree/ChildTree.tsx
@@ -64,19 +64,22 @@ const ChildTree: React.SFC<Props> = ({
   )
 
   const onNodeClick =
-    !disabled && (hasChildren || onClick)
+    !disabled && onClick
       ? (e: React.MouseEvent<HTMLDivElement>) => {
           e.stopPropagation()
           if (e.altKey && onNodeContextMenu) {
             onNodeContextMenu(e)
             return
           }
-          if (hasChildren) {
-            setIsOpen(!isOpen)
-          }
-          if (onClick) {
-            onClick(e)
-          }
+          onClick(e)
+        }
+      : undefined
+
+  const onNodeToggle =
+    !disabled && hasChildren
+      ? (e: React.MouseEvent<HTMLDivElement>) => {
+          e.stopPropagation()
+          setIsOpen(!isOpen)
         }
       : undefined
 
@@ -89,6 +92,7 @@ const ChildTree: React.SFC<Props> = ({
         searchWords={searchWords}
         ignoreSearchWords={ignoreSearchWords}
         onNodeClick={onNodeClick}
+        onNodeToggle={onNodeToggle}
         onNodeContextMenu={onNodeContextMenu}
         highlight={Boolean(highlight)}
         hasChildren={hasChildren}

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -28,10 +28,12 @@ const Wrapper = styled.div`
       {
         label: "ERP",
         tag: "OR",
+        onClick: () => alert("ERP was clicked"),
         childNodes: [
           {
             label: "Region",
             initiallyOpen: true,
+            onClick: () => alert("Region was clicked"),
             childNodes: [
               {
                 label: "City",

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -23,6 +23,7 @@ interface TreeItemProps {
   disabled?: boolean
   cursor?: string
   onNodeClick?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onNodeToggle?: (e: React.MouseEvent<HTMLDivElement>) => void
   onNodeContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void
   onMouseEnter?: (e: React.MouseEvent<HTMLDivElement>) => void
   onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void
@@ -148,6 +149,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
   disabled,
   label,
   onNodeClick,
+  onNodeToggle,
   onNodeContextMenu,
   hasChildren,
   isOpen,
@@ -182,13 +184,13 @@ const TreeItem: React.SFC<TreeItemProps> = ({
         case " ":
         case "Space": // the platform™
           e.preventDefault()
-          if (onNodeClick) {
-            onNodeClick(e)
+          if (onNodeToggle) {
+            onNodeToggle(e)
           }
           return
       }
     },
-    [onNodeContextMenu, onNodeClick],
+    [onNodeContextMenu, onNodeClick, onNodeToggle],
   )
 
   return (
@@ -197,7 +199,6 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       paddingRight={paddingRight}
       level={level}
       hasIconOffset={Boolean(hasIconOffset)}
-      onClick={onNodeClick}
       onContextMenu={onNodeContextMenu}
       onKeyDown={handleKeyDown}
       highlight={Boolean(highlight)}
@@ -205,14 +206,18 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       tabIndex={disabled ? -1 : 0}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onClick={onNodeClick}
     >
-      {hasChildren &&
-        React.createElement(isOpen ? ChevronDownIcon : ChevronRightIcon, {
-          size: 12,
-          left: true,
-          color: isOpen ? "color.text.lighter" : "primary",
-          style: { marginRight: 8 },
-        })}
+      {hasChildren && (
+        <span onClick={onNodeToggle}>
+          {React.createElement(isOpen ? ChevronDownIcon : ChevronRightIcon, {
+            size: 12,
+            left: true,
+            color: isOpen ? "color.text.lighter" : "primary",
+            style: { marginRight: 8 },
+          })}
+        </span>
+      )}
       {tag && (
         <NameTagStyled condensed left color={tagColor}>
           {tag}
@@ -231,6 +236,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
         fontSize={fontSize ? fontSize : constants.font.size.small}
         emphasized={Boolean(emphasized)}
         monospace={Boolean(monospace)}
+        onClick={onNodeClick}
       >
         <Highlighter
           textToHighlight={label}

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -199,6 +199,7 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       paddingRight={paddingRight}
       level={level}
       hasIconOffset={Boolean(hasIconOffset)}
+      onClick={onNodeClick}
       onContextMenu={onNodeContextMenu}
       onKeyDown={handleKeyDown}
       highlight={Boolean(highlight)}
@@ -206,7 +207,6 @@ const TreeItem: React.SFC<TreeItemProps> = ({
       tabIndex={disabled ? -1 : 0}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      onClick={onNodeClick}
     >
       {hasChildren && (
         <span onClick={onNodeToggle}>

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -236,7 +236,6 @@ const TreeItem: React.SFC<TreeItemProps> = ({
         fontSize={fontSize ? fontSize : constants.font.size.small}
         emphasized={Boolean(emphasized)}
         monospace={Boolean(monospace)}
-        onClick={onNodeClick}
       >
         <Highlighter
           textToHighlight={label}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Now onClick action and toggle action are separated. Toggle triggered only when use click arrow (or with space key)

# Related issue

N/A

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
