### PR TITLE
**Fix:** Use div instead of button to handle old firefox versions

### DIFF
--- a/src/Tabs/Tabs.styled.ts
+++ b/src/Tabs/Tabs.styled.ts
@@ -140,7 +140,7 @@ export const TabButton = styled(SectionHeader, {
 `
 
 TabButton.defaultProps = {
-  as: "button",
+  as: "div",
   "aria-hidden": true,
   tabIndex: -1,
 }


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

On firefox 60 (yeah, I know…), having a clickable element inside a `<button />` is not working. Using a div instead solve this problem.

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`
- [x] Try the tab on firefox 60, I can click on an icon inside a tab (close button)

Tester 1

- [x] See if the tabs are still working as before