### PR TITLE
**Feature:** Support arrays in DataTable

### DIFF
--- a/src/DataTable/CellContent.tsx
+++ b/src/DataTable/CellContent.tsx
@@ -11,9 +11,9 @@ export interface CellContentProps {
   close: () => void
 }
 
-const stringifyBooleanAndNull = (value: any) => {
+const stringifyBooleanAndNullAndArray = (value: any) => {
   // We compare booleans like this and without typeof for perf
-  return value === true || value === false || value === null ? String(value) : value
+  return value === true || value === false || value === null || Array.isArray(value) ? String(value) : value
 }
 
 const CellContent: React.FC<CellContentProps> = ({ cell, open, close }) => {
@@ -46,7 +46,7 @@ const CellContent: React.FC<CellContentProps> = ({ cell, open, close }) => {
   }, [width])
 
   const value = React.useMemo(
-    () => (typeof cell === "string" ? cell.replace(/\n/g, " ") : stringifyBooleanAndNull(cell)),
+    () => (typeof cell === "string" ? cell.replace(/\n/g, " ") : stringifyBooleanAndNullAndArray(cell)),
     [cell],
   )
 

--- a/src/DataTable/CellContent.tsx
+++ b/src/DataTable/CellContent.tsx
@@ -13,7 +13,7 @@ export interface CellContentProps {
 
 const stringifyBooleanAndNullAndArray = (value: any) => {
   // We compare booleans like this and without typeof for perf
-  return value === true || value === false || value === null || Array.isArray(value) ? String(value) : value
+  return value === true || value === false || value === null || Array.isArray(value) ? JSON.stringify(value) : value
 }
 
 const CellContent: React.FC<CellContentProps> = ({ cell, open, close }) => {

--- a/src/DataTable/README.md
+++ b/src/DataTable/README.md
@@ -327,3 +327,14 @@ import { DataTable, DataTableSelect, DataTableInput, Checkbox } from "@operation
   ]}
 />
 ```
+
+## Data types
+
+```jsx
+import * as React from "react"
+import { DataTable, DataTableSelect, DataTableInput, Checkbox } from "@operational/components"
+;<DataTable
+  columns={[["string"], ["true"], ["false"], ["null"], ["number"]]}
+  rows={[["a", true, false, null, 1], [["a", "b"], [true, true], [false, false], [null, null], [1, 2]]]}
+/>
+```


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Support arrays in DataTable

With `String()`:
<img width="1116" alt="Screenshot 2020-04-21 at 10 27 15" src="https://user-images.githubusercontent.com/179534/79843733-ed808500-83ba-11ea-9c9a-e527b52d3501.png">

With `JSON.stringify`:
<img width="1116" alt="Screenshot 2020-04-21 at 10 27 15" src="https://user-images.githubusercontent.com/179534/79843715-e6597700-83ba-11ea-8b81-7e3e28fe18ed.png">

Or I can implement custom "stringifier"?

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
