### PR TITLE
**Fix:** first tree item sometimes ignores initially open flag

### DIFF
--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -737,6 +737,7 @@ import { Tree, Button, OlapIcon } from "@operational/components"
 const initialTrees = [
   {
     label: "ERP",
+    key: 10,
     childNodes: [
       {
         label: "Region",
@@ -762,6 +763,7 @@ const initialTrees = [
   },
   {
     label: "Legal Entity",
+    key: 20,
     childNodes: [
       {
         label: "Limited Liability Company",
@@ -783,9 +785,10 @@ const Example = () => {
   const open = React.useCallback(() => {}, [setTrees])
   return (
     <>
-      <Button onClick={() => setTrees(initialTrees.map(x => ({ ...x, initiallyOpen: true })))}>Open</Button>
+      <Button onClick={() => setTrees(initialTrees.map(x => ({ ...x, initiallyOpen: true, key: x.key + 1 })))}>
+        Open
+      </Button>
       <Button onClick={() => setTrees(initialTrees)}>Close</Button>
-      <Button onClick={() => setTrees([])}>Empty</Button>
       <br />
       <br />
       <Tree trees={trees} />

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -733,58 +733,59 @@ const MyComponent = () => {
 ```jsx
 import * as React from "react"
 import { Tree, Button, OlapIcon } from "@operational/components"
+
+const initialTrees = [
+  {
+    label: "ERP",
+    childNodes: [
+      {
+        label: "Region",
+        childNodes: [
+          {
+            label: "City",
+            icon: OlapIcon,
+            iconColor: "primary",
+            disabled: true,
+            childNodes: [],
+          },
+          {
+            label: "Country",
+            tagColor: "primary",
+            onClick: () => alert("country was clicked"),
+            onContextMenu: () => alert("country was right-clicked"),
+            icon: OlapIcon,
+            childNodes: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: "Legal Entity",
+    childNodes: [
+      {
+        label: "Limited Liability Company",
+        icon: OlapIcon,
+        childNodes: [],
+      },
+      {
+        label: "Inc.",
+        icon: OlapIcon,
+        tagColor: "#2C363F",
+        childNodes: [],
+      },
+    ],
+  },
+]
+
 const Example = () => {
-  const [trees, setTrees] = React.useState([
-    {
-      label: "ERP",
-      childNodes: [
-        {
-          label: "Region",
-          childNodes: [
-            {
-              label: "City",
-              icon: OlapIcon,
-              iconColor: "primary",
-              disabled: true,
-              childNodes: [],
-            },
-            {
-              label: "Country",
-              tagColor: "primary",
-              onClick: () => alert("country was clicked"),
-              onContextMenu: () => alert("country was right-clicked"),
-              icon: OlapIcon,
-              childNodes: [],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      label: "Legal Entity",
-      childNodes: [
-        {
-          label: "Limited Liability Company",
-          icon: OlapIcon,
-          childNodes: [],
-        },
-        {
-          label: "Inc.",
-          icon: OlapIcon,
-          tagColor: "#2C363F",
-          childNodes: [],
-        },
-      ],
-    },
-  ])
-
-  const open = React.useCallback(() => {
-    setTrees(trees => trees.map(x => ({ ...x, initiallyOpen: true })))
-  }, [setTrees])
-
+  const [trees, setTrees] = React.useState(initialTrees)
+  const open = React.useCallback(() => {}, [setTrees])
   return (
     <>
-      <Button onClick={open}>Open</Button>
+      <Button onClick={() => setTrees(initialTrees.map(x => ({ ...x, initiallyOpen: true })))}>Open</Button>
+      <Button onClick={() => setTrees(initialTrees)}>Close</Button>
+      <Button onClick={() => setTrees([])}>Empty</Button>
       <br />
       <br />
       <Tree trees={trees} />

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -725,3 +725,70 @@ const MyComponent = () => {
 
 ;<MyComponent />
 ```
+
+### With initiallyOpen change
+
+```jsx
+import * as React from "react"
+import { Tree, Button, OlapIcon } from "@operational/components"
+const Example = () => {
+  const [trees, setTrees] = React.useState([
+    {
+      label: "ERP",
+      childNodes: [
+        {
+          label: "Region",
+          childNodes: [
+            {
+              label: "City",
+              icon: OlapIcon,
+              iconColor: "primary",
+              disabled: true,
+              childNodes: [],
+            },
+            {
+              label: "Country",
+              tagColor: "primary",
+              onClick: () => alert("country was clicked"),
+              onContextMenu: () => alert("country was right-clicked"),
+              icon: OlapIcon,
+              childNodes: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Legal Entity",
+      childNodes: [
+        {
+          label: "Limited Liability Company",
+          icon: OlapIcon,
+          childNodes: [],
+        },
+        {
+          label: "Inc.",
+          icon: OlapIcon,
+          tagColor: "#2C363F",
+          childNodes: [],
+        },
+      ],
+    },
+  ])
+
+  const open = React.useCallback(() => {
+    setTrees(trees => trees.map(x => ({ ...x, initiallyOpen: true })))
+  }, [setTrees])
+
+  return (
+    <>
+      <Button onClick={open}>Open</Button>
+      <br />
+      <br />
+      <Tree trees={trees} />
+    </>
+  )
+}
+
+;<Example />
+```

--- a/src/Tree/README.md
+++ b/src/Tree/README.md
@@ -351,6 +351,7 @@ To offer the most flexibility as possible in your drag & drop implementation, we
 
 FIXME: https://github.com/styleguidist/react-styleguidist/issues/1278
 
+<!--
 ```jsx
 import * as React from "react"
 import { Button, Card, Tree, Title } from "@operational/components"
@@ -488,6 +489,7 @@ const PizzaMaker = () => {
 }
 ;<PizzaMaker />
 ```
+-->
 
 ### In an Accordion with different styling options
 

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -7,6 +7,7 @@ import { IconComponentType } from "../Icon"
 
 interface BaseTree {
   label: string
+  key?: string | number
   paddingLeft?: number
   paddingRight?: number
   highlight?: boolean
@@ -103,7 +104,11 @@ const Tree: React.SFC<TreeProps> = ({
           {trees.length ? (
             <>
               {trees.map((treeData, index) => (
-                <Draggable key={index} {...treeData.draggableProps || { draggableId: treeData.label }} index={index}>
+                <Draggable
+                  key={treeData.key !== undefined ? treeData.key : index}
+                  {...treeData.draggableProps || { draggableId: treeData.label }}
+                  index={index}
+                >
                   {draggableProvided => {
                     return (
                       <ChildTree


### PR DESCRIPTION
# Summary

first tree item sometimes ignores `initiallyOpen` flag.

In new example it is possible to open close items, if key value changes

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
