### PR TITLE
**Breaking:** CON-1281 Introduce more constants for primary color variations

### DIFF
--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -6,6 +6,7 @@ import { InputProps } from "./Input"
 import InputButton from "./Input.Button"
 import { height, iconBoxSize, width } from "./Input.constants"
 import { NoIcon, IDIcon } from "../Icon"
+import { getAccentColor } from "../utils/constants"
 
 const getMaxWidth = (fullWidth: InputProps["fullWidth"], statusIcon: InputProps["statusIcon"]) => {
   if (fullWidth && statusIcon) {
@@ -46,7 +47,7 @@ const Field = styled.input<{
     }
 
     if (preset) {
-      return theme.color.accent
+      return getAccentColor(theme)
     }
 
     return theme.color.white

--- a/src/Input/Input.Field.tsx
+++ b/src/Input/Input.Field.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { FormFieldError, inputFocus, setAlpha } from "../utils"
+import { FormFieldError, inputFocus } from "../utils"
 import styled from "../utils/styled"
 import { InputProps } from "./Input"
 import InputButton from "./Input.Button"
@@ -46,7 +46,7 @@ const Field = styled.input<{
     }
 
     if (preset) {
-      return setAlpha(0.1)(theme.color.primary)
+      return theme.color.accent
     }
 
     return theme.color.white

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -3,6 +3,7 @@ import styled from "../utils/styled"
 import { SearchIcon, CaretDownIcon, CaretUpIcon, EnterIcon, NoIcon } from "../Icon"
 import useHotkey from "../useHotkey"
 import Chip from "../Chip/Chip"
+import { getHighlightColor } from "../utils/constants"
 
 export interface SearchInputProps<TCategory> {
   value: string
@@ -243,7 +244,7 @@ const CategoryDropdown = styled.div<{ highlighted?: boolean; isCondensed?: boole
 
   :hover {
     background-color: ${({ theme, highlighted }) =>
-      highlighted ? theme.color.background.grey : theme.color.highlight};
+      highlighted ? theme.color.background.grey : getHighlightColor(theme)};
     color: ${({ theme, highlighted }) => (highlighted ? theme.color.basic : theme.color.primary)};
   }
 

--- a/src/SearchInput/SearchInput.tsx
+++ b/src/SearchInput/SearchInput.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import styled from "../utils/styled"
 import { SearchIcon, CaretDownIcon, CaretUpIcon, EnterIcon, NoIcon } from "../Icon"
-import { setAlpha } from "../utils"
 import useHotkey from "../useHotkey"
 import Chip from "../Chip/Chip"
 
@@ -244,7 +243,7 @@ const CategoryDropdown = styled.div<{ highlighted?: boolean; isCondensed?: boole
 
   :hover {
     background-color: ${({ theme, highlighted }) =>
-      highlighted ? theme.color.background.grey : setAlpha(0.05)(theme.color.primary)};
+      highlighted ? theme.color.background.grey : theme.color.highlight};
     color: ${({ theme, highlighted }) => (highlighted ? theme.color.basic : theme.color.primary)};
   }
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -14,7 +14,6 @@ import Small from "../Typography/Small"
 import styled from "../utils/styled"
 import { IconComponentType, ChevronDownIcon, ChevronUpDownIcon, ChevronUpIcon } from "../Icon"
 import { useUniqueId } from "../useUniqueId"
-import { setAlpha } from "../utils"
 
 export interface TableProps<T> extends DefaultProps {
   data: T[]
@@ -83,21 +82,21 @@ const Tr = styled.tr<{
   height: condensed ? 36 : 50,
   display: isDragging ? "table" : "table-row",
   tableLayout: "fixed",
-  backgroundColor: active ? setAlpha(0.05)(theme.color.primary) : theme.color.white,
+  backgroundColor: active ? theme.color.highlight : theme.color.white,
   ...(draggable || clickable
     ? {
         ":hover": {
-          backgroundColor: active ? setAlpha(0.07)(theme.color.primary) : setAlpha(0.05)(theme.color.primary),
+          backgroundColor: active ? theme.color.accent : theme.color.highlight,
           cursor: clickable ? "pointer" : draggable ? "move" : "default",
         },
       }
     : {}),
   ":focus": {
     outline: "none",
-    backgroundColor: setAlpha(0.05)(theme.color.primary),
+    backgroundColor: theme.color.highlight,
   },
   ".no-focus &:focus": {
-    backgroundColor: active ? setAlpha(0.05)(theme.color.primary) : theme.color.white,
+    backgroundColor: active ? theme.color.highlight : theme.color.white,
   },
 }))
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -14,6 +14,7 @@ import Small from "../Typography/Small"
 import styled from "../utils/styled"
 import { IconComponentType, ChevronDownIcon, ChevronUpDownIcon, ChevronUpIcon } from "../Icon"
 import { useUniqueId } from "../useUniqueId"
+import { getHighlightColor, getAccentColor } from "../utils/constants"
 
 export interface TableProps<T> extends DefaultProps {
   data: T[]
@@ -82,21 +83,21 @@ const Tr = styled.tr<{
   height: condensed ? 36 : 50,
   display: isDragging ? "table" : "table-row",
   tableLayout: "fixed",
-  backgroundColor: active ? theme.color.highlight : theme.color.white,
+  backgroundColor: active ? getHighlightColor(theme) : theme.color.white,
   ...(draggable || clickable
     ? {
         ":hover": {
-          backgroundColor: active ? theme.color.accent : theme.color.highlight,
+          backgroundColor: active ? getAccentColor(theme) : getHighlightColor(theme),
           cursor: clickable ? "pointer" : draggable ? "move" : "default",
         },
       }
     : {}),
   ":focus": {
     outline: "none",
-    backgroundColor: theme.color.highlight,
+    backgroundColor: getHighlightColor(theme),
   },
   ".no-focus &:focus": {
-    backgroundColor: active ? theme.color.highlight : theme.color.white,
+    backgroundColor: active ? getHighlightColor(theme) : theme.color.white,
   },
 }))
 

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from "react"
 import NameTag from "../NameTag/NameTag"
-import { setAlpha } from "../utils/color"
 import styled from "../utils/styled"
 import { ChevronRightIcon, ChevronDownIcon, IconComponentType } from "../Icon"
 import Highlighter from "react-highlight-words"
@@ -71,7 +70,7 @@ const Header = styled.div<{
   :focus {
     outline: none;
     color: ${({ theme }) => theme.color.primary};
-    background: ${({ theme }) => setAlpha(0.05)(theme.color.primary)};
+    background: ${({ theme }) => theme.color.highlight};
 
     /* Show ActionsContainer on hover */
     div:last-of-type {

--- a/src/Tree/TreeItem.tsx
+++ b/src/Tree/TreeItem.tsx
@@ -3,7 +3,7 @@ import NameTag from "../NameTag/NameTag"
 import styled from "../utils/styled"
 import { ChevronRightIcon, ChevronDownIcon, IconComponentType } from "../Icon"
 import Highlighter from "react-highlight-words"
-import constants, { expandColor } from "../utils/constants"
+import constants, { expandColor, getHighlightColor } from "../utils/constants"
 
 interface TreeItemProps {
   paddingLeft: number
@@ -49,7 +49,7 @@ const Header = styled.div<{
   position: relative;
   align-items: center;
   cursor: ${({ onClick, cursor }) => cursor || (onClick ? "pointer" : "inherit")};
-  background: ${({ highlight, theme }) => (highlight ? theme.color.highlight : "none")};
+  background: ${({ theme, highlight }) => (highlight ? getHighlightColor(theme) : "none")};
   padding: ${({ theme }) => `${theme.space.base / 2}px`};
   padding-left: ${({ theme, paddingLeft, level, hasIconOffset }) =>
     paddingLeft + theme.space.element * level + (hasIconOffset ? theme.space.element : 0)}px;
@@ -59,7 +59,7 @@ const Header = styled.div<{
 
   :hover,
   .no-focus &:hover:focus {
-    background: ${({ theme, highlight }) => (highlight ? theme.color.highlight : theme.color.background.lighter)};
+    background: ${({ theme, highlight }) => (highlight ? getHighlightColor(theme) : theme.color.background.lighter)};
 
     /* Show ActionsContainer on hover */
     div:last-of-type {
@@ -70,7 +70,7 @@ const Header = styled.div<{
   :focus {
     outline: none;
     color: ${({ theme }) => theme.color.primary};
-    background: ${({ theme }) => theme.color.highlight};
+    background: ${({ theme }) => getHighlightColor(theme)};
 
     /* Show ActionsContainer on hover */
     div:last-of-type {
@@ -79,7 +79,7 @@ const Header = styled.div<{
   }
   .no-focus &:focus {
     color: ${({ theme }) => theme.color.text.dark};
-    background: ${({ highlight, theme }) => (highlight ? theme.color.highlight : "none")};
+    background: ${({ theme, highlight }) => (highlight ? getHighlightColor(theme) : "none")};
     div:last-of-type {
       opacity: 0;
     }

--- a/src/Uploader/Uploader.tsx
+++ b/src/Uploader/Uploader.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
-import { setAlpha } from "../utils"
 
 export interface UploaderProps extends DefaultProps {
   dragActive: boolean
@@ -17,7 +16,7 @@ const Container = styled("div")<Pick<UploaderProps, "dragActive">>(({ dragActive
   justifyContent: "center",
   ...(dragActive
     ? {
-        backgroundColor: setAlpha(0.05)(theme.color.primary),
+        backgroundColor: theme.color.highlight,
         border: `1px solid ${theme.color.primary}`,
         color: theme.color.primary,
       }

--- a/src/Uploader/Uploader.tsx
+++ b/src/Uploader/Uploader.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { DefaultProps } from "../types"
 import styled from "../utils/styled"
+import { getHighlightColor } from "../utils/constants"
 
 export interface UploaderProps extends DefaultProps {
   dragActive: boolean
@@ -16,7 +17,7 @@ const Container = styled("div")<Pick<UploaderProps, "dragActive">>(({ dragActive
   justifyContent: "center",
   ...(dragActive
     ? {
-        backgroundColor: theme.color.highlight,
+        backgroundColor: getHighlightColor(theme),
         border: `1px solid ${theme.color.primary}`,
         color: theme.color.primary,
       }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -84,7 +84,6 @@ const textColors = {
  * A specialized color palette for borders.
  */
 const borderColors = {
-  primary: setAlpha(0.1)(primaryColor),
   /** `#c0c0c0` */
   default: "#c0c0c0",
   /** `#ddd` */
@@ -123,6 +122,7 @@ const color = {
   ghost: "hsla(0, 0%, 100%, 0.33)",
   white: whiteColor,
   highlight: setAlpha(0.05)(primaryColor),
+  accent: setAlpha(0.1)(primaryColor),
   /** `#000` */
   black: "#000",
   background: backgroundColors,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -243,7 +243,7 @@ const zIndex = {
 const shadows = {
   pressed: "inset 0 1px 1px rgba(0,0,0,0.15)",
   topBar: "0px 1px 5px #d3d1d1",
-  focus: `inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px ${setAlpha(0.1)(primaryColor)}`,
+  focus: `inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px ${color.accent}`,
   insetFocus: `inset 0 0 0px 1px ${primaryColor}`,
   popup: "0 3px 12px rgba(0, 0, 0, .15)",
   contextMenu: "0 2px 4px 0 rgba(0, 0, 0, 0.25)",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -121,8 +121,6 @@ const color = {
   basic: "#636363",
   ghost: "hsla(0, 0%, 100%, 0.33)",
   white: whiteColor,
-  highlight: setAlpha(0.05)(primaryColor),
-  accent: setAlpha(0.1)(primaryColor),
   /** `#000` */
   black: "#000",
   background: backgroundColors,
@@ -142,6 +140,10 @@ const color = {
     "#006865",
   ],
 }
+
+export const getHighlightColor = (theme: OperationalStyleConstants) => setAlpha(0.05)(theme.color.primary)
+
+export const getAccentColor = (theme: OperationalStyleConstants) => setAlpha(0.1)(theme.color.primary)
 
 type FontWeight = 400 | 500 | 600
 
@@ -243,8 +245,8 @@ const zIndex = {
 const shadows = {
   pressed: "inset 0 1px 1px rgba(0,0,0,0.15)",
   topBar: "0px 1px 5px #d3d1d1",
-  focus: `inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px ${color.accent}`,
-  insetFocus: `inset 0 0 0px 1px ${primaryColor}`,
+  focus: "inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6)",
+  insetFocus: "inset 0 0 0px 1px #1499ce",
   popup: "0 3px 12px rgba(0, 0, 0, .15)",
   contextMenu: "0 2px 4px 0 rgba(0, 0, 0, 0.25)",
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -84,6 +84,7 @@ const textColors = {
  * A specialized color palette for borders.
  */
 const borderColors = {
+  primary: setAlpha(0.1)(primaryColor),
   /** `#c0c0c0` */
   default: "#c0c0c0",
   /** `#ddd` */
@@ -242,8 +243,8 @@ const zIndex = {
 const shadows = {
   pressed: "inset 0 1px 1px rgba(0,0,0,0.15)",
   topBar: "0px 1px 5px #d3d1d1",
-  focus: "inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6)",
-  insetFocus: "inset 0 0 0px 1px #1499ce",
+  focus: `inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px ${setAlpha(0.1)(primaryColor)}`,
+  insetFocus: `inset 0 0 0px 1px ${primaryColor}`,
   popup: "0 3px 12px rgba(0, 0, 0, .15)",
   contextMenu: "0 2px 4px 0 rgba(0, 0, 0, 0.25)",
 }


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
Add more constants that represent primary color variations
<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
CON-1281
<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
