### PR TITLE
**Fix:** no-focus

### DIFF
--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -124,7 +124,7 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
   constructor(props: OperationalUIProps) {
     super(props)
     this.onKeyDown = this.onKeyDown.bind(this)
-    this.onClick = this.onClick.bind(this)
+    this.onMousudown = this.onMousudown.bind(this)
   }
 
   /**
@@ -170,16 +170,17 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
       clearInterval(this.messageTimerInterval)
     }
     document.removeEventListener("keydown", this.onKeyDown)
-    document.removeEventListener("click", this.onClick)
+    document.removeEventListener("mousedown", this.onMousudown)
   }
 
   public componentDidMount() {
     document.addEventListener("keydown", this.onKeyDown)
-    document.addEventListener("click", this.onClick)
+    document.addEventListener("mousedown", this.onMousudown)
+    document.body.classList.add("no-focus")
   }
 
   // We tried to use state instead of directly accessing DOM but it breaks
-  private onClick() {
+  private onMousudown() {
     document.body.classList.add("no-focus")
   }
 

--- a/src/OperationalUI/OperationalUI.tsx
+++ b/src/OperationalUI/OperationalUI.tsx
@@ -124,7 +124,7 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
   constructor(props: OperationalUIProps) {
     super(props)
     this.onKeyDown = this.onKeyDown.bind(this)
-    this.onMousudown = this.onMousudown.bind(this)
+    this.onMouseDown = this.onMouseDown.bind(this)
   }
 
   /**
@@ -170,17 +170,17 @@ class OperationalUI extends React.Component<OperationalUIProps, State> {
       clearInterval(this.messageTimerInterval)
     }
     document.removeEventListener("keydown", this.onKeyDown)
-    document.removeEventListener("mousedown", this.onMousudown)
+    document.removeEventListener("mousedown", this.onMouseDown)
   }
 
   public componentDidMount() {
     document.addEventListener("keydown", this.onKeyDown)
-    document.addEventListener("mousedown", this.onMousudown)
+    document.addEventListener("mousedown", this.onMouseDown)
     document.body.classList.add("no-focus")
   }
 
   // We tried to use state instead of directly accessing DOM but it breaks
-  private onMousudown() {
+  private onMouseDown() {
     document.body.classList.add("no-focus")
   }
 


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

- use mousedown instead of click, because click is triggered onkeydown on button for space and enter
- add "no-focus" on initial render, to prevent blink of focus state on first click

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [ ] No error or warning in the console on `localhost:6060`

Tester 1

- [x] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
