### PR TITLE
**Feature:** Speed up the dev environment

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -2,7 +2,6 @@
 const { join, resolve } = require("path")
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin")
 
-const { parse: propsParser } = require("react-docgen-typescript")
 const { version } = require("./package.json")
 
 const { styles, theme } = require("./styleguide/styles.js")
@@ -15,7 +14,8 @@ const fs = require("fs")
 module.exports = {
   title: "Operational UI",
   version,
-  propsParser,
+  // We are skipping the props docs generation in dev to speed-up the dev server
+  propsParser: process.env.NODE_ENV === "development" ? undefined : require("react-docgen-typescript").parse,
   styles,
   theme,
   sections,


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

Quick and simple action to make the dev env a bit faster -> don't parse the props when we are in dev.

Impact:
* No more props info in dev
![image](https://user-images.githubusercontent.com/1761469/80964616-7d89ea00-8e11-11ea-9cb5-dd7a2e775cc0.png)

* 30sc less compilation time (on my beasty computer)

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
