### PR TITLE
**Fix:** Deal with trailing spaces in getInitials

### DIFF
--- a/src/utils/__tests__/index.test.ts
+++ b/src/utils/__tests__/index.test.ts
@@ -8,6 +8,8 @@ describe("text", () => {
       { value: "Tejas", expected: "T" },
       { value: "Lucrèce Rolland Nevière", expected: "LN" },
       { value: "Jean-pierre Bernard", expected: "JB" },
+      { value: " With starting spaces", expected: "WS" },
+      { value: "With trailing spaces ", expected: "WS" },
       { value: "", expected: "" },
     ].map(({ value, expected }) =>
       it(`should return ${expected} for ${value}`, () => expect(getInitials(value)).toEqual(expected)),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,6 +23,7 @@ export const isCmdEnter = (ev: React.KeyboardEvent<HTMLElement>) => {
  * @param name
  */
 export const getInitials = (name: string): string => {
+  name = name.trim()
   if (!name) {
     return ""
   }


### PR DESCRIPTION
<!-- 
  ❗️IMPORTANT ❗️
  Please prefix the title of this PR with _one_ of the following.

  **Breaking:**
    For when we break a public API.

  **Feature:** 
    For when we add something NEW that doesn't
    break the public API.
      
  **Fix:**
    For when we fix something that previously
    did not look or work correctly.
    
  Leaving off this prefix will prevent the PR from being
  included in a release. A good case to omit the prefix
  is when proposing infrastructural changes to the repo
  that do not affect the library.
-->
# Summary

`getInitials` utils was throwing an error with trailing spaces.

# Related issue

<!-- Paste the github issue here -->

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`

Tester 1

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 1 should test to be sure that everything is working properly -->

Tester 2

- [ ] Things look good on the demo.
  <!-- Put here everything that the reviewer 2 should test to be sure that everything is working properly -->
