### PR TITLE
**Fix:** Fix context menu positionning on edge44

### DIFF
--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -8,7 +8,6 @@ import { isRefRefObject } from "../utils/isRefRefObject"
 
 export interface ContextMenuPopoutProps {
   embedChildrenInMenu?: ContextMenuProps["embedChildrenInMenu"]
-  numRows: number
   align: ContextMenuProps["align"]
   condensed: ContextMenuProps["condensed"]
   rowHeight: number
@@ -46,7 +45,7 @@ const Container = styled.div<ContextMenuPopoutProps & PositionProps>`
 
 const ContextMenuPopout = React.forwardRef<HTMLDivElement, ContextMenuPopoutProps & { width?: number }>(
   (
-    { align, children, condensed, container, embedChildrenInMenu, numRows, rowHeight, anchored, width: propsWidth },
+    { align, children, condensed, container, embedChildrenInMenu, rowHeight, anchored, width: propsWidth },
     forwardRef,
   ) => {
     const $fallback = React.useRef<HTMLDivElement | null>(null)
@@ -70,7 +69,6 @@ const ContextMenuPopout = React.forwardRef<HTMLDivElement, ContextMenuPopoutProp
       <Container
         align={align}
         condensed={condensed}
-        numRows={numRows}
         rowHeight={rowHeight}
         anchored={anchored}
         left={anchored ? initialValue.left : left}

--- a/src/ContextMenu/ContextMenu.Popout.tsx
+++ b/src/ContextMenu/ContextMenu.Popout.tsx
@@ -32,14 +32,14 @@ const Container = styled.div<ContextMenuPopoutProps & PositionProps>`
   max-height: 50vh;
   overflow: auto;
   box-shadow: ${({ theme }) => theme.shadows.contextMenu};
-  min-width: fit-content;
   width: ${({ width }) => width};
   max-width: 90vw;
   min-height: ${({ rowHeight }) => rowHeight}px;
-  display: grid;
-  grid-template-rows: repeat(${({ numRows }) => numRows}, max-content);
   background-color: ${({ theme }) => theme.color.white};
   padding: ${({ theme }) => theme.space.small}px 0;
+  display: inline-flex;
+  width: auto;
+  flex-direction: column;
 
   ${({ theme, anchored }) => (anchored ? "" : `z-index: ${theme.zIndex.selectOptions + 2};`)}
 `

--- a/src/ContextMenu/ContextMenu.tsx
+++ b/src/ContextMenu/ContextMenu.tsx
@@ -215,7 +215,6 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
             key={`ContextMenuPopout-${uniqueId}-${items.length}-items`}
             ref={containerRef}
             condensed={Boolean(condensed)}
-            numRows={items.length}
             align={align}
             embedChildrenInMenu={embedChildrenInMenu}
             container={$invisibleOverlay}


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

`min-width: fit-content` is not supported by edge 44, this is causing the following issue.

Before: 
![image](https://user-images.githubusercontent.com/1761469/96866116-1fa69880-146b-11eb-8e5e-16dd94776cca.png)

After:
![image](https://user-images.githubusercontent.com/1761469/96866032-030a6080-146b-11eb-91ec-f52f9f98a67a.png)


# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Story "CardSection/Actions" looks good

