### PR TITLE
**Fix:** Remove <Form> wrapper to fix <Select> from increasing width …

### DIFF
--- a/src/Select/README.md
+++ b/src/Select/README.md
@@ -323,7 +323,7 @@ const MyComponent = () => {
   const [customOptionValue, setCustomOptionValue] = React.useState("chickens")
 
   return (
-    <Form>
+    <>
       <Select
         data-cy="custom-select"
         value={value}
@@ -347,7 +347,7 @@ Last changed option:
 ${JSON.stringify(lastChanged, null, 2)}
       `}
       </Code>
-    </Form>
+    </>
   )
 }
 
@@ -395,7 +395,7 @@ const MyComponent = () => {
   }
 
   return (
-    <Form>
+    <>
       <Select
         data-cy="custom-select"
         value={value}
@@ -422,7 +422,7 @@ Last changed option:
 ${JSON.stringify(lastChanged, null, 2)}
       `}
       </Code>
-    </Form>
+    </>
   )
 }
 


### PR DESCRIPTION
…on selecting

<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary
The Form wrapper added in Select component with custom fields was adding an extra margin to child elements. Removed the Form wrapper and added a fragment wrapper - this prevents the style being added from the Form element, solving the problem.

<!-- Some context about this PR: screenshots and links to the docs are appreciate -->

# Related issue
Fixes #1311
<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
